### PR TITLE
feat(rooms): room role abstraction for permissions ui

### DIFF
--- a/lib/features/rooms/models/room_role.dart
+++ b/lib/features/rooms/models/room_role.dart
@@ -1,0 +1,189 @@
+/// Abstraction for Matrix room roles based on power levels.
+///
+/// This module provides a type-safe way to work with room roles instead of
+/// raw power-level integers. It handles conversions between roles and levels,
+/// enforces Matrix hierarchy rules, and provides human-readable descriptions.
+library;
+
+import 'package:flutter/foundation.dart';
+
+/// Represents a role in a Matrix room with associated power level.
+///
+/// Roles are mapped to standard power levels:
+/// - [admin] = 100
+/// - [moderator] = 50
+/// - [member] = 0
+/// - [custom] = any integer not matching the presets
+///
+/// This enum abstracts away raw power-level integers while maintaining
+/// compatibility with the Matrix protocol.
+sealed class RoomRole {
+  const RoomRole();
+
+  /// Creates a [RoomRole] from a power level integer.
+  ///
+  /// Maps standard levels (100 → admin, 50 → moderator, 0 → member)
+  /// to their presets, and creates a [custom] variant for other values.
+  factory RoomRole.fromPowerLevel(int level) {
+    return switch (level) {
+      100 => const RoomRole.admin(),
+      50 => const RoomRole.moderator(),
+      0 => const RoomRole.member(),
+      _ => RoomRole.custom(level),
+    };
+  }
+
+  /// Admin role with full room control (power level 100).
+  const factory RoomRole.admin() = _AdminRole;
+
+  /// Moderator role with limited administrative privileges (power level 50).
+  const factory RoomRole.moderator() = _ModeratorRole;
+
+  /// Member role with basic permissions (power level 0).
+  const factory RoomRole.member() = _MemberRole;
+
+  /// Custom role with non-standard power level.
+  const factory RoomRole.custom(int value) = _CustomRole;
+
+  /// Converts this role to its corresponding power level integer.
+  int toPowerLevel() => switch (this) {
+        _AdminRole() => 100,
+        _ModeratorRole() => 50,
+        _MemberRole() => 0,
+        _CustomRole(:final value) => value,
+      };
+
+  /// Human-readable label for this role.
+  ///
+  /// Examples: "Admin", "Moderator", "Member", "Custom (45)"
+  String get label => switch (this) {
+        _AdminRole() => 'Admin',
+        _ModeratorRole() => 'Moderator',
+        _MemberRole() => 'Member',
+        _CustomRole(:final value) => 'Custom ($value)',
+      };
+
+  /// One-line description of this role's capabilities.
+  String get description => map(
+        admin: (_) => 'Full room control and management',
+        moderator: (_) => 'Can moderate members and pin messages',
+        member: (_) => 'Can send messages and react',
+        custom: (_) => 'Custom power level',
+      );
+
+  /// Determines if a user with [ownLevel] can assign [target] role to a user
+  /// currently at [targetCurrentLevel].
+  ///
+  /// Enforces Matrix hierarchy rules:
+  /// 1. Can only assign roles ≤ own power level
+  /// 2. Can only modify users strictly below own power level
+  ///
+  /// Examples:
+  /// - Admin (100) can assign any role to users below them ✓
+  /// - Moderator (50) can only assign Member (0) to users below them ✓
+  /// - Moderator (50) cannot demote another Moderator ✗
+  /// - Member (0) cannot assign any role ✗
+  static bool canAssignRole({
+    required RoomRole target,
+    required int ownLevel,
+    required int targetCurrentLevel,
+  }) {
+    final targetLevel = target.toPowerLevel();
+
+    // Can only assign roles at or below own level
+    if (targetLevel > ownLevel) {
+      return false;
+    }
+
+    // Can only modify users strictly below own level
+    if (targetCurrentLevel >= ownLevel) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /// Pattern matches on the role type.
+  ///
+  /// This is the primary way to handle role-specific logic.
+  T map<T>({
+    required T Function(RoomRole) admin,
+    required T Function(RoomRole) moderator,
+    required T Function(RoomRole) member,
+    required T Function(RoomRole) custom,
+  }) =>
+      switch (this) {
+        _AdminRole _ => admin(this),
+        _ModeratorRole _ => moderator(this),
+        _MemberRole _ => member(this),
+        _CustomRole _ => custom(this),
+      };
+
+  /// Pattern matches with null-coalescing for convenience.
+  T maybeMap<T>({
+    required T orElse,
+    T Function(RoomRole)? admin,
+    T Function(RoomRole)? moderator,
+    T Function(RoomRole)? member,
+    T Function(RoomRole)? custom,
+  }) =>
+      map(
+        admin: admin != null ? (role) => admin(role) : (_) => orElse,
+        moderator: moderator != null ? (role) => moderator(role) : (_) => orElse,
+        member: member != null ? (role) => member(role) : (_) => orElse,
+        custom: custom != null ? (role) => custom(role) : (_) => orElse,
+      );
+
+  @override
+  String toString() => label;
+}
+
+@immutable
+final class _AdminRole extends RoomRole {
+  const _AdminRole();
+
+  @override
+  bool operator ==(Object other) => other is _AdminRole;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+@immutable
+final class _ModeratorRole extends RoomRole {
+  const _ModeratorRole();
+
+  @override
+  bool operator ==(Object other) => other is _ModeratorRole;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+@immutable
+final class _MemberRole extends RoomRole {
+  const _MemberRole();
+
+  @override
+  bool operator ==(Object other) => other is _MemberRole;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+@immutable
+final class _CustomRole extends RoomRole {
+  final int value;
+
+  const _CustomRole(this.value);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is _CustomRole &&
+          runtimeType == other.runtimeType &&
+          value == other.value;
+
+  @override
+  int get hashCode => value.hashCode;
+}

--- a/test/e2e/chat_screen_test.mocks.dart
+++ b/test/e2e/chat_screen_test.mocks.dart
@@ -7936,6 +7936,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -8442,6 +8449,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/e2e/room_management_test.mocks.dart
+++ b/test/e2e/room_management_test.mocks.dart
@@ -7926,6 +7926,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -8432,6 +8439,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/e2e/settings_screen_test.mocks.dart
+++ b/test/e2e/settings_screen_test.mocks.dart
@@ -7916,6 +7916,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -8422,6 +8429,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/e2e/space_management_test.mocks.dart
+++ b/test/e2e/space_management_test.mocks.dart
@@ -7916,6 +7916,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -8422,6 +8429,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/models/room_role_test.dart
+++ b/test/models/room_role_test.dart
@@ -1,0 +1,480 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/features/rooms/models/room_role.dart';
+
+void main() {
+  group('RoomRole', () {
+    group('fromPowerLevel', () {
+      test('maps 100 to admin', () {
+        final role = RoomRole.fromPowerLevel(100);
+        expect(role, isA<RoomRole>());
+        expect(role.toPowerLevel(), equals(100));
+        expect(role.label, equals('Admin'));
+      });
+
+      test('maps 50 to moderator', () {
+        final role = RoomRole.fromPowerLevel(50);
+        expect(role.toPowerLevel(), equals(50));
+        expect(role.label, equals('Moderator'));
+      });
+
+      test('maps 0 to member', () {
+        final role = RoomRole.fromPowerLevel(0);
+        expect(role.toPowerLevel(), equals(0));
+        expect(role.label, equals('Member'));
+      });
+
+      test('maps non-standard levels to custom', () {
+        final role = RoomRole.fromPowerLevel(47);
+        expect(role.toPowerLevel(), equals(47));
+        expect(role.label, equals('Custom (47)'));
+      });
+
+      test('handles negative power levels', () {
+        final role = RoomRole.fromPowerLevel(-10);
+        expect(role.toPowerLevel(), equals(-10));
+        expect(role.label, equals('Custom (-10)'));
+      });
+
+      test('handles large power levels', () {
+        final role = RoomRole.fromPowerLevel(9999);
+        expect(role.toPowerLevel(), equals(9999));
+        expect(role.label, equals('Custom (9999)'));
+      });
+    });
+
+    group('direct construction', () {
+      test('can create admin role directly', () {
+        const role = RoomRole.admin();
+        expect(role.toPowerLevel(), equals(100));
+        expect(role.label, equals('Admin'));
+      });
+
+      test('can create moderator role directly', () {
+        const role = RoomRole.moderator();
+        expect(role.toPowerLevel(), equals(50));
+        expect(role.label, equals('Moderator'));
+      });
+
+      test('can create member role directly', () {
+        const role = RoomRole.member();
+        expect(role.toPowerLevel(), equals(0));
+        expect(role.label, equals('Member'));
+      });
+
+      test('can create custom role directly', () {
+        const role = RoomRole.custom(75);
+        expect(role.toPowerLevel(), equals(75));
+        expect(role.label, equals('Custom (75)'));
+      });
+    });
+
+    group('round-trip conversions', () {
+      test('admin round-trips', () {
+        const admin = RoomRole.admin();
+        final level = admin.toPowerLevel();
+        final reconstructed = RoomRole.fromPowerLevel(level);
+        expect(reconstructed.toPowerLevel(), equals(admin.toPowerLevel()));
+        expect(reconstructed.label, equals(admin.label));
+      });
+
+      test('moderator round-trips', () {
+        const moderator = RoomRole.moderator();
+        final level = moderator.toPowerLevel();
+        final reconstructed = RoomRole.fromPowerLevel(level);
+        expect(reconstructed.toPowerLevel(), equals(moderator.toPowerLevel()));
+        expect(reconstructed.label, equals(moderator.label));
+      });
+
+      test('member round-trips', () {
+        const member = RoomRole.member();
+        final level = member.toPowerLevel();
+        final reconstructed = RoomRole.fromPowerLevel(level);
+        expect(reconstructed.toPowerLevel(), equals(member.toPowerLevel()));
+        expect(reconstructed.label, equals(member.label));
+      });
+
+      test('custom levels round-trip', () {
+        const custom = RoomRole.custom(42);
+        final level = custom.toPowerLevel();
+        final reconstructed = RoomRole.fromPowerLevel(level);
+        expect(reconstructed.toPowerLevel(), equals(custom.toPowerLevel()));
+        expect(reconstructed.label, equals(custom.label));
+      });
+    });
+
+    group('descriptions', () {
+      test('admin has appropriate description', () {
+        expect(
+          const RoomRole.admin().description,
+          equals('Full room control and management'),
+        );
+      });
+
+      test('moderator has appropriate description', () {
+        expect(
+          const RoomRole.moderator().description,
+          equals('Can moderate members and pin messages'),
+        );
+      });
+
+      test('member has appropriate description', () {
+        expect(
+          const RoomRole.member().description,
+          equals('Can send messages and react'),
+        );
+      });
+
+      test('custom has generic description', () {
+        expect(
+          const RoomRole.custom(99).description,
+          equals('Custom power level'),
+        );
+      });
+    });
+
+    group('canAssignRole - admin hierarchy', () {
+      test('admin can assign admin to anyone below them', () {
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.admin(),
+            ownLevel: 100,
+            targetCurrentLevel: 50,
+          ),
+          isTrue,
+        );
+      });
+
+      test('admin can assign moderator to anyone below them', () {
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.moderator(),
+            ownLevel: 100,
+            targetCurrentLevel: 0,
+          ),
+          isTrue,
+        );
+      });
+
+      test('admin can assign member to anyone below them', () {
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.member(),
+            ownLevel: 100,
+            targetCurrentLevel: 50,
+          ),
+          isTrue,
+        );
+      });
+
+      test('admin can assign custom roles', () {
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.custom(75),
+            ownLevel: 100,
+            targetCurrentLevel: 25,
+          ),
+          isTrue,
+        );
+      });
+
+      test('admin cannot assign role to someone at their level', () {
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.moderator(),
+            ownLevel: 100,
+            targetCurrentLevel: 100,
+          ),
+          isFalse,
+        );
+      });
+
+      test('admin cannot assign role to someone above their level', () {
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.admin(),
+            ownLevel: 100,
+            targetCurrentLevel: 150,
+          ),
+          isFalse,
+        );
+      });
+    });
+
+    group('canAssignRole - moderator hierarchy', () {
+      test('moderator can only assign member role', () {
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.member(),
+            ownLevel: 50,
+            targetCurrentLevel: 0,
+          ),
+          isTrue,
+        );
+      });
+
+      test('moderator cannot assign admin', () {
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.admin(),
+            ownLevel: 50,
+            targetCurrentLevel: 0,
+          ),
+          isFalse,
+        );
+      });
+
+      test('moderator can assign moderator role to users below them', () {
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.moderator(),
+            ownLevel: 50,
+            targetCurrentLevel: 0,
+          ),
+          isTrue,
+        );
+      });
+
+      test('moderator cannot assign role to someone at their level', () {
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.member(),
+            ownLevel: 50,
+            targetCurrentLevel: 50,
+          ),
+          isFalse,
+        );
+      });
+
+      test('moderator cannot assign role to anyone above them', () {
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.member(),
+            ownLevel: 50,
+            targetCurrentLevel: 100,
+          ),
+          isFalse,
+        );
+      });
+
+      test('moderator can assign custom role below their level', () {
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.custom(25),
+            ownLevel: 50,
+            targetCurrentLevel: 10,
+          ),
+          isTrue,
+        );
+      });
+
+      test('moderator can assign custom role equal to their level to users below them', () {
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.custom(50),
+            ownLevel: 50,
+            targetCurrentLevel: 10,
+          ),
+          isTrue,
+        );
+      });
+
+      test('moderator cannot assign custom role above their level', () {
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.custom(75),
+            ownLevel: 50,
+            targetCurrentLevel: 10,
+          ),
+          isFalse,
+        );
+      });
+    });
+
+    group('canAssignRole - member hierarchy', () {
+      test('member cannot assign any role', () {
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.member(),
+            ownLevel: 0,
+            targetCurrentLevel: 0,
+          ),
+          isFalse,
+        );
+      });
+
+      test('member cannot assign admin', () {
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.admin(),
+            ownLevel: 0,
+            targetCurrentLevel: 0,
+          ),
+          isFalse,
+        );
+      });
+    });
+
+    group('canAssignRole - edge cases', () {
+      test('cannot modify self at same level', () {
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.moderator(),
+            ownLevel: 50,
+            targetCurrentLevel: 50,
+          ),
+          isFalse,
+        );
+      });
+
+      test('cannot modify user at same level even with higher target role', () {
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.admin(),
+            ownLevel: 100,
+            targetCurrentLevel: 100,
+          ),
+          isFalse,
+        );
+      });
+
+      test('room creator (level 100) can demote everyone else', () {
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.member(),
+            ownLevel: 100,
+            targetCurrentLevel: 100,
+          ),
+          isFalse, // Cannot modify user at same level
+        );
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.member(),
+            ownLevel: 100,
+            targetCurrentLevel: 99,
+          ),
+          isTrue, // Can modify users below them
+        );
+      });
+
+      test('handles zero and negative power levels correctly', () {
+        expect(
+          RoomRole.canAssignRole(
+            target: const RoomRole.custom(-5),
+            ownLevel: 0,
+            targetCurrentLevel: -10,
+          ),
+          isTrue,
+        );
+      });
+    });
+
+    group('pattern matching', () {
+      test('map works for admin', () {
+        const admin = RoomRole.admin();
+        final result = admin.map(
+          admin: (_) => 'is_admin',
+          moderator: (_) => 'is_moderator',
+          member: (_) => 'is_member',
+          custom: (_) => 'is_custom',
+        );
+        expect(result, equals('is_admin'));
+      });
+
+      test('map works for custom', () {
+        const custom = RoomRole.custom(42);
+        final result = custom.map(
+          admin: (_) => 'is_admin',
+          moderator: (_) => 'is_moderator',
+          member: (_) => 'is_member',
+          custom: (_) => 'is_custom',
+        );
+        expect(result, equals('is_custom'));
+      });
+
+      test('maybeMap handles null cases', () {
+        const member = RoomRole.member();
+        final result = member.maybeMap(
+          admin: (_) => 'admin_case',
+          orElse: 'other_case',
+        );
+        expect(result, equals('other_case'));
+      });
+
+      test('maybeMap returns mapped value when present', () {
+        const member = RoomRole.member();
+        final result = member.maybeMap(
+          member: (_) => 'member_case',
+          orElse: 'other_case',
+        );
+        expect(result, equals('member_case'));
+      });
+    });
+
+    group('equality and hashing', () {
+      test('admin roles are equal', () {
+        expect(const RoomRole.admin(), equals(const RoomRole.admin()));
+      });
+
+      test('moderator roles are equal', () {
+        expect(const RoomRole.moderator(), equals(const RoomRole.moderator()));
+      });
+
+      test('member roles are equal', () {
+        expect(const RoomRole.member(), equals(const RoomRole.member()));
+      });
+
+      test('custom roles with same value are equal', () {
+        expect(
+          const RoomRole.custom(42),
+          equals(const RoomRole.custom(42)),
+        );
+      });
+
+      test('custom roles with different values are not equal', () {
+        expect(
+          const RoomRole.custom(42),
+          isNot(equals(const RoomRole.custom(43))),
+        );
+      });
+
+      test('different role types are not equal', () {
+        expect(
+          const RoomRole.admin(),
+          isNot(equals(const RoomRole.custom(100))),
+        );
+      });
+
+      test('admin roles have same hash', () {
+        expect(
+          const RoomRole.admin().hashCode,
+          equals(const RoomRole.admin().hashCode),
+        );
+      });
+
+      test('custom roles with same value have same hash', () {
+        expect(
+          const RoomRole.custom(42).hashCode,
+          equals(const RoomRole.custom(42).hashCode),
+        );
+      });
+    });
+
+    group('toString', () {
+      test('admin toString returns label', () {
+        expect(const RoomRole.admin().toString(), equals('Admin'));
+      });
+
+      test('moderator toString returns label', () {
+        expect(const RoomRole.moderator().toString(), equals('Moderator'));
+      });
+
+      test('member toString returns label', () {
+        expect(const RoomRole.member().toString(), equals('Member'));
+      });
+
+      test('custom toString returns label with value', () {
+        expect(const RoomRole.custom(47).toString(), equals('Custom (47)'));
+      });
+    });
+  });
+}

--- a/test/screens/chat_search_test.mocks.dart
+++ b/test/screens/chat_search_test.mocks.dart
@@ -4,33 +4,35 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i12;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i15;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i16;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i23;
+import 'package:matrix/src/utils/space_child.dart' as _i24;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -802,8 +804,9 @@ class _FakeSelectionService_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
-  _FakeSyncService_71(
+class _FakeSpaceAccessService_71 extends _i1.SmartFake
+    implements _i12.SpaceAccessService {
+  _FakeSpaceAccessService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -812,8 +815,8 @@ class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
         );
 }
 
-class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
-  _FakeAuthService_72(
+class _FakeSyncService_72 extends _i1.SmartFake implements _i13.SyncService {
+  _FakeSyncService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -822,9 +825,8 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeOutboxService_73 extends _i1.SmartFake
-    implements _i14.OutboxService {
-  _FakeOutboxService_73(
+class _FakeAuthService_73 extends _i1.SmartFake implements _i14.AuthService {
+  _FakeAuthService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -833,8 +835,9 @@ class _FakeOutboxService_73 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_74(
+class _FakeOutboxService_74 extends _i1.SmartFake
+    implements _i15.OutboxService {
+  _FakeOutboxService_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -843,9 +846,19 @@ class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_75 extends _i1.SmartFake
+class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_76 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_75(
+  _FakeLatestReceiptState_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -854,8 +867,8 @@ class _FakeLatestReceiptState_75 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_76(
+class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -864,8 +877,8 @@ class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_77(
+class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -874,8 +887,8 @@ class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_78 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_78(
+class _FakeRoom_79 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -884,9 +897,9 @@ class _FakeRoom_78 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeTimelineChunk_79 extends _i1.SmartFake
-    implements _i15.TimelineChunk {
-  _FakeTimelineChunk_79(
+class _FakeTimelineChunk_80 extends _i1.SmartFake
+    implements _i16.TimelineChunk {
+  _FakeTimelineChunk_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -913,12 +926,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1038,11 +1051,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1079,11 +1092,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1113,11 +1126,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1126,11 +1139,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1416,34 +1429,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1599,7 +1612,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1888,14 +1901,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2283,8 +2296,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2300,8 +2313,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2342,7 +2355,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2358,7 +2371,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2407,7 +2420,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2428,7 +2441,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2531,7 +2544,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2549,7 +2562,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3068,7 +3081,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3420,7 +3433,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3434,7 +3447,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3585,7 +3598,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4963,7 +4976,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4985,7 +4998,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5479,7 +5492,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5491,7 +5504,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6499,7 +6512,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6510,7 +6523,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6758,7 +6771,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6770,7 +6783,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7030,7 +7043,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7043,7 +7056,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7110,7 +7123,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7123,7 +7136,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7171,7 +7184,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7183,7 +7196,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7431,7 +7444,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7442,7 +7455,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7704,7 +7717,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7731,7 +7744,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7761,11 +7774,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7838,43 +7851,56 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i11.SelectionService);
 
   @override
-  _i12.SyncService get sync => (super.noSuchMethod(
+  _i12.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i12.SpaceAccessService);
+
+  @override
+  _i13.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_71(
+        returnValue: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_71(
+        returnValueForMissingStub: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i12.SyncService);
+      ) as _i13.SyncService);
 
   @override
-  _i13.AuthService get auth => (super.noSuchMethod(
+  _i14.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_72(
+        returnValue: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_72(
+        returnValueForMissingStub: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i13.AuthService);
+      ) as _i14.AuthService);
 
   @override
-  _i14.OutboxService get outbox => (super.noSuchMethod(
+  _i15.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_73(
+        returnValue: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_73(
+        returnValueForMissingStub: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i14.OutboxService);
+      ) as _i15.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7938,7 +7964,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set sync(_i12.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i12.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i13.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7947,7 +7982,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set auth(_i13.AuthService? value) => super.noSuchMethod(
+  set auth(_i14.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7956,7 +7991,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i15.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -8009,7 +8044,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8103,7 +8138,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8112,7 +8147,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8131,7 +8166,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8142,7 +8177,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8190,7 +8225,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8228,7 +8263,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8237,7 +8272,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8246,16 +8281,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8283,11 +8318,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8317,11 +8352,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_74(
+        returnValue: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_74(
+        returnValueForMissingStub: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
@@ -8374,11 +8409,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8414,11 +8449,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8434,11 +8469,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8447,11 +8482,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8494,11 +8529,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8541,11 +8576,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_75(
+        returnValue: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_75(
+        returnValueForMissingStub: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8582,6 +8617,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   bool get isFavourite => (super.noSuchMethod(
         Invocation.getter(#isFavourite),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
@@ -8757,18 +8799,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i23.SpaceParent>[],
-        returnValueForMissingStub: <_i23.SpaceParent>[],
-      ) as List<_i23.SpaceParent>);
+        returnValue: <_i24.SpaceParent>[],
+        returnValueForMissingStub: <_i24.SpaceParent>[],
+      ) as List<_i24.SpaceParent>);
 
   @override
-  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i23.SpaceChild>[],
-        returnValueForMissingStub: <_i23.SpaceChild>[],
-      ) as List<_i23.SpaceChild>);
+        returnValue: <_i24.SpaceChild>[],
+        returnValueForMissingStub: <_i24.SpaceChild>[],
+      ) as List<_i24.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8935,14 +8977,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8990,7 +9032,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8998,7 +9040,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9013,7 +9055,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9021,7 +9063,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9099,13 +9141,23 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   _i5.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9113,7 +9165,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9355,7 +9407,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9366,7 +9418,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9455,15 +9507,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i15.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i16.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i15.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i15.TimelineChunk?>.value(),
-      ) as _i5.Future<_i15.TimelineChunk?>);
+        returnValue: _i5.Future<_i16.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i16.TimelineChunk?>.value(),
+      ) as _i5.Future<_i16.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9504,7 +9556,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -9521,7 +9573,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -9585,14 +9637,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9608,14 +9660,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9671,7 +9723,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9679,7 +9731,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9991,11 +10043,11 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_78(
+        returnValue: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_78(
+        returnValueForMissingStub: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
@@ -10045,17 +10097,17 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       ) as bool);
 
   @override
-  _i15.TimelineChunk get chunk => (super.noSuchMethod(
+  _i16.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_79(
+        returnValue: _FakeTimelineChunk_80(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_79(
+        returnValueForMissingStub: _FakeTimelineChunk_80(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i15.TimelineChunk);
+      ) as _i16.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10158,7 +10210,7 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       );
 
   @override
-  set chunk(_i15.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i16.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,

--- a/test/screens/devices_screen_test.mocks.dart
+++ b/test/screens/devices_screen_test.mocks.dart
@@ -4,31 +4,33 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i17;
-import 'dart:ui' as _i19;
+import 'dart:typed_data' as _i18;
+import 'dart:ui' as _i20;
 
-import 'package:flutter/services.dart' as _i20;
-import 'package:flutter/widgets.dart' as _i21;
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i12;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i15;
+import 'package:matrix/encryption.dart' as _i16;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -800,8 +802,9 @@ class _FakeSelectionService_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
-  _FakeSyncService_71(
+class _FakeSpaceAccessService_71 extends _i1.SmartFake
+    implements _i12.SpaceAccessService {
+  _FakeSpaceAccessService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -810,8 +813,8 @@ class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
         );
 }
 
-class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
-  _FakeAuthService_72(
+class _FakeSyncService_72 extends _i1.SmartFake implements _i13.SyncService {
+  _FakeSyncService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -820,9 +823,19 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeOutboxService_73 extends _i1.SmartFake
-    implements _i14.OutboxService {
-  _FakeOutboxService_73(
+class _FakeAuthService_73 extends _i1.SmartFake implements _i14.AuthService {
+  _FakeAuthService_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeOutboxService_74 extends _i1.SmartFake
+    implements _i15.OutboxService {
+  _FakeOutboxService_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -849,12 +862,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i15.KeyVerificationMethod> get verificationMethods =>
+  Set<_i16.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i15.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
-      ) as Set<_i15.KeyVerificationMethod>);
+        returnValue: <_i16.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
+      ) as Set<_i16.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -974,11 +987,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1015,11 +1028,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1049,11 +1062,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1062,11 +1075,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1352,34 +1365,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i15.KeyVerification>
+  _i3.CachedStreamController<_i16.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i15.KeyVerification>(
+                _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i15.KeyVerification>);
+          ) as _i3.CachedStreamController<_i16.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1535,7 +1548,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1824,14 +1837,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2219,8 +2232,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2236,8 +2249,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2278,7 +2291,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2294,7 +2307,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2343,7 +2356,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2364,7 +2377,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2467,7 +2480,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2485,7 +2498,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3004,7 +3017,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i17.Uint8List? file, {
+    _i18.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3356,7 +3369,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3370,7 +3383,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3521,7 +3534,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i17.Uint8List? body,
+    _i18.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4899,7 +4912,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4921,7 +4934,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5415,7 +5428,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5427,7 +5440,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6435,7 +6448,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6446,7 +6459,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6694,7 +6707,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6706,7 +6719,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6966,7 +6979,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6979,7 +6992,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7046,7 +7059,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7059,7 +7072,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7107,7 +7120,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7119,7 +7132,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7367,7 +7380,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7378,7 +7391,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7640,7 +7653,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i17.Uint8List? body, {
+    _i18.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7667,7 +7680,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7697,11 +7710,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7774,43 +7787,56 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i11.SelectionService);
 
   @override
-  _i12.SyncService get sync => (super.noSuchMethod(
+  _i12.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i12.SpaceAccessService);
+
+  @override
+  _i13.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_71(
+        returnValue: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_71(
+        returnValueForMissingStub: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i12.SyncService);
+      ) as _i13.SyncService);
 
   @override
-  _i13.AuthService get auth => (super.noSuchMethod(
+  _i14.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_72(
+        returnValue: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_72(
+        returnValueForMissingStub: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i13.AuthService);
+      ) as _i14.AuthService);
 
   @override
-  _i14.OutboxService get outbox => (super.noSuchMethod(
+  _i15.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_73(
+        returnValue: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_73(
+        returnValueForMissingStub: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i14.OutboxService);
+      ) as _i15.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7874,7 +7900,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set sync(_i12.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i12.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i13.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7883,7 +7918,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set auth(_i13.AuthService? value) => super.noSuchMethod(
+  set auth(_i14.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7892,7 +7927,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i15.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -7945,7 +7980,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8039,7 +8074,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8048,7 +8083,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8067,7 +8102,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8078,7 +8113,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8126,7 +8161,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i21.RouteInformation? routeInformation) =>
+          _i22.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8164,7 +8199,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8173,7 +8208,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8182,16 +8217,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
-      ) as _i5.Future<_i19.AppExitResponse>);
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i5.Future<_i20.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8277,7 +8312,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> runKeyRecovery({_i15.OpenSSSS? ssssKey}) =>
+  _i5.Future<void> runKeyRecovery({_i16.OpenSSSS? ssssKey}) =>
       (super.noSuchMethod(
         Invocation.method(
           #runKeyRecovery,
@@ -8331,7 +8366,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8340,7 +8375,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/test/services/call_service_test.mocks.dart
+++ b/test/services/call_service_test.mocks.dart
@@ -7916,6 +7916,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -8422,6 +8429,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/services/call_signaling_service_test.mocks.dart
+++ b/test/services/call_signaling_service_test.mocks.dart
@@ -7916,6 +7916,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -8422,6 +8429,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/services/chat_message_actions_test.mocks.dart
+++ b/test/services/chat_message_actions_test.mocks.dart
@@ -4,39 +4,41 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i6;
-import 'dart:typed_data' as _i22;
-import 'dart:ui' as _i25;
+import 'dart:typed_data' as _i23;
+import 'dart:ui' as _i26;
 
-import 'package:flutter/scheduler.dart' as _i19;
-import 'package:flutter/services.dart' as _i26;
-import 'package:flutter/src/foundation/assertions.dart' as _i29;
-import 'package:flutter/src/foundation/diagnostics.dart' as _i18;
-import 'package:flutter/src/material/banner.dart' as _i28;
-import 'package:flutter/src/material/scaffold.dart' as _i16;
-import 'package:flutter/src/material/snack_bar.dart' as _i27;
-import 'package:flutter/widgets.dart' as _i17;
+import 'package:flutter/scheduler.dart' as _i20;
+import 'package:flutter/services.dart' as _i27;
+import 'package:flutter/src/foundation/assertions.dart' as _i30;
+import 'package:flutter/src/foundation/diagnostics.dart' as _i19;
+import 'package:flutter/src/material/banner.dart' as _i29;
+import 'package:flutter/src/material/scaffold.dart' as _i17;
+import 'package:flutter/src/material/snack_bar.dart' as _i28;
+import 'package:flutter/widgets.dart' as _i18;
 import 'package:http/http.dart' as _i5;
-import 'package:kohera/core/services/matrix_service.dart' as _i24;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
+import 'package:kohera/core/services/matrix_service.dart' as _i25;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i11;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i15;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i12;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i13;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i10;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i8;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i9;
-import 'package:matrix/encryption.dart' as _i23;
+import 'package:matrix/encryption.dart' as _i24;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i7;
 import 'package:matrix/src/models/timeline_chunk.dart' as _i4;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/src/utils/space_child.dart' as _i22;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i20;
+import 'package:mockito/src/dummies.dart' as _i21;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -889,8 +891,9 @@ class _FakeSelectionService_78 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_79 extends _i1.SmartFake implements _i13.SyncService {
-  _FakeSyncService_79(
+class _FakeSpaceAccessService_79 extends _i1.SmartFake
+    implements _i13.SpaceAccessService {
+  _FakeSpaceAccessService_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -899,8 +902,8 @@ class _FakeSyncService_79 extends _i1.SmartFake implements _i13.SyncService {
         );
 }
 
-class _FakeAuthService_80 extends _i1.SmartFake implements _i14.AuthService {
-  _FakeAuthService_80(
+class _FakeSyncService_80 extends _i1.SmartFake implements _i14.SyncService {
+  _FakeSyncService_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -909,9 +912,8 @@ class _FakeAuthService_80 extends _i1.SmartFake implements _i14.AuthService {
         );
 }
 
-class _FakeOutboxService_81 extends _i1.SmartFake
-    implements _i15.OutboxService {
-  _FakeOutboxService_81(
+class _FakeAuthService_81 extends _i1.SmartFake implements _i15.AuthService {
+  _FakeAuthService_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -920,24 +922,9 @@ class _FakeOutboxService_81 extends _i1.SmartFake
         );
 }
 
-class _FakeScaffoldMessenger_82 extends _i1.SmartFake
-    implements _i16.ScaffoldMessenger {
-  _FakeScaffoldMessenger_82(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-
-  @override
-  String toString(
-          {_i17.DiagnosticLevel? minLevel = _i17.DiagnosticLevel.info}) =>
-      super.toString();
-}
-
-class _FakeBuildContext_83 extends _i1.SmartFake implements _i17.BuildContext {
-  _FakeBuildContext_83(
+class _FakeOutboxService_82 extends _i1.SmartFake
+    implements _i16.OutboxService {
+  _FakeOutboxService_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -946,19 +933,9 @@ class _FakeBuildContext_83 extends _i1.SmartFake implements _i17.BuildContext {
         );
 }
 
-class _FakeScaffoldFeatureController_84<T extends _i17.Widget, U>
-    extends _i1.SmartFake implements _i16.ScaffoldFeatureController<T, U> {
-  _FakeScaffoldFeatureController_84(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
-class _FakeWidget_85 extends _i1.SmartFake implements _i17.Widget {
-  _FakeWidget_85(
+class _FakeScaffoldMessenger_83 extends _i1.SmartFake
+    implements _i17.ScaffoldMessenger {
+  _FakeScaffoldMessenger_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -968,13 +945,49 @@ class _FakeWidget_85 extends _i1.SmartFake implements _i17.Widget {
 
   @override
   String toString(
-          {_i17.DiagnosticLevel? minLevel = _i17.DiagnosticLevel.info}) =>
+          {_i18.DiagnosticLevel? minLevel = _i18.DiagnosticLevel.info}) =>
       super.toString();
 }
 
-class _FakeDiagnosticsNode_86 extends _i1.SmartFake
-    implements _i17.DiagnosticsNode {
-  _FakeDiagnosticsNode_86(
+class _FakeBuildContext_84 extends _i1.SmartFake implements _i18.BuildContext {
+  _FakeBuildContext_84(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeScaffoldFeatureController_85<T extends _i18.Widget, U>
+    extends _i1.SmartFake implements _i17.ScaffoldFeatureController<T, U> {
+  _FakeScaffoldFeatureController_85(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeWidget_86 extends _i1.SmartFake implements _i18.Widget {
+  _FakeWidget_86(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+
+  @override
+  String toString(
+          {_i18.DiagnosticLevel? minLevel = _i18.DiagnosticLevel.info}) =>
+      super.toString();
+}
+
+class _FakeDiagnosticsNode_87 extends _i1.SmartFake
+    implements _i18.DiagnosticsNode {
+  _FakeDiagnosticsNode_87(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -984,14 +997,14 @@ class _FakeDiagnosticsNode_86 extends _i1.SmartFake
 
   @override
   String toString({
-    _i18.TextTreeConfiguration? parentConfiguration,
-    _i17.DiagnosticLevel? minLevel = _i17.DiagnosticLevel.info,
+    _i19.TextTreeConfiguration? parentConfiguration,
+    _i18.DiagnosticLevel? minLevel = _i18.DiagnosticLevel.info,
   }) =>
       super.toString();
 }
 
-class _FakeTicker_87 extends _i1.SmartFake implements _i19.Ticker {
-  _FakeTicker_87(
+class _FakeTicker_88 extends _i1.SmartFake implements _i20.Ticker {
+  _FakeTicker_88(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1010,11 +1023,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1101,11 +1114,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -1141,11 +1154,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1161,11 +1174,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1174,11 +1187,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1221,11 +1234,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1309,6 +1322,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   bool get isFavourite => (super.noSuchMethod(
         Invocation.getter(#isFavourite),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
@@ -1484,18 +1504,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i22.SpaceParent>[],
+        returnValueForMissingStub: <_i22.SpaceParent>[],
+      ) as List<_i22.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i22.SpaceChild>[],
+        returnValueForMissingStub: <_i22.SpaceChild>[],
+      ) as List<_i22.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -1662,14 +1682,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -1717,7 +1737,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -1725,7 +1745,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i20.dummyValue<String>(
+            _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -1740,7 +1760,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -1748,7 +1768,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i20.dummyValue<String>(
+            _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -1826,13 +1846,23 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i6.Future<void>);
 
   @override
+  _i6.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+
+  @override
   _i6.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -1840,7 +1870,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i20.dummyValue<String>(
+            _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2082,7 +2112,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2093,7 +2123,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i20.dummyValue<String>(
+            _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2398,7 +2428,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2406,7 +2436,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i20.dummyValue<String>(
+            _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2784,11 +2814,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -2797,11 +2827,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -2810,11 +2840,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -2823,11 +2853,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -2836,11 +2866,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -2905,11 +2935,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -2918,11 +2948,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -2975,11 +3005,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -3064,11 +3094,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -3086,11 +3116,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -3301,7 +3331,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i6.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i6.Future<_i22.Uint8List> Function(Uri)? downloadCallback,
+    _i6.Future<_i23.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -3366,7 +3396,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -3381,7 +3411,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i20.dummyValue<String>(
+            _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -3418,7 +3448,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -3432,7 +3462,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -3469,7 +3499,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -3483,7 +3513,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -3517,7 +3547,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -3530,7 +3560,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -4007,12 +4037,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i23.KeyVerificationMethod> get verificationMethods =>
+  Set<_i24.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i23.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i23.KeyVerificationMethod>{},
-      ) as Set<_i23.KeyVerificationMethod>);
+        returnValue: <_i24.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i24.KeyVerificationMethod>{},
+      ) as Set<_i24.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -4132,11 +4162,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -4173,11 +4203,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -4207,11 +4237,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -4220,11 +4250,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -4511,34 +4541,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i23.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i24.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_1<_i23.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_1<_i24.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_1<_i23.RoomKeyRequest>(
+            _FakeCachedStreamController_1<_i24.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i23.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i24.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i23.KeyVerification>
+  _i3.CachedStreamController<_i24.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_1<_i23.KeyVerification>(
+            returnValue: _FakeCachedStreamController_1<_i24.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_1<_i23.KeyVerification>(
+                _FakeCachedStreamController_1<_i24.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i23.KeyVerification>);
+          ) as _i3.CachedStreamController<_i24.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -4694,7 +4724,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i23.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i24.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -4983,14 +5013,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -5378,8 +5408,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValue: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -5395,8 +5425,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -5437,7 +5467,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -5453,7 +5483,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i20.dummyValue<String>(
+            _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -5502,7 +5532,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -5523,7 +5553,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i20.dummyValue<String>(
+            _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -5626,7 +5656,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -5644,7 +5674,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i20.dummyValue<String>(
+            _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -6166,7 +6196,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i6.Future<Uri> uploadContent(
-    _i22.Uint8List? file, {
+    _i23.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -6518,7 +6548,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -6532,7 +6562,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i20.dummyValue<String>(
+            _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -6683,7 +6713,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i5.BaseResponse? response,
-    _i22.Uint8List? body,
+    _i23.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8061,7 +8091,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -8083,7 +8113,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i20.dummyValue<String>(
+            _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -8577,7 +8607,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -8589,7 +8619,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i20.dummyValue<String>(
+            _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -9597,7 +9627,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -9608,7 +9638,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i20.dummyValue<String>(
+            _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -9856,7 +9886,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9868,7 +9898,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i20.dummyValue<String>(
+            _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -10128,7 +10158,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -10141,7 +10171,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i20.dummyValue<String>(
+            _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -10208,7 +10238,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -10221,7 +10251,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i20.dummyValue<String>(
+            _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -10269,7 +10299,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -10281,7 +10311,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i20.dummyValue<String>(
+            _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -10529,7 +10559,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -10540,7 +10570,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i20.dummyValue<String>(
+            _i6.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -10802,7 +10832,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i6.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i22.Uint8List? body, {
+    _i23.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -10829,7 +10859,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i25.MatrixService {
   @override
   _i8.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -10859,11 +10889,11 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -10936,43 +10966,56 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       ) as _i12.SelectionService);
 
   @override
-  _i13.SyncService get sync => (super.noSuchMethod(
+  _i13.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_79(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_79(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i13.SpaceAccessService);
+
+  @override
+  _i14.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_79(
+        returnValue: _FakeSyncService_80(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_79(
+        returnValueForMissingStub: _FakeSyncService_80(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i13.SyncService);
+      ) as _i14.SyncService);
 
   @override
-  _i14.AuthService get auth => (super.noSuchMethod(
+  _i15.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_80(
+        returnValue: _FakeAuthService_81(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_80(
+        returnValueForMissingStub: _FakeAuthService_81(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i14.AuthService);
+      ) as _i15.AuthService);
 
   @override
-  _i15.OutboxService get outbox => (super.noSuchMethod(
+  _i16.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_81(
+        returnValue: _FakeOutboxService_82(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_81(
+        returnValueForMissingStub: _FakeOutboxService_82(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i15.OutboxService);
+      ) as _i16.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -11036,7 +11079,16 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       );
 
   @override
-  set sync(_i13.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i13.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i14.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -11045,7 +11097,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       );
 
   @override
-  set auth(_i14.AuthService? value) => super.noSuchMethod(
+  set auth(_i15.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -11054,7 +11106,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       );
 
   @override
-  set outbox(_i15.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i16.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -11107,7 +11159,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i25.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i26.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -11201,7 +11253,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       ) as _i6.Future<void>);
 
   @override
-  void addListener(_i25.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i26.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -11210,7 +11262,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       );
 
   @override
-  void removeListener(_i25.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i26.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -11229,7 +11281,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       ) as _i6.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i26.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i27.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -11240,7 +11292,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i26.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i27.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -11288,7 +11340,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
 
   @override
   _i6.Future<bool> didPushRouteInformation(
-          _i17.RouteInformation? routeInformation) =>
+          _i18.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -11326,7 +11378,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i25.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i26.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -11335,7 +11387,7 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i25.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i26.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -11344,16 +11396,16 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
       );
 
   @override
-  _i6.Future<_i25.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i6.Future<_i26.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i6.Future<_i25.AppExitResponse>.value(_i25.AppExitResponse.exit),
+            _i6.Future<_i26.AppExitResponse>.value(_i26.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i6.Future<_i25.AppExitResponse>.value(_i25.AppExitResponse.exit),
-      ) as _i6.Future<_i25.AppExitResponse>);
+            _i6.Future<_i26.AppExitResponse>.value(_i26.AppExitResponse.exit),
+      ) as _i6.Future<_i26.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -11378,32 +11430,32 @@ class MockMatrixService extends _i1.Mock implements _i24.MatrixService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockScaffoldMessengerState extends _i1.Mock
-    implements _i16.ScaffoldMessengerState {
+    implements _i17.ScaffoldMessengerState {
   @override
-  _i16.ScaffoldMessenger get widget => (super.noSuchMethod(
+  _i17.ScaffoldMessenger get widget => (super.noSuchMethod(
         Invocation.getter(#widget),
-        returnValue: _FakeScaffoldMessenger_82(
+        returnValue: _FakeScaffoldMessenger_83(
           this,
           Invocation.getter(#widget),
         ),
-        returnValueForMissingStub: _FakeScaffoldMessenger_82(
+        returnValueForMissingStub: _FakeScaffoldMessenger_83(
           this,
           Invocation.getter(#widget),
         ),
-      ) as _i16.ScaffoldMessenger);
+      ) as _i17.ScaffoldMessenger);
 
   @override
-  _i17.BuildContext get context => (super.noSuchMethod(
+  _i18.BuildContext get context => (super.noSuchMethod(
         Invocation.getter(#context),
-        returnValue: _FakeBuildContext_83(
+        returnValue: _FakeBuildContext_84(
           this,
           Invocation.getter(#context),
         ),
-        returnValueForMissingStub: _FakeBuildContext_83(
+        returnValueForMissingStub: _FakeBuildContext_84(
           this,
           Invocation.getter(#context),
         ),
-      ) as _i17.BuildContext);
+      ) as _i18.BuildContext);
 
   @override
   bool get mounted => (super.noSuchMethod(
@@ -11422,10 +11474,10 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  _i16.ScaffoldFeatureController<_i27.SnackBar, _i27.SnackBarClosedReason>
+  _i17.ScaffoldFeatureController<_i28.SnackBar, _i28.SnackBarClosedReason>
       showSnackBar(
-    _i27.SnackBar? snackBar, {
-    _i17.AnimationStyle? snackBarAnimationStyle,
+    _i28.SnackBar? snackBar, {
+    _i18.AnimationStyle? snackBarAnimationStyle,
   }) =>
           (super.noSuchMethod(
             Invocation.method(
@@ -11433,8 +11485,8 @@ class MockScaffoldMessengerState extends _i1.Mock
               [snackBar],
               {#snackBarAnimationStyle: snackBarAnimationStyle},
             ),
-            returnValue: _FakeScaffoldFeatureController_84<_i27.SnackBar,
-                _i27.SnackBarClosedReason>(
+            returnValue: _FakeScaffoldFeatureController_85<_i28.SnackBar,
+                _i28.SnackBarClosedReason>(
               this,
               Invocation.method(
                 #showSnackBar,
@@ -11442,8 +11494,8 @@ class MockScaffoldMessengerState extends _i1.Mock
                 {#snackBarAnimationStyle: snackBarAnimationStyle},
               ),
             ),
-            returnValueForMissingStub: _FakeScaffoldFeatureController_84<
-                _i27.SnackBar, _i27.SnackBarClosedReason>(
+            returnValueForMissingStub: _FakeScaffoldFeatureController_85<
+                _i28.SnackBar, _i28.SnackBarClosedReason>(
               this,
               Invocation.method(
                 #showSnackBar,
@@ -11451,13 +11503,13 @@ class MockScaffoldMessengerState extends _i1.Mock
                 {#snackBarAnimationStyle: snackBarAnimationStyle},
               ),
             ),
-          ) as _i16.ScaffoldFeatureController<_i27.SnackBar,
-              _i27.SnackBarClosedReason>);
+          ) as _i17.ScaffoldFeatureController<_i28.SnackBar,
+              _i28.SnackBarClosedReason>);
 
   @override
   void removeCurrentSnackBar(
-          {_i27.SnackBarClosedReason? reason =
-              _i27.SnackBarClosedReason.remove}) =>
+          {_i28.SnackBarClosedReason? reason =
+              _i28.SnackBarClosedReason.remove}) =>
       super.noSuchMethod(
         Invocation.method(
           #removeCurrentSnackBar,
@@ -11469,8 +11521,8 @@ class MockScaffoldMessengerState extends _i1.Mock
 
   @override
   void hideCurrentSnackBar(
-          {_i27.SnackBarClosedReason? reason =
-              _i27.SnackBarClosedReason.hide}) =>
+          {_i28.SnackBarClosedReason? reason =
+              _i28.SnackBarClosedReason.hide}) =>
       super.noSuchMethod(
         Invocation.method(
           #hideCurrentSnackBar,
@@ -11490,37 +11542,37 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  _i16.ScaffoldFeatureController<_i28.MaterialBanner,
-      _i28.MaterialBannerClosedReason> showMaterialBanner(
-          _i28.MaterialBanner? materialBanner) =>
+  _i17.ScaffoldFeatureController<_i29.MaterialBanner,
+      _i29.MaterialBannerClosedReason> showMaterialBanner(
+          _i29.MaterialBanner? materialBanner) =>
       (super.noSuchMethod(
         Invocation.method(
           #showMaterialBanner,
           [materialBanner],
         ),
-        returnValue: _FakeScaffoldFeatureController_84<_i28.MaterialBanner,
-            _i28.MaterialBannerClosedReason>(
+        returnValue: _FakeScaffoldFeatureController_85<_i29.MaterialBanner,
+            _i29.MaterialBannerClosedReason>(
           this,
           Invocation.method(
             #showMaterialBanner,
             [materialBanner],
           ),
         ),
-        returnValueForMissingStub: _FakeScaffoldFeatureController_84<
-            _i28.MaterialBanner, _i28.MaterialBannerClosedReason>(
+        returnValueForMissingStub: _FakeScaffoldFeatureController_85<
+            _i29.MaterialBanner, _i29.MaterialBannerClosedReason>(
           this,
           Invocation.method(
             #showMaterialBanner,
             [materialBanner],
           ),
         ),
-      ) as _i16.ScaffoldFeatureController<_i28.MaterialBanner,
-          _i28.MaterialBannerClosedReason>);
+      ) as _i17.ScaffoldFeatureController<_i29.MaterialBanner,
+          _i29.MaterialBannerClosedReason>);
 
   @override
   void removeCurrentMaterialBanner(
-          {_i28.MaterialBannerClosedReason? reason =
-              _i28.MaterialBannerClosedReason.remove}) =>
+          {_i29.MaterialBannerClosedReason? reason =
+              _i29.MaterialBannerClosedReason.remove}) =>
       super.noSuchMethod(
         Invocation.method(
           #removeCurrentMaterialBanner,
@@ -11532,8 +11584,8 @@ class MockScaffoldMessengerState extends _i1.Mock
 
   @override
   void hideCurrentMaterialBanner(
-          {_i28.MaterialBannerClosedReason? reason =
-              _i28.MaterialBannerClosedReason.hide}) =>
+          {_i29.MaterialBannerClosedReason? reason =
+              _i29.MaterialBannerClosedReason.hide}) =>
       super.noSuchMethod(
         Invocation.method(
           #hideCurrentMaterialBanner,
@@ -11553,26 +11605,26 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  _i17.Widget build(_i17.BuildContext? context) => (super.noSuchMethod(
+  _i18.Widget build(_i18.BuildContext? context) => (super.noSuchMethod(
         Invocation.method(
           #build,
           [context],
         ),
-        returnValue: _FakeWidget_85(
+        returnValue: _FakeWidget_86(
           this,
           Invocation.method(
             #build,
             [context],
           ),
         ),
-        returnValueForMissingStub: _FakeWidget_85(
+        returnValueForMissingStub: _FakeWidget_86(
           this,
           Invocation.method(
             #build,
             [context],
           ),
         ),
-      ) as _i17.Widget);
+      ) as _i18.Widget);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -11593,7 +11645,7 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  void didUpdateWidget(_i16.ScaffoldMessenger? oldWidget) => super.noSuchMethod(
+  void didUpdateWidget(_i17.ScaffoldMessenger? oldWidget) => super.noSuchMethod(
         Invocation.method(
           #didUpdateWidget,
           [oldWidget],
@@ -11611,7 +11663,7 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  void setState(_i25.VoidCallback? fn) => super.noSuchMethod(
+  void setState(_i26.VoidCallback? fn) => super.noSuchMethod(
         Invocation.method(
           #setState,
           [fn],
@@ -11638,7 +11690,7 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  void debugFillProperties(_i29.DiagnosticPropertiesBuilder? properties) =>
+  void debugFillProperties(_i30.DiagnosticPropertiesBuilder? properties) =>
       super.noSuchMethod(
         Invocation.method(
           #debugFillProperties,
@@ -11649,7 +11701,7 @@ class MockScaffoldMessengerState extends _i1.Mock
 
   @override
   String toString(
-          {_i17.DiagnosticLevel? minLevel = _i17.DiagnosticLevel.info}) =>
+          {_i18.DiagnosticLevel? minLevel = _i18.DiagnosticLevel.info}) =>
       super.toString();
 
   @override
@@ -11658,14 +11710,14 @@ class MockScaffoldMessengerState extends _i1.Mock
           #toStringShort,
           [],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #toStringShort,
             [],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #toStringShort,
@@ -11675,9 +11727,9 @@ class MockScaffoldMessengerState extends _i1.Mock
       ) as String);
 
   @override
-  _i17.DiagnosticsNode toDiagnosticsNode({
+  _i18.DiagnosticsNode toDiagnosticsNode({
     String? name,
-    _i29.DiagnosticsTreeStyle? style,
+    _i30.DiagnosticsTreeStyle? style,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -11688,7 +11740,7 @@ class MockScaffoldMessengerState extends _i1.Mock
             #style: style,
           },
         ),
-        returnValue: _FakeDiagnosticsNode_86(
+        returnValue: _FakeDiagnosticsNode_87(
           this,
           Invocation.method(
             #toDiagnosticsNode,
@@ -11699,7 +11751,7 @@ class MockScaffoldMessengerState extends _i1.Mock
             },
           ),
         ),
-        returnValueForMissingStub: _FakeDiagnosticsNode_86(
+        returnValueForMissingStub: _FakeDiagnosticsNode_87(
           this,
           Invocation.method(
             #toDiagnosticsNode,
@@ -11710,27 +11762,27 @@ class MockScaffoldMessengerState extends _i1.Mock
             },
           ),
         ),
-      ) as _i17.DiagnosticsNode);
+      ) as _i18.DiagnosticsNode);
 
   @override
-  _i19.Ticker createTicker(_i19.TickerCallback? onTick) => (super.noSuchMethod(
+  _i20.Ticker createTicker(_i20.TickerCallback? onTick) => (super.noSuchMethod(
         Invocation.method(
           #createTicker,
           [onTick],
         ),
-        returnValue: _FakeTicker_87(
+        returnValue: _FakeTicker_88(
           this,
           Invocation.method(
             #createTicker,
             [onTick],
           ),
         ),
-        returnValueForMissingStub: _FakeTicker_87(
+        returnValueForMissingStub: _FakeTicker_88(
           this,
           Invocation.method(
             #createTicker,
             [onTick],
           ),
         ),
-      ) as _i19.Ticker);
+      ) as _i20.Ticker);
 }

--- a/test/services/chat_search_controller_test.mocks.dart
+++ b/test/services/chat_search_controller_test.mocks.dart
@@ -461,6 +461,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -967,6 +974,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/services/inbox_controller_test.mocks.dart
+++ b/test/services/inbox_controller_test.mocks.dart
@@ -7926,6 +7926,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -8432,6 +8439,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/services/ios_voip_push_service_test.mocks.dart
+++ b/test/services/ios_voip_push_service_test.mocks.dart
@@ -3,44 +3,46 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i13;
-import 'dart:typed_data' as _i23;
-import 'dart:ui' as _i19;
+import 'dart:async' as _i14;
+import 'dart:typed_data' as _i24;
+import 'dart:ui' as _i20;
 
-import 'package:flutter/services.dart' as _i20;
-import 'package:flutter/widgets.dart' as _i21;
-import 'package:http/http.dart' as _i12;
-import 'package:kohera/core/services/call_service.dart' as _i24;
-import 'package:kohera/core/services/matrix_service.dart' as _i15;
-import 'package:kohera/core/services/preferences_service.dart' as _i16;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
+import 'package:http/http.dart' as _i13;
+import 'package:kohera/core/services/call_service.dart' as _i25;
+import 'package:kohera/core/services/matrix_service.dart' as _i16;
+import 'package:kohera/core/services/preferences_service.dart' as _i17;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i7;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i8;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
-import 'package:kohera/features/calling/models/call_participant.dart' as _i27;
-import 'package:kohera/features/calling/models/call_state.dart' as _i29;
-import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i28;
-import 'package:kohera/features/calling/services/livekit_service.dart' as _i25;
-import 'package:kohera/features/calling/services/ringtone_service.dart' as _i30;
+import 'package:kohera/features/calling/models/call_participant.dart' as _i28;
+import 'package:kohera/features/calling/models/call_state.dart' as _i30;
+import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i29;
+import 'package:kohera/features/calling/services/livekit_service.dart' as _i26;
+import 'package:kohera/features/calling/services/ringtone_service.dart' as _i31;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
 import 'package:kohera/features/notifications/services/notification_service.dart'
-    as _i31;
-import 'package:livekit_client/livekit_client.dart' as _i26;
-import 'package:matrix/encryption.dart' as _i22;
+    as _i32;
+import 'package:livekit_client/livekit_client.dart' as _i27;
+import 'package:matrix/encryption.dart' as _i23;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i14;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i17;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i11;
-import 'package:matrix/src/utils/space_child.dart' as _i32;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i15;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i18;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i12;
+import 'package:matrix/src/utils/space_child.dart' as _i33;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i18;
+import 'package:mockito/src/dummies.dart' as _i19;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -121,8 +123,9 @@ class _FakeSelectionService_5 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
-  _FakeSyncService_6(
+class _FakeSpaceAccessService_6 extends _i1.SmartFake
+    implements _i8.SpaceAccessService {
+  _FakeSpaceAccessService_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -131,8 +134,8 @@ class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
         );
 }
 
-class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
-  _FakeAuthService_7(
+class _FakeSyncService_7 extends _i1.SmartFake implements _i9.SyncService {
+  _FakeSyncService_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -141,8 +144,8 @@ class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
         );
 }
 
-class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
-  _FakeOutboxService_8(
+class _FakeAuthService_8 extends _i1.SmartFake implements _i10.AuthService {
+  _FakeAuthService_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -151,8 +154,8 @@ class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
         );
 }
 
-class _FakeDatabaseApi_9 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_9(
+class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
+  _FakeOutboxService_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -161,8 +164,8 @@ class _FakeDatabaseApi_9 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_10 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_10(
+class _FakeDatabaseApi_10 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -171,9 +174,19 @@ class _FakeFilter_10 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_11 extends _i1.SmartFake
+class _FakeFilter_11 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_11(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeNativeImplementations_12 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_11(
+  _FakeNativeImplementations_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -182,8 +195,8 @@ class _FakeNativeImplementations_11 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_12 extends _i1.SmartFake implements Duration {
-  _FakeDuration_12(
+class _FakeDuration_13 extends _i1.SmartFake implements Duration {
+  _FakeDuration_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -192,9 +205,9 @@ class _FakeDuration_12 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_13 extends _i1.SmartFake
+class _FakePushruleEvaluator_14 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_13(
+  _FakePushruleEvaluator_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -203,8 +216,8 @@ class _FakePushruleEvaluator_13 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_14 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_14(
+class _FakeProfile_15 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -213,9 +226,9 @@ class _FakeProfile_14 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeCachedStreamController_15<T> extends _i1.SmartFake
-    implements _i11.CachedStreamController<T> {
-  _FakeCachedStreamController_15(
+class _FakeCachedStreamController_16<T> extends _i1.SmartFake
+    implements _i12.CachedStreamController<T> {
+  _FakeCachedStreamController_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -224,8 +237,8 @@ class _FakeCachedStreamController_15<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_16 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_16(
+class _FakeDateTime_17 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -234,8 +247,8 @@ class _FakeDateTime_16 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_17 extends _i1.SmartFake implements _i12.Client {
-  _FakeClient_17(
+class _FakeClient_18 extends _i1.SmartFake implements _i13.Client {
+  _FakeClient_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -244,9 +257,9 @@ class _FakeClient_17 extends _i1.SmartFake implements _i12.Client {
         );
 }
 
-class _FakeDiscoveryInformation_18 extends _i1.SmartFake
+class _FakeDiscoveryInformation_19 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_18(
+  _FakeDiscoveryInformation_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -255,9 +268,9 @@ class _FakeDiscoveryInformation_18 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_19 extends _i1.SmartFake
+class _FakeGetVersionsResponse_20 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_19(
+  _FakeGetVersionsResponse_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -266,9 +279,9 @@ class _FakeGetVersionsResponse_19 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_20 extends _i1.SmartFake
+class _FakeRegisterResponse_21 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_20(
+  _FakeRegisterResponse_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -277,8 +290,8 @@ class _FakeRegisterResponse_20 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_21 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_21(
+class _FakeLoginResponse_22 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -287,9 +300,9 @@ class _FakeLoginResponse_21 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_22 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_23 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_22(
+  _FakeGetAuthMetadataResponse_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -298,8 +311,8 @@ class _FakeGetAuthMetadataResponse_22 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_23<T1> extends _i1.SmartFake implements _i13.Future<T1> {
-  _FakeFuture_23(
+class _FakeFuture_24<T1> extends _i1.SmartFake implements _i14.Future<T1> {
+  _FakeFuture_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -308,8 +321,8 @@ class _FakeFuture_23<T1> extends _i1.SmartFake implements _i13.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_24 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_24(
+class _FakeSyncUpdate_25 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -318,9 +331,9 @@ class _FakeSyncUpdate_24 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_25 extends _i1.SmartFake
+class _FakeCachedProfileInformation_26 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_25(
+  _FakeCachedProfileInformation_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -329,8 +342,8 @@ class _FakeCachedProfileInformation_25 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_26 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_26(
+class _FakeMediaConfig_27 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -339,8 +352,8 @@ class _FakeMediaConfig_26 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_27 extends _i1.SmartFake implements _i14.FileResponse {
-  _FakeFileResponse_27(
+class _FakeFileResponse_28 extends _i1.SmartFake implements _i15.FileResponse {
+  _FakeFileResponse_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -349,8 +362,8 @@ class _FakeFileResponse_27 extends _i1.SmartFake implements _i14.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_28 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_28(
+class _FakePreviewForUrl_29 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -359,8 +372,8 @@ class _FakePreviewForUrl_28 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeUri_29 extends _i1.SmartFake implements Uri {
-  _FakeUri_29(
+class _FakeUri_30 extends _i1.SmartFake implements Uri {
+  _FakeUri_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -369,9 +382,9 @@ class _FakeUri_29 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_30 extends _i1.SmartFake
+class _FakeCachedPresence_31 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_30(
+  _FakeCachedPresence_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -380,9 +393,9 @@ class _FakeCachedPresence_30 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_31 extends _i1.SmartFake
+class _FakeTurnServerCredentials_32 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_31(
+  _FakeTurnServerCredentials_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -391,9 +404,9 @@ class _FakeTurnServerCredentials_31 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_32 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_33 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_32(
+  _FakeRoomKeysUpdateResponse_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -402,8 +415,8 @@ class _FakeRoomKeysUpdateResponse_32 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_33 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_33(
+class _FakeKeyBackupData_34 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -412,9 +425,9 @@ class _FakeKeyBackupData_33 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_34 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_35 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_34(
+  _FakeGetWellknownSupportResponse_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -423,9 +436,9 @@ class _FakeGetWellknownSupportResponse_34 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_35 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_36 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_35(
+  _FakeGenerateLoginTokenResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -434,9 +447,9 @@ class _FakeGenerateLoginTokenResponse_35 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_36 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_37 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_36(
+  _FakeGetRoomSummaryResponse$3_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -445,9 +458,9 @@ class _FakeGetRoomSummaryResponse$3_36 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_37 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_38 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_37(
+  _FakeGetSpaceHierarchyResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -456,9 +469,9 @@ class _FakeGetSpaceHierarchyResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_38 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_39 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_38(
+  _FakeGetRelatingEventsResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -467,9 +480,9 @@ class _FakeGetRelatingEventsResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_39 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_40 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_39(
+  _FakeGetRelatingEventsWithRelTypeResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -478,9 +491,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -489,9 +502,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_41 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_42 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_41(
+  _FakeGetThreadRootsResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -500,9 +513,9 @@ class _FakeGetThreadRootsResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_42 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_43 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_42(
+  _FakeGetEventByTimestampResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -511,9 +524,9 @@ class _FakeGetEventByTimestampResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_43 extends _i1.SmartFake
+class _FakeRequestTokenResponse_44 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_43(
+  _FakeRequestTokenResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -522,9 +535,9 @@ class _FakeRequestTokenResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_44 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_45 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_44(
+  _FakeTokenOwnerInfo_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -533,8 +546,8 @@ class _FakeTokenOwnerInfo_44 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_45 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_45(
+class _FakeWhoIsInfo_46 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -543,8 +556,8 @@ class _FakeWhoIsInfo_45 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_46 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_46(
+class _FakeCapabilities_47 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -553,8 +566,8 @@ class _FakeCapabilities_46 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_47 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_47(
+class _FakeDevice_48 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -563,9 +576,9 @@ class _FakeDevice_47 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_48 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_49 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_48(
+  _FakeGetRoomIdByAliasResponse_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -574,9 +587,9 @@ class _FakeGetRoomIdByAliasResponse_48 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_49 extends _i1.SmartFake
+class _FakeGetEventsResponse_50 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_49(
+  _FakeGetEventsResponse_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -585,9 +598,9 @@ class _FakeGetEventsResponse_49 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_50 extends _i1.SmartFake
+class _FakePeekEventsResponse_51 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_50(
+  _FakePeekEventsResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -596,8 +609,8 @@ class _FakePeekEventsResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_51 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_51(
+class _FakeMatrixEvent_52 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -606,9 +619,9 @@ class _FakeMatrixEvent_51 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_52 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_53 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_52(
+  _FakeGetKeysChangesResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -617,9 +630,9 @@ class _FakeGetKeysChangesResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_53 extends _i1.SmartFake
+class _FakeClaimKeysResponse_54 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_53(
+  _FakeClaimKeysResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -628,9 +641,9 @@ class _FakeClaimKeysResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_54 extends _i1.SmartFake
+class _FakeQueryKeysResponse_55 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_54(
+  _FakeQueryKeysResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -639,9 +652,9 @@ class _FakeQueryKeysResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_55 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_56 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_55(
+  _FakeGetNotificationsResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -650,9 +663,9 @@ class _FakeGetNotificationsResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_56 extends _i1.SmartFake
+class _FakeGetPresenceResponse_57 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_56(
+  _FakeGetPresenceResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -661,9 +674,9 @@ class _FakeGetPresenceResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_57 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_58 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_57(
+  _FakeGetPublicRoomsResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -672,9 +685,9 @@ class _FakeGetPublicRoomsResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_58 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_59 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_58(
+  _FakeQueryPublicRoomsResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -683,8 +696,8 @@ class _FakeQueryPublicRoomsResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_59 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_59(
+class _FakePushRuleSet_60 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -693,9 +706,9 @@ class _FakePushRuleSet_59 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_60 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_61 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_60(
+  _FakeGetPushRulesGlobalResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -704,8 +717,8 @@ class _FakeGetPushRulesGlobalResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_61 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_61(
+class _FakePushRule_62 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -714,9 +727,9 @@ class _FakePushRule_61 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_62 extends _i1.SmartFake
+class _FakeRefreshResponse_63 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_62(
+  _FakeRefreshResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -725,8 +738,8 @@ class _FakeRefreshResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_63 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_63(
+class _FakeRoomKeys_64 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -735,8 +748,8 @@ class _FakeRoomKeys_63 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_64 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_64(
+class _FakeRoomKeyBackup_65 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -745,9 +758,9 @@ class _FakeRoomKeyBackup_64 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_65 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_66 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_65(
+  _FakeGetRoomKeysVersionCurrentResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,9 +769,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_66 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_67 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_66(
+  _FakeGetRoomKeysVersionResponse_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -767,8 +780,8 @@ class _FakeGetRoomKeysVersionResponse_66 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_67 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_67(
+class _FakeEventContext_68 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -777,9 +790,9 @@ class _FakeEventContext_67 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_68 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_69 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_68(
+  _FakeGetRoomEventsResponse_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -788,8 +801,8 @@ class _FakeGetRoomEventsResponse_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_69 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_69(
+class _FakeSearchResults_70 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,9 +811,9 @@ class _FakeSearchResults_69 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_70 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_71 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_70(
+  _FakeGetProtocolMetadataResponse$2_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -809,9 +822,9 @@ class _FakeGetProtocolMetadataResponse$2_70 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_71 extends _i1.SmartFake
+class _FakeOpenIdCredentials_72 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_71(
+  _FakeOpenIdCredentials_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -820,9 +833,9 @@ class _FakeOpenIdCredentials_71 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_72 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_73 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_72(
+  _FakeSearchUserDirectoryResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -831,9 +844,9 @@ class _FakeSearchUserDirectoryResponse_72 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_73 extends _i1.SmartFake
+class _FakeCreateContentResponse_74 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_73(
+  _FakeCreateContentResponse_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,8 +855,8 @@ class _FakeCreateContentResponse_73 extends _i1.SmartFake
         );
 }
 
-class _FakeResponse_74 extends _i1.SmartFake implements _i12.Response {
-  _FakeResponse_74(
+class _FakeResponse_75 extends _i1.SmartFake implements _i13.Response {
+  _FakeResponse_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -852,9 +865,9 @@ class _FakeResponse_74 extends _i1.SmartFake implements _i12.Response {
         );
 }
 
-class _FakeMatrixService_75 extends _i1.SmartFake
-    implements _i15.MatrixService {
-  _FakeMatrixService_75(
+class _FakeMatrixService_76 extends _i1.SmartFake
+    implements _i16.MatrixService {
+  _FakeMatrixService_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -863,9 +876,9 @@ class _FakeMatrixService_75 extends _i1.SmartFake
         );
 }
 
-class _FakePreferencesService_76 extends _i1.SmartFake
-    implements _i16.PreferencesService {
-  _FakePreferencesService_76(
+class _FakePreferencesService_77 extends _i1.SmartFake
+    implements _i17.PreferencesService {
+  _FakePreferencesService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -874,8 +887,8 @@ class _FakePreferencesService_76 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_77 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_77(
+class _FakeRoomSummary_78 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -884,9 +897,9 @@ class _FakeRoomSummary_77 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_78 extends _i1.SmartFake
+class _FakeLatestReceiptState_79 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_78(
+  _FakeLatestReceiptState_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -895,8 +908,8 @@ class _FakeLatestReceiptState_78 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_79 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_79(
+class _FakeTimeline_80 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -905,8 +918,8 @@ class _FakeTimeline_79 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_80 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_80(
+class _FakeUser_81 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -915,8 +928,8 @@ class _FakeUser_80 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeRoom_81 extends _i1.SmartFake implements _i4.Room {
-  _FakeRoom_81(
+class _FakeRoom_82 extends _i1.SmartFake implements _i4.Room {
+  _FakeRoom_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -925,9 +938,9 @@ class _FakeRoom_81 extends _i1.SmartFake implements _i4.Room {
         );
 }
 
-class _FakeTimelineChunk_82 extends _i1.SmartFake
-    implements _i17.TimelineChunk {
-  _FakeTimelineChunk_82(
+class _FakeTimelineChunk_83 extends _i1.SmartFake
+    implements _i18.TimelineChunk {
+  _FakeTimelineChunk_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -939,7 +952,7 @@ class _FakeTimelineChunk_82 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -969,11 +982,11 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1046,43 +1059,56 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as _i7.SelectionService);
 
   @override
-  _i8.SyncService get sync => (super.noSuchMethod(
+  _i8.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_6(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_6(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i8.SpaceAccessService);
+
+  @override
+  _i9.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_6(
+        returnValue: _FakeSyncService_7(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_6(
+        returnValueForMissingStub: _FakeSyncService_7(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i8.SyncService);
+      ) as _i9.SyncService);
 
   @override
-  _i9.AuthService get auth => (super.noSuchMethod(
+  _i10.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_7(
+        returnValue: _FakeAuthService_8(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_7(
+        returnValueForMissingStub: _FakeAuthService_8(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i9.AuthService);
+      ) as _i10.AuthService);
 
   @override
-  _i10.OutboxService get outbox => (super.noSuchMethod(
+  _i11.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_8(
+        returnValue: _FakeOutboxService_9(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_8(
+        returnValueForMissingStub: _FakeOutboxService_9(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i10.OutboxService);
+      ) as _i11.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1146,7 +1172,16 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set sync(_i8.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i8.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i9.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -1155,7 +1190,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set auth(_i9.AuthService? value) => super.noSuchMethod(
+  set auth(_i10.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -1164,7 +1199,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set outbox(_i10.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i11.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -1180,14 +1215,14 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as bool);
 
   @override
-  _i13.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1217,7 +1252,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1227,18 +1262,18 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<bool> login({
+  _i14.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1253,12 +1288,12 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> completeSsoLogin({
+  _i14.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1271,12 +1306,12 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> completeRegistration(
+  _i14.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1286,32 +1321,32 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1320,7 +1355,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1329,17 +1364,17 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1350,7 +1385,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1387,26 +1422,26 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> didPushRouteInformation(
-          _i21.RouteInformation? routeInformation) =>
+  _i14.Future<bool> didPushRouteInformation(
+          _i22.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1436,7 +1471,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1445,7 +1480,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1454,16 +1489,16 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i14.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i13.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+            _i14.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i13.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
-      ) as _i13.Future<_i19.AppExitResponse>);
+            _i14.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i14.Future<_i20.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1491,23 +1526,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_9(
+        returnValue: _FakeDatabaseApi_10(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_9(
+        returnValueForMissingStub: _FakeDatabaseApi_10(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i22.KeyVerificationMethod> get verificationMethods =>
+  Set<_i23.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i22.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i22.KeyVerificationMethod>{},
-      ) as Set<_i22.KeyVerificationMethod>);
+        returnValue: <_i23.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i23.KeyVerificationMethod>{},
+      ) as Set<_i23.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1568,11 +1603,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_10(
+        returnValue: _FakeFilter_11(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_10(
+        returnValueForMissingStub: _FakeFilter_11(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -1581,11 +1616,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_11(
+        returnValue: _FakeNativeImplementations_12(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_11(
+        returnValueForMissingStub: _FakeNativeImplementations_12(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -1601,11 +1636,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_12(
+        returnValue: _FakeDuration_13(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_12(
+        returnValueForMissingStub: _FakeDuration_13(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -1614,11 +1649,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_12(
+        returnValue: _FakeDuration_13(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_12(
+        returnValueForMissingStub: _FakeDuration_13(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -1627,11 +1662,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1668,11 +1703,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1702,11 +1737,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1715,11 +1750,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1742,11 +1777,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_13(
+        returnValue: _FakePushruleEvaluator_14(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_13(
+        returnValueForMissingStub: _FakePushruleEvaluator_14(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -1767,332 +1802,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i13.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i14.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i11.CachedStreamController<String> get onUserProfileUpdate =>
+  _i12.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_15<String>(
+        returnValue: _FakeCachedStreamController_16<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i13.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i14.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i13.Future<List<_i4.Room>>);
+            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i14.Future<List<_i4.Room>>);
 
   @override
-  _i11.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i12.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_15<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_16<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.EventUpdate>(
+            _FakeCachedStreamController_16<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.EventUpdate>);
+      ) as _i12.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i12.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_15<_i4.Event>(
+        returnValue: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i12.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_15<_i4.Event>(
+        returnValue: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onNotification =>
+  _i12.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_15<_i4.Event>(
+        returnValue: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i12.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_15<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_16<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_16<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i12.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i11.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i12.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_15<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_16<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_15<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_16<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i11.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i12.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i11.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i12.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_15<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_16<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.LoginState>(
+            _FakeCachedStreamController_16<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i11.CachedStreamController<_i4.LoginState>);
+      ) as _i12.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i11.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i12.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_15<bool>(
+        returnValue: _FakeCachedStreamController_16<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i11.CachedStreamController<bool>);
+      ) as _i12.CachedStreamController<bool>);
 
   @override
-  _i11.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i12.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_15<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_16<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i11.CachedStreamController<_i4.SdkError>);
+      ) as _i12.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i11.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i12.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_15<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_16<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.SyncUpdate>(
+            _FakeCachedStreamController_16<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i11.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i12.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i12.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_15<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_16<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_16<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i11.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i12.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.Presence> get onPresence =>
+  _i12.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_15<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_16<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i11.CachedStreamController<_i4.Presence>);
+      ) as _i12.CachedStreamController<_i4.Presence>);
 
   @override
-  _i11.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i12.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_15<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_16<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.CachedPresence>(
+            _FakeCachedStreamController_16<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i11.CachedStreamController<_i4.CachedPresence>);
+      ) as _i12.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i11.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i12.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_15<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_16<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.BasicEvent>(
+            _FakeCachedStreamController_16<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i11.CachedStreamController<_i4.BasicEvent>);
+      ) as _i12.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i11.CachedStreamController<_i22.RoomKeyRequest> get onRoomKeyRequest =>
+  _i12.CachedStreamController<_i23.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_15<_i22.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_16<_i23.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i22.RoomKeyRequest>(
+            _FakeCachedStreamController_16<_i23.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i11.CachedStreamController<_i22.RoomKeyRequest>);
+      ) as _i12.CachedStreamController<_i23.RoomKeyRequest>);
 
   @override
-  _i11.CachedStreamController<_i22.KeyVerification>
+  _i12.CachedStreamController<_i23.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_15<_i22.KeyVerification>(
+            returnValue: _FakeCachedStreamController_16<_i23.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_15<_i22.KeyVerification>(
+                _FakeCachedStreamController_16<_i23.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i11.CachedStreamController<_i22.KeyVerification>);
+          ) as _i12.CachedStreamController<_i23.KeyVerification>);
 
   @override
-  _i11.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i12.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_15<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_16<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_16<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i11.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i12.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i12.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_15<_i4.Event>(
+        returnValue: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<String> get onCancelSendEvent =>
+  _i12.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_15<String>(
+        returnValue: _FakeCachedStreamController_16<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i11.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i12.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_15<
+            returnValue: _FakeCachedStreamController_16<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_15<
+            returnValueForMissingStub: _FakeCachedStreamController_16<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i11.CachedStreamController<
+          ) as _i12.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -2112,11 +2147,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_16(
+        returnValue: _FakeDateTime_17(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_16(
+        returnValueForMissingStub: _FakeDateTime_17(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2189,7 +2224,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i22.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i23.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2244,7 +2279,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i13.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i14.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2255,7 +2290,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i13.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i14.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -2366,7 +2401,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -2375,7 +2410,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -2384,7 +2419,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -2411,20 +2446,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Client get httpClient => (super.noSuchMethod(
+  _i13.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_17(
+        returnValue: _FakeClient_18(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_17(
+        returnValueForMissingStub: _FakeClient_18(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i12.Client);
+      ) as _i13.Client);
 
   @override
-  set httpClient(_i12.Client? value) => super.noSuchMethod(
+  set httpClient(_i13.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -2451,7 +2486,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<void> refreshAccessToken(
+  _i14.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2459,9 +2494,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -2479,14 +2514,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2523,33 +2558,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i13.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i14.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_18(
+        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_19(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_18(
+        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_19(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i13.Future<_i4.DiscoveryInformation>);
+      ) as _i14.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i13.Future<
+  _i14.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -2571,7 +2606,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i13.Future<
+        returnValue: _i14.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2579,7 +2614,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_19(
+          _FakeGetVersionsResponse_20(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2594,7 +2629,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i13.Future<
+        returnValueForMissingStub: _i14.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2602,7 +2637,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_19(
+          _FakeGetVersionsResponse_20(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2617,7 +2652,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i13.Future<
+      ) as _i14.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -2626,7 +2661,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i13.Future<_i4.DiscoveryInformation> getWellknown({
+  _i14.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2639,8 +2674,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_18(
+        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_19(
           this,
           Invocation.method(
             #getWellknown,
@@ -2651,8 +2686,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_18(
+        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_19(
           this,
           Invocation.method(
             #getWellknown,
@@ -2663,10 +2698,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.DiscoveryInformation>);
+      ) as _i14.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i13.Future<_i4.RegisterResponse> register({
+  _i14.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -2694,7 +2729,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_20(
+            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_21(
           this,
           Invocation.method(
             #register,
@@ -2713,7 +2748,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_20(
+            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_21(
           this,
           Invocation.method(
             #register,
@@ -2731,10 +2766,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RegisterResponse>);
+      ) as _i14.Future<_i4.RegisterResponse>);
 
   @override
-  _i13.Future<_i4.LoginResponse> login(
+  _i14.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -2764,7 +2799,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_21(
+        returnValue: _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_22(
           this,
           Invocation.method(
             #login,
@@ -2784,7 +2819,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_21(
+            _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_22(
           this,
           Invocation.method(
             #login,
@@ -2803,10 +2838,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.LoginResponse>);
+      ) as _i14.Future<_i4.LoginResponse>);
 
   @override
-  _i13.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i14.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2819,8 +2854,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_22(
+        returnValue: _i14.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_23(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2832,8 +2867,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_22(
+            _i14.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_23(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2844,74 +2879,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i14.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> logoutAll() => (super.noSuchMethod(
+  _i14.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<T> uiaRequestBackground<T>(
-          _i13.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i14.Future<T> uiaRequestBackground<T>(
+          _i14.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValue: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i13.Future<T>.value(v),
+              (T v) => _i14.Future<T>.value(v),
             ) ??
-            _FakeFuture_23<T>(
+            _FakeFuture_24<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i13.Future<T>.value(v),
+              (T v) => _i14.Future<T>.value(v),
             ) ??
-            _FakeFuture_23<T>(
+            _FakeFuture_24<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i13.Future<T>);
+      ) as _i14.Future<T>);
 
   @override
-  _i13.Future<String> startDirectChat(
+  _i14.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -2933,7 +2968,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2949,7 +2984,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i18.dummyValue<String>(
+            _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2964,10 +2999,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<String> createGroupChat({
+  _i14.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -2998,7 +3033,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3019,7 +3054,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i18.dummyValue<String>(
+            _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3039,10 +3074,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i14.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -3058,7 +3093,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3071,7 +3106,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3083,21 +3118,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i14.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<String> createSpace({
+  _i14.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -3122,7 +3157,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3140,7 +3175,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i18.dummyValue<String>(
+            _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3157,10 +3192,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i14.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3168,7 +3203,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3177,7 +3212,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3185,10 +3220,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i13.Future<_i4.Profile> fetchOwnProfile({
+  _i14.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3201,7 +3236,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3213,7 +3248,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3224,10 +3259,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i13.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i14.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3241,8 +3276,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i13.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_25(
+        returnValue: _i14.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_26(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3254,8 +3289,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_25(
+            _i14.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_26(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3266,10 +3301,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.CachedProfileInformation>);
+      ) as _i14.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i13.Future<_i4.Profile> getProfileFromUserId(
+  _i14.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3287,7 +3322,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3301,7 +3336,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3314,7 +3349,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -3336,31 +3371,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i13.Future<List<_i4.Room>>);
+            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i14.Future<List<_i4.Room>>);
 
   @override
-  _i13.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i14.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i13.Future<List<_i4.ArchivedRoom>>);
+            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i14.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i13.Future<_i4.GetVersionsResponse> getVersions({
+  _i14.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3373,8 +3408,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_19(
+        returnValue: _i14.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_20(
           this,
           Invocation.method(
             #getVersions,
@@ -3385,8 +3420,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_19(
+        returnValueForMissingStub: _i14.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_20(
           this,
           Invocation.method(
             #getVersions,
@@ -3397,20 +3432,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetVersionsResponse>);
+      ) as _i14.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i13.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i14.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<_i4.MediaConfig> getConfig({
+  _i14.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3423,7 +3458,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
+        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
           this,
           Invocation.method(
             #getConfig,
@@ -3435,7 +3470,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
+            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
           this,
           Invocation.method(
             #getConfig,
@@ -3446,10 +3481,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.MediaConfig>);
+      ) as _i14.Future<_i4.MediaConfig>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContent(
+  _i14.Future<_i15.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -3469,7 +3504,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContent,
@@ -3485,7 +3520,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContent,
@@ -3500,10 +3535,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentOverrideName(
+  _i14.Future<_i15.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -3525,7 +3560,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3542,7 +3577,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3558,10 +3593,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentThumbnail(
+  _i14.Future<_i15.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -3589,7 +3624,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3609,7 +3644,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3628,10 +3663,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i14.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -3641,7 +3676,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
+        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3650,7 +3685,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
+            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3658,11 +3693,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i13.Future<_i4.PreviewForUrl>);
+      ) as _i14.Future<_i4.PreviewForUrl>);
 
   @override
-  _i13.Future<Uri> uploadContent(
-    _i23.Uint8List? file, {
+  _i14.Future<Uri> uploadContent(
+    _i24.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3675,7 +3710,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i13.Future<Uri>.value(_FakeUri_29(
+        returnValue: _i14.Future<Uri>.value(_FakeUri_30(
           this,
           Invocation.method(
             #uploadContent,
@@ -3686,7 +3721,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_29(
+        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_30(
           this,
           Invocation.method(
             #uploadContent,
@@ -3697,10 +3732,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<Uri>);
+      ) as _i14.Future<Uri>);
 
   @override
-  _i13.Future<void> setTyping(
+  _i14.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -3716,42 +3751,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> exportDump() => (super.noSuchMethod(
+  _i14.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i14.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i14.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Event?> getEventByPushNotification(
+  _i14.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -3767,12 +3802,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
-  _i13.Future<void> init({
+  _i14.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -3807,9 +3842,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -3821,40 +3856,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<void> clear() => (super.noSuchMethod(
+  _i14.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i14.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ensureNotSoftLoggedOut(
+  _i14.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleSync(
+  _i14.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -3864,9 +3899,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -3879,29 +3914,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i13.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i14.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i14.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDevice(
+  _i14.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -3915,12 +3950,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDevicesOfUserIds(
+  _i14.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -3936,12 +3971,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDeviceEncrypted(
+  _i14.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -3961,12 +3996,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDeviceEncryptedChunked(
+  _i14.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -3980,23 +4015,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i14.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> joinRoom(
+  _i14.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -4014,7 +4049,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4028,7 +4063,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i18.dummyValue<String>(
+            _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4041,10 +4076,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> changePassword(
+  _i14.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -4060,22 +4095,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> clearCache() => (super.noSuchMethod(
+  _i14.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ignoreUser(
+  _i14.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4085,22 +4120,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i14.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i14.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4111,7 +4146,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_30(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_31(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4120,7 +4155,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_30(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_31(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4128,32 +4163,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i13.Future<_i4.CachedPresence>);
+      ) as _i14.Future<_i4.CachedPresence>);
 
   @override
-  _i13.Future<void> abortSync() => (super.noSuchMethod(
+  _i14.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i14.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEventWithMetadata(
+  _i14.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4173,14 +4208,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i12.BaseResponse? response,
-    _i23.Uint8List? body,
+    _i13.BaseResponse? response,
+    _i24.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4212,7 +4247,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i13.Future<Map<String, Object?>> request(
+  _i14.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -4233,13 +4268,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> postPusher(
+  _i14.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -4249,57 +4284,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i14.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i14.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i14.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i13.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_31(
+        returnValue: _i14.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_32(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_31(
+        returnValueForMissingStub: _i14.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_32(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.TurnServerCredentials>);
+      ) as _i14.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4313,8 +4348,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4326,8 +4361,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4338,10 +4373,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4357,8 +4392,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4371,8 +4406,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4384,10 +4419,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i14.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4401,7 +4436,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
+        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4413,7 +4448,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
+            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4424,17 +4459,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.KeyBackupData>);
+      ) as _i14.Future<_i4.KeyBackupData>);
 
   @override
-  _i13.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i14.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i13.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_34(
+        returnValue: _i14.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_35(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -4442,18 +4477,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_34(
+            _i14.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_35(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i14.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i13.Future<int> pingAppservice(
+  _i14.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -4463,12 +4498,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i13.Future<int>.value(0),
-        returnValueForMissingStub: _i13.Future<int>.value(0),
-      ) as _i13.Future<int>);
+        returnValue: _i14.Future<int>.value(0),
+        returnValueForMissingStub: _i14.Future<int>.value(0),
+      ) as _i14.Future<int>);
 
   @override
-  _i13.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i14.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4476,8 +4511,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_35(
+        returnValue: _i14.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_36(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4486,8 +4521,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_35(
+            _i14.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_36(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4495,15 +4530,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i13.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i14.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i13.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i14.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
+        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -4511,17 +4546,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
+            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.MediaConfig>);
+      ) as _i14.Future<_i4.MediaConfig>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentAuthed(
+  _i14.Future<_i15.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -4535,7 +4570,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4547,7 +4582,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4558,10 +4593,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentOverrideNameAuthed(
+  _i14.Future<_i15.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4577,7 +4612,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4590,7 +4625,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4602,10 +4637,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i14.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -4615,7 +4650,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
+        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4624,7 +4659,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
+            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4632,10 +4667,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i13.Future<_i4.PreviewForUrl>);
+      ) as _i14.Future<_i4.PreviewForUrl>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentThumbnailAuthed(
+  _i14.Future<_i15.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -4659,7 +4694,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4677,7 +4712,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4694,21 +4729,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<bool> registrationTokenValidity(String? token) =>
+  _i14.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i14.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -4718,8 +4753,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_36(
+        returnValue: _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_37(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4728,8 +4763,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_36(
+            _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_37(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4737,10 +4772,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i14.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i13.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i14.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -4758,8 +4793,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_37(
+        returnValue: _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_38(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4773,8 +4808,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_37(
+            _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_38(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4787,10 +4822,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i14.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i14.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -4814,8 +4849,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i13.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_38(
+        returnValue: _i14.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_39(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4833,8 +4868,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_38(
+            _i14.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_39(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4851,10 +4886,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i14.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -4882,8 +4917,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_39(
+                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_40(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4902,8 +4937,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_39(
+                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_40(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4921,10 +4956,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i14.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -4953,9 +4988,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i13.Future<
+            returnValue: _i14.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -4974,9 +5009,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i13.Future<
+            returnValueForMissingStub: _i14.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -4995,11 +5030,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i13
+          ) as _i14
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i13.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i14.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -5015,8 +5050,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i13.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_41(
+        returnValue: _i14.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_42(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5029,8 +5064,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_41(
+            _i14.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_42(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5042,10 +5077,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetThreadRootsResponse>);
+      ) as _i14.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i13.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i14.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -5059,8 +5094,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i13.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_42(
+        returnValue: _i14.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_43(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5072,8 +5107,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_42(
+            _i14.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_43(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5084,33 +5119,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i14.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i14.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i13.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i14.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i13.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i14.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i13.Future<Uri?>.value(),
-        returnValueForMissingStub: _i13.Future<Uri?>.value(),
-      ) as _i13.Future<Uri?>);
+        returnValue: _i14.Future<Uri?>.value(),
+        returnValueForMissingStub: _i14.Future<Uri?>.value(),
+      ) as _i14.Future<Uri?>);
 
   @override
-  _i13.Future<void> add3PID(
+  _i14.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -5124,12 +5159,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> bind3PID(
+  _i14.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5145,12 +5180,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i14.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5164,14 +5199,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5193,8 +5228,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5210,8 +5245,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5227,10 +5262,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5254,8 +5289,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5272,8 +5307,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5290,10 +5325,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i14.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5307,14 +5342,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i14.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -5329,14 +5364,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5358,8 +5393,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5375,8 +5410,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5392,10 +5427,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5419,8 +5454,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5437,8 +5472,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5455,16 +5490,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i14.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_44(
+            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_45(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -5472,22 +5507,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_44(
+            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_45(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.TokenOwnerInfo>);
+      ) as _i14.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i13.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i14.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_45(
+        returnValue: _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_46(
           this,
           Invocation.method(
             #getWhoIs,
@@ -5495,22 +5530,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_45(
+            _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_46(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i13.Future<_i4.WhoIsInfo>);
+      ) as _i14.Future<_i4.WhoIsInfo>);
 
   @override
-  _i13.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i14.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_46(
+        returnValue: _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_47(
           this,
           Invocation.method(
             #getCapabilities,
@@ -5518,17 +5553,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_46(
+            _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_47(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.Capabilities>);
+      ) as _i14.Future<_i4.Capabilities>);
 
   @override
-  _i13.Future<String> createRoom({
+  _i14.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -5561,7 +5596,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5583,7 +5618,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i18.dummyValue<String>(
+            _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5604,10 +5639,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> deleteDevices(
+  _i14.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5617,22 +5652,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.Device>?>.value(),
-      ) as _i13.Future<List<_i4.Device>?>);
+        returnValue: _i14.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.Device>?>.value(),
+      ) as _i14.Future<List<_i4.Device>?>);
 
   @override
-  _i13.Future<void> deleteDevice(
+  _i14.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5642,34 +5677,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i14.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i13.Future<_i4.Device>.value(_FakeDevice_47(
+        returnValue: _i14.Future<_i4.Device>.value(_FakeDevice_48(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.Device>.value(_FakeDevice_47(
+        returnValueForMissingStub: _i14.Future<_i4.Device>.value(_FakeDevice_48(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i13.Future<_i4.Device>);
+      ) as _i14.Future<_i4.Device>);
 
   @override
-  _i13.Future<void> updateDevice(
+  _i14.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -5679,12 +5714,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i14.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -5699,24 +5734,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i14.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i13.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Visibility?>.value(),
-      ) as _i13.Future<_i4.Visibility?>);
+        returnValue: _i14.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Visibility?>.value(),
+      ) as _i14.Future<_i4.Visibility?>);
 
   @override
-  _i13.Future<void> setRoomVisibilityOnDirectory(
+  _i14.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -5726,30 +5761,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i14.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i14.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_48(
+        returnValue: _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_49(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -5757,18 +5792,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_48(
+            _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_49(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i14.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i13.Future<void> setRoomAlias(
+  _i14.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -5780,12 +5815,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetEventsResponse> getEvents({
+  _i14.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -5799,7 +5834,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_49(
+            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_50(
           this,
           Invocation.method(
             #getEvents,
@@ -5811,7 +5846,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_49(
+            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_50(
           this,
           Invocation.method(
             #getEvents,
@@ -5822,10 +5857,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetEventsResponse>);
+      ) as _i14.Future<_i4.GetEventsResponse>);
 
   @override
-  _i13.Future<_i4.PeekEventsResponse> peekEvents({
+  _i14.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -5840,8 +5875,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i13.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_50(
+        returnValue: _i14.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_51(
           this,
           Invocation.method(
             #peekEvents,
@@ -5853,8 +5888,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_50(
+        returnValueForMissingStub: _i14.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_51(
           this,
           Invocation.method(
             #peekEvents,
@@ -5866,16 +5901,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.PeekEventsResponse>);
+      ) as _i14.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i13.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i14.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
+        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
           this,
           Invocation.method(
             #getOneEvent,
@@ -5883,27 +5918,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
+            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i13.Future<_i4.MatrixEvent>);
+      ) as _i14.Future<_i4.MatrixEvent>);
 
   @override
-  _i13.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i14.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i13.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
-      ) as _i13.Future<List<String>>);
+        returnValue: _i14.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
+      ) as _i14.Future<List<String>>);
 
   @override
-  _i13.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i14.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -5915,8 +5950,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i13.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_52(
+        returnValue: _i14.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_53(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5927,8 +5962,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_52(
+            _i14.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_53(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5938,10 +5973,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.GetKeysChangesResponse>);
+      ) as _i14.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i13.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i14.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -5952,7 +5987,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_53(
+            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_54(
           this,
           Invocation.method(
             #claimKeys,
@@ -5961,7 +5996,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_53(
+            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_54(
           this,
           Invocation.method(
             #claimKeys,
@@ -5969,10 +6004,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i13.Future<_i4.ClaimKeysResponse>);
+      ) as _i14.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i13.Future<void> uploadCrossSigningKeys({
+  _i14.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -5989,12 +6024,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.QueryKeysResponse> queryKeys(
+  _i14.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -6005,7 +6040,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_54(
+            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_55(
           this,
           Invocation.method(
             #queryKeys,
@@ -6014,7 +6049,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_54(
+            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_55(
           this,
           Invocation.method(
             #queryKeys,
@@ -6022,10 +6057,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i13.Future<_i4.QueryKeysResponse>);
+      ) as _i14.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -6033,14 +6068,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i13.Future<
+            returnValue: _i14.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i13.Future<
+            returnValueForMissingStub: _i14.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i13.Future<Map<String, int>> uploadKeys({
+  _i14.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -6055,13 +6090,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i13.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i14.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i13.Future<Map<String, int>>);
+            _i14.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i14.Future<Map<String, int>>);
 
   @override
-  _i13.Future<String> knockRoom(
+  _i14.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -6075,7 +6110,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6087,7 +6122,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i18.dummyValue<String>(
+            _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6098,20 +6133,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i14.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i13.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i14.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i14.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i13.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i14.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6126,8 +6161,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i13.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_55(
+        returnValue: _i14.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_56(
           this,
           Invocation.method(
             #getNotifications,
@@ -6140,8 +6175,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_55(
+            _i14.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_56(
           this,
           Invocation.method(
             #getNotifications,
@@ -6153,35 +6188,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetNotificationsResponse>);
+      ) as _i14.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i13.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i14.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i13.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_56(
+        returnValue: _i14.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_57(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_56(
+        returnValueForMissingStub: _i14.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_57(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i13.Future<_i4.GetPresenceResponse>);
+      ) as _i14.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i13.Future<void> setPresence(
+  _i14.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -6195,12 +6230,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, Object?>> deleteProfileField(
+  _i14.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6213,13 +6248,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getProfileField(
+  _i14.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6232,13 +6267,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<Map<String, Object?>> setProfileField(
+  _i14.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6253,13 +6288,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i14.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6274,8 +6309,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i13.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_57(
+        returnValue: _i14.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_58(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6288,8 +6323,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_57(
+            _i14.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_58(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6301,10 +6336,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i14.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i13.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i14.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -6325,8 +6360,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i13.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_58(
+        returnValue: _i14.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_59(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6342,8 +6377,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_58(
+            _i14.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_59(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6358,25 +6393,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i14.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i13.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.Pusher>?>.value(),
-      ) as _i13.Future<List<_i4.Pusher>?>);
+        returnValue: _i14.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.Pusher>?>.value(),
+      ) as _i14.Future<List<_i4.Pusher>?>);
 
   @override
-  _i13.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i14.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_59(
+        returnValue: _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_60(
           this,
           Invocation.method(
             #getPushRules,
@@ -6384,24 +6419,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_59(
+            _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_60(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.PushRuleSet>);
+      ) as _i14.Future<_i4.PushRuleSet>);
 
   @override
-  _i13.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i14.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_60(
+        returnValue: _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_61(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -6409,18 +6444,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_60(
+            _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_61(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i14.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i13.Future<void> deletePushRule(
+  _i14.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6432,12 +6467,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.PushRule> getPushRule(
+  _i14.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6449,7 +6484,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<_i4.PushRule>.value(_FakePushRule_61(
+        returnValue: _i14.Future<_i4.PushRule>.value(_FakePushRule_62(
           this,
           Invocation.method(
             #getPushRule,
@@ -6460,7 +6495,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PushRule>.value(_FakePushRule_61(
+            _i14.Future<_i4.PushRule>.value(_FakePushRule_62(
           this,
           Invocation.method(
             #getPushRule,
@@ -6470,10 +6505,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.PushRule>);
+      ) as _i14.Future<_i4.PushRule>);
 
   @override
-  _i13.Future<void> setPushRule(
+  _i14.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -6497,12 +6532,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<Object?>> getPushRuleActions(
+  _i14.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6514,13 +6549,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i14.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i13.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i13.Future<List<Object?>>);
+            _i14.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i14.Future<List<Object?>>);
 
   @override
-  _i13.Future<void> setPushRuleActions(
+  _i14.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -6534,12 +6569,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<bool> isPushRuleEnabled(
+  _i14.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6551,12 +6586,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> setPushRuleEnabled(
+  _i14.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -6570,19 +6605,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i14.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_62(
+            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_63(
           this,
           Invocation.method(
             #refresh,
@@ -6590,28 +6625,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_62(
+            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_63(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i13.Future<_i4.RefreshResponse>);
+      ) as _i14.Future<_i4.RefreshResponse>);
 
   @override
-  _i13.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i14.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i13.Future<bool?>.value(),
-        returnValueForMissingStub: _i13.Future<bool?>.value(),
-      ) as _i13.Future<bool?>);
+        returnValue: _i14.Future<bool?>.value(),
+        returnValueForMissingStub: _i14.Future<bool?>.value(),
+      ) as _i14.Future<bool?>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6633,8 +6668,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6650,8 +6685,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6667,10 +6702,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6694,8 +6729,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6712,8 +6747,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6730,17 +6765,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -6748,23 +6783,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i14.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_63(
+        returnValue: _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_64(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -6772,17 +6807,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_63(
+            _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_64(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeys>);
+      ) as _i14.Future<_i4.RoomKeys>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -6794,8 +6829,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6806,8 +6841,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6817,10 +6852,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6832,8 +6867,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6844,8 +6879,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6855,10 +6890,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6870,7 +6905,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_64(
+        returnValue: _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_65(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6881,7 +6916,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_64(
+            _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_65(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6891,10 +6926,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeyBackup>);
+      ) as _i14.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -6908,8 +6943,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6921,8 +6956,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6933,10 +6968,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6950,8 +6985,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -6963,8 +6998,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -6975,10 +7010,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i14.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6992,7 +7027,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
+        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7004,7 +7039,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
+            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7015,10 +7050,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.KeyBackupData>);
+      ) as _i14.Future<_i4.KeyBackupData>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7034,8 +7069,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7048,8 +7083,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7061,18 +7096,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_65(
+                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_66(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -7080,18 +7115,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_65(
+                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_66(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i13.Future<String> postRoomKeysVersion(
+  _i14.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -7103,7 +7138,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7114,7 +7149,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i18.dummyValue<String>(
+            _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7124,29 +7159,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i14.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i14.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_66(
+        returnValue: _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_67(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7154,18 +7189,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_66(
+            _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_67(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i14.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i14.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -7180,24 +7215,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i14.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i13.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
-      ) as _i13.Future<List<String>>);
+        returnValue: _i14.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
+      ) as _i14.Future<List<String>>);
 
   @override
-  _i13.Future<void> ban(
+  _i14.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7211,12 +7246,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.EventContext> getEventContext(
+  _i14.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7234,7 +7269,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<_i4.EventContext>.value(_FakeEventContext_67(
+        returnValue: _i14.Future<_i4.EventContext>.value(_FakeEventContext_68(
           this,
           Invocation.method(
             #getEventContext,
@@ -7249,7 +7284,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.EventContext>.value(_FakeEventContext_67(
+            _i14.Future<_i4.EventContext>.value(_FakeEventContext_68(
           this,
           Invocation.method(
             #getEventContext,
@@ -7263,10 +7298,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.EventContext>);
+      ) as _i14.Future<_i4.EventContext>);
 
   @override
-  _i13.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i14.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7278,7 +7313,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
+        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7289,7 +7324,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
+            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7299,20 +7334,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.MatrixEvent>);
+      ) as _i14.Future<_i4.MatrixEvent>);
 
   @override
-  _i13.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i14.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> inviteBy3PID(
+  _i14.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -7324,12 +7359,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> inviteUser(
+  _i14.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7343,12 +7378,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> joinRoomById(
+  _i14.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -7362,7 +7397,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7374,7 +7409,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i18.dummyValue<String>(
+            _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7385,23 +7420,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i14.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i13.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i14.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i13.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i13.Future<Map<String, _i4.RoomMember>?>);
+            _i14.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i14.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i13.Future<void> kick(
+  _i14.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7415,12 +7450,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> leaveRoom(
+  _i14.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -7430,12 +7465,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i14.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -7451,12 +7486,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i13.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i13.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i14.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i14.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i13.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i14.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -7478,8 +7513,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_68(
+        returnValue: _i14.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_69(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7495,8 +7530,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_68(
+        returnValueForMissingStub: _i14.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_69(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7512,10 +7547,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomEventsResponse>);
+      ) as _i14.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i13.Future<void> setReadMarker(
+  _i14.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -7531,12 +7566,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> postReceipt(
+  _i14.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -7552,12 +7587,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEvent(
+  _i14.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -7573,12 +7608,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> reportRoom(
+  _i14.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -7590,12 +7625,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> reportEvent(
+  _i14.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -7613,12 +7648,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> sendMessage(
+  _i14.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -7634,7 +7669,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7647,7 +7682,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i18.dummyValue<String>(
+            _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7659,23 +7694,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i14.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i13.Future<List<_i4.MatrixEvent>>);
+            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i14.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i14.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -7692,13 +7727,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<String> setRoomStateWithKey(
+  _i14.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -7714,7 +7749,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7727,7 +7762,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i18.dummyValue<String>(
+            _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7739,10 +7774,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> unban(
+  _i14.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7756,12 +7791,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> upgradeRoom(
+  _i14.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -7775,7 +7810,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7787,7 +7822,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i18.dummyValue<String>(
+            _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7798,10 +7833,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.SearchResults> search(
+  _i14.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -7811,7 +7846,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_69(
+        returnValue: _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_70(
           this,
           Invocation.method(
             #search,
@@ -7820,7 +7855,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_69(
+            _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_70(
           this,
           Invocation.method(
             #search,
@@ -7828,10 +7863,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i13.Future<_i4.SearchResults>);
+      ) as _i14.Future<_i4.SearchResults>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> sync({
+  _i14.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -7852,7 +7887,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
           this,
           Invocation.method(
             #sync,
@@ -7868,7 +7903,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
           this,
           Invocation.method(
             #sync,
@@ -7883,22 +7918,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i14.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i13.Future<List<_i4.Location>>);
+            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i14.Future<List<_i4.Location>>);
 
   @override
-  _i13.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i14.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -7908,21 +7943,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i13.Future<List<_i4.Location>>);
+            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i14.Future<List<_i4.Location>>);
 
   @override
-  _i13.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i14.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_70(
+        returnValue: _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_71(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -7930,45 +7965,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_70(
+            _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_71(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i13.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i14.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i13.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i14.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -7979,13 +8014,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getAccountData(
+  _i14.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -7998,13 +8033,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> setAccountData(
+  _i14.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -8018,12 +8053,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> defineFilter(
+  _i14.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -8035,7 +8070,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8046,7 +8081,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i18.dummyValue<String>(
+            _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8056,10 +8091,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.Filter> getFilter(
+  _i14.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -8071,7 +8106,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i13.Future<_i4.Filter>.value(_FakeFilter_10(
+        returnValue: _i14.Future<_i4.Filter>.value(_FakeFilter_11(
           this,
           Invocation.method(
             #getFilter,
@@ -8081,7 +8116,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.Filter>.value(_FakeFilter_10(
+        returnValueForMissingStub: _i14.Future<_i4.Filter>.value(_FakeFilter_11(
           this,
           Invocation.method(
             #getFilter,
@@ -8091,10 +8126,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.Filter>);
+      ) as _i14.Future<_i4.Filter>);
 
   @override
-  _i13.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i14.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8107,7 +8142,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_71(
+            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_72(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8118,7 +8153,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_71(
+            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_72(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8128,10 +8163,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.OpenIdCredentials>);
+      ) as _i14.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i13.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i14.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8146,13 +8181,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> setAccountDataPerRoom(
+  _i14.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8168,12 +8203,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i14.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8185,12 +8220,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i13.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i13.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i13.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i14.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i14.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i14.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i13.Future<void> deleteRoomTag(
+  _i14.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8204,12 +8239,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setRoomTag(
+  _i14.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8225,12 +8260,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i14.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8240,8 +8275,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i13.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_72(
+        returnValue: _i14.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_73(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8250,8 +8285,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_72(
+            _i14.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_73(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8259,10 +8294,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i13.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i14.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> reportUser(
+  _i14.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8275,40 +8310,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i14.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i13.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_73(
+        returnValue: _i14.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_74(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_73(
+        returnValueForMissingStub: _i14.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_74(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.CreateContentResponse>);
+      ) as _i14.Future<_i4.CreateContentResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> uploadContentToMXC(
+  _i14.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i23.Uint8List? body, {
+    _i24.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8326,16 +8361,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [CallService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCallService extends _i1.Mock implements _i24.CallService {
+class MockCallService extends _i1.Mock implements _i25.CallService {
   @override
   _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -8357,36 +8392,36 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       ) as bool);
 
   @override
-  _i25.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
+  _i26.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
         Invocation.getter(#httpPostForTest),
         returnValue: (
-          _i12.Client httpClient,
+          _i13.Client httpClient,
           Uri url, {
           Object? body,
           Map<String, String>? headers,
         }) =>
-            _i13.Future<_i12.Response>.value(_FakeResponse_74(
+            _i14.Future<_i13.Response>.value(_FakeResponse_75(
           this,
           Invocation.getter(#httpPostForTest),
         )),
         returnValueForMissingStub: (
-          _i12.Client httpClient,
+          _i13.Client httpClient,
           Uri url, {
           Object? body,
           Map<String, String>? headers,
         }) =>
-            _i13.Future<_i12.Response>.value(_FakeResponse_74(
+            _i14.Future<_i13.Response>.value(_FakeResponse_75(
           this,
           Invocation.getter(#httpPostForTest),
         )),
-      ) as _i25.HttpPostFunction);
+      ) as _i26.HttpPostFunction);
 
   @override
-  List<_i26.RemoteParticipant> get participants => (super.noSuchMethod(
+  List<_i27.RemoteParticipant> get participants => (super.noSuchMethod(
         Invocation.getter(#participants),
-        returnValue: <_i26.RemoteParticipant>[],
-        returnValueForMissingStub: <_i26.RemoteParticipant>[],
-      ) as List<_i26.RemoteParticipant>);
+        returnValue: <_i27.RemoteParticipant>[],
+        returnValueForMissingStub: <_i27.RemoteParticipant>[],
+      ) as List<_i27.RemoteParticipant>);
 
   @override
   bool get isMicEnabled => (super.noSuchMethod(
@@ -8417,14 +8452,14 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       ) as bool);
 
   @override
-  List<_i26.Participant<_i26.TrackPublication<_i26.Track>>>
+  List<_i27.Participant<_i27.TrackPublication<_i27.Track>>>
       get activeSpeakers => (super.noSuchMethod(
             Invocation.getter(#activeSpeakers),
-            returnValue: <_i26
-                .Participant<_i26.TrackPublication<_i26.Track>>>[],
-            returnValueForMissingStub: <_i26
-                .Participant<_i26.TrackPublication<_i26.Track>>>[],
-          ) as List<_i26.Participant<_i26.TrackPublication<_i26.Track>>>);
+            returnValue: <_i27
+                .Participant<_i27.TrackPublication<_i27.Track>>>[],
+            returnValueForMissingStub: <_i27
+                .Participant<_i27.TrackPublication<_i27.Track>>>[],
+          ) as List<_i27.Participant<_i27.TrackPublication<_i27.Track>>>);
 
   @override
   bool get isCallingAvailable => (super.noSuchMethod(
@@ -8434,11 +8469,11 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       ) as bool);
 
   @override
-  List<_i27.CallParticipant> get allParticipants => (super.noSuchMethod(
+  List<_i28.CallParticipant> get allParticipants => (super.noSuchMethod(
         Invocation.getter(#allParticipants),
-        returnValue: <_i27.CallParticipant>[],
-        returnValueForMissingStub: <_i27.CallParticipant>[],
-      ) as List<_i27.CallParticipant>);
+        returnValue: <_i28.CallParticipant>[],
+        returnValueForMissingStub: <_i28.CallParticipant>[],
+      ) as List<_i28.CallParticipant>);
 
   @override
   bool get isSpeakerOn => (super.noSuchMethod(
@@ -8448,29 +8483,29 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       ) as bool);
 
   @override
-  _i13.Stream<_i28.IncomingCallInfo> get incomingCallStream =>
+  _i14.Stream<_i29.IncomingCallInfo> get incomingCallStream =>
       (super.noSuchMethod(
         Invocation.getter(#incomingCallStream),
-        returnValue: _i13.Stream<_i28.IncomingCallInfo>.empty(),
-        returnValueForMissingStub: _i13.Stream<_i28.IncomingCallInfo>.empty(),
-      ) as _i13.Stream<_i28.IncomingCallInfo>);
+        returnValue: _i14.Stream<_i29.IncomingCallInfo>.empty(),
+        returnValueForMissingStub: _i14.Stream<_i29.IncomingCallInfo>.empty(),
+      ) as _i14.Stream<_i29.IncomingCallInfo>);
 
   @override
-  _i13.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
+  _i14.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
         Invocation.getter(#nativeAcceptedCallStream),
-        returnValue: _i13.Stream<String>.empty(),
-        returnValueForMissingStub: _i13.Stream<String>.empty(),
-      ) as _i13.Stream<String>);
+        returnValue: _i14.Stream<String>.empty(),
+        returnValueForMissingStub: _i14.Stream<String>.empty(),
+      ) as _i14.Stream<String>);
 
   @override
-  _i29.KoheraCallState get callState => (super.noSuchMethod(
+  _i30.KoheraCallState get callState => (super.noSuchMethod(
         Invocation.getter(#callState),
-        returnValue: _i29.KoheraCallState.idle,
-        returnValueForMissingStub: _i29.KoheraCallState.idle,
-      ) as _i29.KoheraCallState);
+        returnValue: _i30.KoheraCallState.idle,
+        returnValueForMissingStub: _i30.KoheraCallState.idle,
+      ) as _i30.KoheraCallState);
 
   @override
-  set preferencesService(_i16.PreferencesService? prefs) => super.noSuchMethod(
+  set preferencesService(_i17.PreferencesService? prefs) => super.noSuchMethod(
         Invocation.setter(
           #preferencesService,
           prefs,
@@ -8479,7 +8514,7 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  set ringtoneService(_i30.RingtoneService? service) => super.noSuchMethod(
+  set ringtoneService(_i31.RingtoneService? service) => super.noSuchMethod(
         Invocation.setter(
           #ringtoneService,
           service,
@@ -8488,7 +8523,7 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  set roomFactoryForTest(_i25.LiveKitRoomFactory? factory) =>
+  set roomFactoryForTest(_i26.LiveKitRoomFactory? factory) =>
       super.noSuchMethod(
         Invocation.setter(
           #roomFactoryForTest,
@@ -8498,7 +8533,7 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  set httpPostForTest(_i25.HttpPostFunction? fn) => super.noSuchMethod(
+  set httpPostForTest(_i26.HttpPostFunction? fn) => super.noSuchMethod(
         Invocation.setter(
           #httpPostForTest,
           fn,
@@ -8532,27 +8567,27 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  _i13.Future<void> toggleMicrophone() => (super.noSuchMethod(
+  _i14.Future<void> toggleMicrophone() => (super.noSuchMethod(
         Invocation.method(
           #toggleMicrophone,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> toggleCamera() => (super.noSuchMethod(
+  _i14.Future<void> toggleCamera() => (super.noSuchMethod(
         Invocation.method(
           #toggleCamera,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> toggleScreenShare({
+  _i14.Future<void> toggleScreenShare({
     String? sourceId,
     bool? captureScreenAudio = false,
   }) =>
@@ -8565,39 +8600,39 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
             #captureScreenAudio: captureScreenAudio,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> toggleScreenAudio() => (super.noSuchMethod(
+  _i14.Future<void> toggleScreenAudio() => (super.noSuchMethod(
         Invocation.method(
           #toggleScreenAudio,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setOutputVolume(double? volume) => (super.noSuchMethod(
+  _i14.Future<void> setOutputVolume(double? volume) => (super.noSuchMethod(
         Invocation.method(
           #setOutputVolume,
           [volume],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> toggleSpeaker() => (super.noSuchMethod(
+  _i14.Future<void> toggleSpeaker() => (super.noSuchMethod(
         Invocation.method(
           #toggleSpeaker,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void setVoipPushHandlesCallKit(bool? value) => super.noSuchMethod(
@@ -8627,7 +8662,7 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8655,36 +8690,36 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  _i13.Future<void> joinCall(String? roomId) => (super.noSuchMethod(
+  _i14.Future<void> joinCall(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #joinCall,
           [roomId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> leaveCall() => (super.noSuchMethod(
+  _i14.Future<void> leaveCall() => (super.noSuchMethod(
         Invocation.method(
           #leaveCall,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> acceptCall({bool? withVideo = false}) =>
+  _i14.Future<void> acceptCall({bool? withVideo = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #acceptCall,
           [],
           {#withVideo: withVideo},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void declineCall() => super.noSuchMethod(
@@ -8706,9 +8741,9 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  _i13.Future<void> initiateCall(
+  _i14.Future<void> initiateCall(
     String? roomId, {
-    _i28.CallType? type = _i28.CallType.voice,
+    _i29.CallType? type = _i29.CallType.voice,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8716,9 +8751,9 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
           [roomId],
           {#type: type},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   bool roomHasActiveCall(String? roomId) => (super.noSuchMethod(
@@ -8811,7 +8846,7 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8820,7 +8855,7 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8829,17 +8864,17 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8850,7 +8885,7 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8887,26 +8922,26 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> didPushRouteInformation(
-          _i21.RouteInformation? routeInformation) =>
+  _i14.Future<bool> didPushRouteInformation(
+          _i22.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -8936,7 +8971,7 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8945,7 +8980,7 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8954,16 +8989,16 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  _i13.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i14.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i13.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+            _i14.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i13.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
-      ) as _i13.Future<_i19.AppExitResponse>);
+            _i14.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i14.Future<_i20.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8988,32 +9023,32 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockNotificationService extends _i1.Mock
-    implements _i31.NotificationService {
+    implements _i32.NotificationService {
   @override
-  _i15.MatrixService get matrixService => (super.noSuchMethod(
+  _i16.MatrixService get matrixService => (super.noSuchMethod(
         Invocation.getter(#matrixService),
-        returnValue: _FakeMatrixService_75(
+        returnValue: _FakeMatrixService_76(
           this,
           Invocation.getter(#matrixService),
         ),
-        returnValueForMissingStub: _FakeMatrixService_75(
+        returnValueForMissingStub: _FakeMatrixService_76(
           this,
           Invocation.getter(#matrixService),
         ),
-      ) as _i15.MatrixService);
+      ) as _i16.MatrixService);
 
   @override
-  _i16.PreferencesService get preferencesService => (super.noSuchMethod(
+  _i17.PreferencesService get preferencesService => (super.noSuchMethod(
         Invocation.getter(#preferencesService),
-        returnValue: _FakePreferencesService_76(
+        returnValue: _FakePreferencesService_77(
           this,
           Invocation.getter(#preferencesService),
         ),
-        returnValueForMissingStub: _FakePreferencesService_76(
+        returnValueForMissingStub: _FakePreferencesService_77(
           this,
           Invocation.getter(#preferencesService),
         ),
-      ) as _i16.PreferencesService);
+      ) as _i17.PreferencesService);
 
   @override
   bool get isAppResumed => (super.noSuchMethod(
@@ -9032,14 +9067,14 @@ class MockNotificationService extends _i1.Mock
       );
 
   @override
-  _i13.Future<void> init() => (super.noSuchMethod(
+  _i14.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void startListening() => super.noSuchMethod(
@@ -9060,7 +9095,7 @@ class MockNotificationService extends _i1.Mock
       );
 
   @override
-  _i13.Future<String?> downloadAvatarToTemp(
+  _i14.Future<String?> downloadAvatarToTemp(
     _i4.Client? client,
     Uri? avatarUrl,
     String? userId,
@@ -9074,9 +9109,9 @@ class MockNotificationService extends _i1.Mock
             userId,
           ],
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
   void navigateToRoom(String? roomId) => super.noSuchMethod(
@@ -9088,7 +9123,7 @@ class MockNotificationService extends _i1.Mock
       );
 
   @override
-  _i13.Future<void> showPushNotification({
+  _i14.Future<void> showPushNotification({
     required String? roomId,
     required String? title,
     required String? body,
@@ -9105,29 +9140,29 @@ class MockNotificationService extends _i1.Mock
             #senderName: senderName,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> cancelForRoom(String? roomId) => (super.noSuchMethod(
+  _i14.Future<void> cancelForRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #cancelForRoom,
           [roomId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> cancelAll() => (super.noSuchMethod(
+  _i14.Future<void> cancelAll() => (super.noSuchMethod(
         Invocation.method(
           #cancelAll,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -9146,11 +9181,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -9180,11 +9215,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_77(
+        returnValue: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_77(
+        returnValueForMissingStub: _FakeRoomSummary_78(
           this,
           Invocation.getter(#summary),
         ),
@@ -9214,11 +9249,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i13.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i14.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i13.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i13.Completer<dynamic>>[],
-      ) as List<_i13.Completer<dynamic>>);
+        returnValue: <_i14.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i14.Completer<dynamic>>[],
+      ) as List<_i14.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -9237,51 +9272,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i11.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i12.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_15<String>(
+        returnValue: _FakeCachedStreamController_16<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i11.CachedStreamController<String> get onSessionKeyReceived =>
+  _i12.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_15<String>(
+        returnValue: _FakeCachedStreamController_16<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -9297,11 +9332,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -9310,11 +9345,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -9357,11 +9392,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -9370,11 +9405,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_16(
+        returnValue: _FakeDateTime_17(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_16(
+        returnValueForMissingStub: _FakeDateTime_17(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -9404,11 +9439,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_78(
+        returnValue: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_78(
+        returnValueForMissingStub: _FakeLatestReceiptState_79(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -9429,22 +9464,29 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i13.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i14.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
         Invocation.getter(#isFavourite),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
@@ -9620,18 +9662,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i32.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i33.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i32.SpaceParent>[],
-        returnValueForMissingStub: <_i32.SpaceParent>[],
-      ) as List<_i32.SpaceParent>);
+        returnValue: <_i33.SpaceParent>[],
+        returnValueForMissingStub: <_i33.SpaceParent>[],
+      ) as List<_i33.SpaceParent>);
 
   @override
-  List<_i32.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i33.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i32.SpaceChild>[],
-        returnValueForMissingStub: <_i32.SpaceChild>[],
-      ) as List<_i32.SpaceChild>);
+        returnValue: <_i33.SpaceChild>[],
+        returnValueForMissingStub: <_i33.SpaceChild>[],
+      ) as List<_i33.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -9744,14 +9786,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i13.Future<void> postLoad() => (super.noSuchMethod(
+  _i14.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -9779,15 +9821,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i13.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i14.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i13.Future<List<_i4.User>>);
+            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i14.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -9798,14 +9840,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9815,18 +9857,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i13.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i14.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Event?> refreshLastEvent(
+  _i14.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9834,9 +9876,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -9848,12 +9890,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i13.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i14.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9861,22 +9903,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i18.dummyValue<String>(
+            _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i14.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9884,17 +9926,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i18.dummyValue<String>(
+            _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> addTag(
+  _i14.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -9904,27 +9946,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i14.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i14.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -9932,43 +9974,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i14.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i14.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i14.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
+        ),
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
+
+  @override
+  _i14.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9976,14 +10028,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i18.dummyValue<String>(
+            _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -9995,7 +10047,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i13.Future<String?> sendTextEvent(
+  _i14.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -10027,12 +10079,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendReaction(
+  _i14.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -10046,12 +10098,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendLocation(
+  _i14.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -10065,12 +10117,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendFileEvent(
+  _i14.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -10098,25 +10150,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i14.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i13.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i14.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i13.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i14.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i13.Future<_i4.EncryptionHealthState>);
+      ) as _i14.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i13.Future<String?> sendEvent(
+  _i14.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -10140,73 +10192,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i14.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> leave() => (super.noSuchMethod(
+  _i14.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> forget() => (super.noSuchMethod(
+  _i14.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> setPower(
+  _i14.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -10218,7 +10270,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -10229,7 +10281,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i18.dummyValue<String>(
+            _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -10239,10 +10291,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> invite(
+  _i14.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -10252,12 +10304,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<int> requestHistory({
+  _i14.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -10274,32 +10326,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<int>.value(0),
-        returnValueForMissingStub: _i13.Future<int>.value(0),
-      ) as _i13.Future<int>);
+        returnValue: _i14.Future<int>.value(0),
+        returnValueForMissingStub: _i14.Future<int>.value(0),
+      ) as _i14.Future<int>);
 
   @override
-  _i13.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i14.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setReadMarker(
+  _i14.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -10313,23 +10365,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i17.TimelineChunk?> getEventContext(String? eventId) =>
+  _i14.Future<_i18.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i13.Future<_i17.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i13.Future<_i17.TimelineChunk?>.value(),
-      ) as _i13.Future<_i17.TimelineChunk?>);
+        returnValue: _i14.Future<_i18.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i14.Future<_i18.TimelineChunk?>.value(),
+      ) as _i14.Future<_i18.TimelineChunk?>);
 
   @override
-  _i13.Future<void> postReceipt(
+  _i14.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -10339,12 +10391,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Timeline> getTimeline({
+  _i14.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -10367,7 +10419,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i13.Future<_i4.Timeline>.value(_FakeTimeline_79(
+        returnValue: _i14.Future<_i4.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -10384,7 +10436,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Timeline>.value(_FakeTimeline_79(
+            _i14.Future<_i4.Timeline>.value(_FakeTimeline_80(
           this,
           Invocation.method(
             #getTimeline,
@@ -10400,7 +10452,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Timeline>);
+      ) as _i14.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -10419,7 +10471,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i13.Future<List<_i4.User>> requestParticipants([
+  _i14.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -10437,10 +10489,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i13.Future<List<_i4.User>>);
+            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i14.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -10448,14 +10500,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -10471,14 +10523,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_80(
+        returnValue: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_80(
+        returnValueForMissingStub: _FakeUser_81(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -10488,7 +10540,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i13.Future<_i4.User?> requestUser(
+  _i14.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -10504,19 +10556,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i13.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.User?>.value(),
-      ) as _i13.Future<_i4.User?>);
+        returnValue: _i14.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.User?>.value(),
+      ) as _i14.Future<_i4.User?>);
 
   @override
-  _i13.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i14.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -10529,12 +10581,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i13.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i14.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i13.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10542,14 +10594,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i18.dummyValue<String>(
+            _i14.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -10572,14 +10624,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i13.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i14.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -10618,18 +10670,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i13.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i14.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEvent(
+  _i14.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -10643,12 +10695,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> setTyping(
+  _i14.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -10658,12 +10710,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setJoinRules(
+  _i14.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -10677,59 +10729,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i14.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setHistoryVisibility(
+  _i14.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i14.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i14.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i13.Future<List<_i4.DeviceKeys>>);
+            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i14.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i13.Future<void> requestSessionKey(
+  _i14.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -10741,12 +10793,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setSpaceChild(
+  _i14.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -10762,44 +10814,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i14.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i13.Future<Uri>.value(_FakeUri_29(
+        returnValue: _i14.Future<Uri>.value(_FakeUri_30(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_29(
+        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_30(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i13.Future<Uri>);
+      ) as _i14.Future<Uri>);
 
   @override
-  _i13.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i14.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<
+  _i14.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -10826,21 +10878,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i13.Future<
+        returnValue: _i14.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i13.Future<
+        returnValueForMissingStub: _i14.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i13.Future<
+      ) as _i14.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -10855,11 +10907,11 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
   @override
   _i4.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_81(
+        returnValue: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_81(
+        returnValueForMissingStub: _FakeRoom_82(
           this,
           Invocation.getter(#room),
         ),
@@ -10909,17 +10961,17 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       ) as bool);
 
   @override
-  _i17.TimelineChunk get chunk => (super.noSuchMethod(
+  _i18.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_82(
+        returnValue: _FakeTimelineChunk_83(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_82(
+        returnValueForMissingStub: _FakeTimelineChunk_83(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i17.TimelineChunk);
+      ) as _i18.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10936,7 +10988,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       ) as bool);
 
   @override
-  set timelineSub(_i13.StreamSubscription<_i4.Event>? value) =>
+  set timelineSub(_i14.StreamSubscription<_i4.Event>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #timelineSub,
@@ -10946,7 +10998,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  set historySub(_i13.StreamSubscription<_i4.Event>? value) =>
+  set historySub(_i14.StreamSubscription<_i4.Event>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #historySub,
@@ -10956,7 +11008,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  set roomSub(_i13.StreamSubscription<_i4.SyncUpdate>? value) =>
+  set roomSub(_i14.StreamSubscription<_i4.SyncUpdate>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #roomSub,
@@ -10966,7 +11018,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  set sessionIdReceivedSub(_i13.StreamSubscription<String>? value) =>
+  set sessionIdReceivedSub(_i14.StreamSubscription<String>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #sessionIdReceivedSub,
@@ -10976,7 +11028,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  set cancelSendEventSub(_i13.StreamSubscription<String>? value) =>
+  set cancelSendEventSub(_i14.StreamSubscription<String>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #cancelSendEventSub,
@@ -11022,7 +11074,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  set chunk(_i17.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i18.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,
@@ -11031,17 +11083,17 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  _i13.Future<_i4.Event?> getEventById(String? id) => (super.noSuchMethod(
+  _i14.Future<_i4.Event?> getEventById(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [id],
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
-  _i13.Future<void> requestHistory({
+  _i14.Future<void> requestHistory({
     int? historyCount = 30,
     _i4.StateFilter? filter,
   }) =>
@@ -11054,12 +11106,12 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> requestFuture({
+  _i14.Future<void> requestFuture({
     int? historyCount = 30,
     _i4.StateFilter? filter,
   }) =>
@@ -11072,12 +11124,12 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<int> getRoomEvents({
+  _i14.Future<int> getRoomEvents({
     int? historyCount = 30,
     dynamic direction = _i4.Direction.b,
     _i4.StateFilter? filter,
@@ -11092,9 +11144,9 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<int>.value(0),
-        returnValueForMissingStub: _i13.Future<int>.value(0),
-      ) as _i13.Future<int>);
+        returnValue: _i14.Future<int>.value(0),
+        returnValueForMissingStub: _i14.Future<int>.value(0),
+      ) as _i14.Future<int>);
 
   @override
   void cancelSubscriptions() => super.noSuchMethod(
@@ -11123,7 +11175,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  _i13.Future<void> setReadMarker({
+  _i14.Future<void> setReadMarker({
     String? eventId,
     bool? public,
   }) =>
@@ -11136,9 +11188,9 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #public: public,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void addAggregatedEvent(_i4.Event? event) => super.noSuchMethod(
@@ -11159,7 +11211,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  _i13.Stream<List<_i4.Event>> searchEvent({
+  _i14.Stream<List<_i4.Event>> searchEvent({
     String? searchTerm,
     int? requestHistoryCount = 100,
     int? maxHistoryRequests = 10,
@@ -11180,12 +11232,12 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #searchFunc: searchFunc,
           },
         ),
-        returnValue: _i13.Stream<List<_i4.Event>>.empty(),
-        returnValueForMissingStub: _i13.Stream<List<_i4.Event>>.empty(),
-      ) as _i13.Stream<List<_i4.Event>>);
+        returnValue: _i14.Stream<List<_i4.Event>>.empty(),
+        returnValueForMissingStub: _i14.Stream<List<_i4.Event>>.empty(),
+      ) as _i14.Stream<List<_i4.Event>>);
 
   @override
-  _i13.Stream<(List<_i4.Event>, String?)> startSearch({
+  _i14.Stream<(List<_i4.Event>, String?)> startSearch({
     String? searchTerm,
     int? requestHistoryCount = 100,
     int? maxHistoryRequests = 10,
@@ -11208,8 +11260,8 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #searchFunc: searchFunc,
           },
         ),
-        returnValue: _i13.Stream<(List<_i4.Event>, String?)>.empty(),
+        returnValue: _i14.Stream<(List<_i4.Event>, String?)>.empty(),
         returnValueForMissingStub:
-            _i13.Stream<(List<_i4.Event>, String?)>.empty(),
-      ) as _i13.Stream<(List<_i4.Event>, String?)>);
+            _i14.Stream<(List<_i4.Event>, String?)>.empty(),
+      ) as _i14.Stream<(List<_i4.Event>, String?)>);
 }

--- a/test/services/livekit_service_test.mocks.dart
+++ b/test/services/livekit_service_test.mocks.dart
@@ -7916,6 +7916,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -8422,6 +8429,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/services/matrix_service_test.mocks.dart
+++ b/test/services/matrix_service_test.mocks.dart
@@ -8115,6 +8115,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -8621,6 +8628,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/services/notification_service_test.mocks.dart
+++ b/test/services/notification_service_test.mocks.dart
@@ -3,46 +3,48 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i13;
-import 'dart:typed_data' as _i21;
-import 'dart:ui' as _i17;
+import 'dart:async' as _i14;
+import 'dart:typed_data' as _i22;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
 import 'package:flutter_local_notifications/src/flutter_local_notifications_plugin.dart'
-    as _i24;
-import 'package:flutter_local_notifications/src/initialization_settings.dart'
     as _i25;
-import 'package:flutter_local_notifications/src/notification_details.dart'
-    as _i27;
-import 'package:flutter_local_notifications/src/platform_specifics/android/schedule_mode.dart'
-    as _i29;
-import 'package:flutter_local_notifications/src/types.dart' as _i30;
-import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart'
+import 'package:flutter_local_notifications/src/initialization_settings.dart'
     as _i26;
-import 'package:http/http.dart' as _i12;
-import 'package:kohera/core/services/matrix_service.dart' as _i15;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
+import 'package:flutter_local_notifications/src/notification_details.dart'
+    as _i28;
+import 'package:flutter_local_notifications/src/platform_specifics/android/schedule_mode.dart'
+    as _i30;
+import 'package:flutter_local_notifications/src/types.dart' as _i31;
+import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart'
+    as _i27;
+import 'package:http/http.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i16;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i7;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i8;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i20;
+import 'package:matrix/encryption.dart' as _i21;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i14;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i23;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i11;
-import 'package:matrix/src/utils/space_child.dart' as _i22;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i15;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i12;
+import 'package:matrix/src/utils/space_child.dart' as _i23;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
-import 'package:timezone/timezone.dart' as _i28;
+import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:timezone/timezone.dart' as _i29;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -123,8 +125,9 @@ class _FakeSelectionService_5 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
-  _FakeSyncService_6(
+class _FakeSpaceAccessService_6 extends _i1.SmartFake
+    implements _i8.SpaceAccessService {
+  _FakeSpaceAccessService_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -133,8 +136,8 @@ class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
         );
 }
 
-class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
-  _FakeAuthService_7(
+class _FakeSyncService_7 extends _i1.SmartFake implements _i9.SyncService {
+  _FakeSyncService_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -143,8 +146,8 @@ class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
         );
 }
 
-class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
-  _FakeOutboxService_8(
+class _FakeAuthService_8 extends _i1.SmartFake implements _i10.AuthService {
+  _FakeAuthService_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -153,8 +156,8 @@ class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
         );
 }
 
-class _FakeDatabaseApi_9 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_9(
+class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
+  _FakeOutboxService_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -163,8 +166,8 @@ class _FakeDatabaseApi_9 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_10 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_10(
+class _FakeDatabaseApi_10 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -173,9 +176,19 @@ class _FakeFilter_10 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_11 extends _i1.SmartFake
+class _FakeFilter_11 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_11(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeNativeImplementations_12 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_11(
+  _FakeNativeImplementations_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -184,8 +197,8 @@ class _FakeNativeImplementations_11 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_12 extends _i1.SmartFake implements Duration {
-  _FakeDuration_12(
+class _FakeDuration_13 extends _i1.SmartFake implements Duration {
+  _FakeDuration_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -194,9 +207,9 @@ class _FakeDuration_12 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_13 extends _i1.SmartFake
+class _FakePushruleEvaluator_14 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_13(
+  _FakePushruleEvaluator_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -205,8 +218,8 @@ class _FakePushruleEvaluator_13 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_14 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_14(
+class _FakeProfile_15 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -215,9 +228,9 @@ class _FakeProfile_14 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeCachedStreamController_15<T> extends _i1.SmartFake
-    implements _i11.CachedStreamController<T> {
-  _FakeCachedStreamController_15(
+class _FakeCachedStreamController_16<T> extends _i1.SmartFake
+    implements _i12.CachedStreamController<T> {
+  _FakeCachedStreamController_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -226,8 +239,8 @@ class _FakeCachedStreamController_15<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_16 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_16(
+class _FakeDateTime_17 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -236,8 +249,8 @@ class _FakeDateTime_16 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_17 extends _i1.SmartFake implements _i12.Client {
-  _FakeClient_17(
+class _FakeClient_18 extends _i1.SmartFake implements _i13.Client {
+  _FakeClient_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -246,9 +259,9 @@ class _FakeClient_17 extends _i1.SmartFake implements _i12.Client {
         );
 }
 
-class _FakeDiscoveryInformation_18 extends _i1.SmartFake
+class _FakeDiscoveryInformation_19 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_18(
+  _FakeDiscoveryInformation_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -257,9 +270,9 @@ class _FakeDiscoveryInformation_18 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_19 extends _i1.SmartFake
+class _FakeGetVersionsResponse_20 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_19(
+  _FakeGetVersionsResponse_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -268,9 +281,9 @@ class _FakeGetVersionsResponse_19 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_20 extends _i1.SmartFake
+class _FakeRegisterResponse_21 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_20(
+  _FakeRegisterResponse_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -279,8 +292,8 @@ class _FakeRegisterResponse_20 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_21 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_21(
+class _FakeLoginResponse_22 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -289,9 +302,9 @@ class _FakeLoginResponse_21 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_22 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_23 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_22(
+  _FakeGetAuthMetadataResponse_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -300,8 +313,8 @@ class _FakeGetAuthMetadataResponse_22 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_23<T1> extends _i1.SmartFake implements _i13.Future<T1> {
-  _FakeFuture_23(
+class _FakeFuture_24<T1> extends _i1.SmartFake implements _i14.Future<T1> {
+  _FakeFuture_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -310,8 +323,8 @@ class _FakeFuture_23<T1> extends _i1.SmartFake implements _i13.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_24 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_24(
+class _FakeSyncUpdate_25 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -320,9 +333,9 @@ class _FakeSyncUpdate_24 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_25 extends _i1.SmartFake
+class _FakeCachedProfileInformation_26 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_25(
+  _FakeCachedProfileInformation_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -331,8 +344,8 @@ class _FakeCachedProfileInformation_25 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_26 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_26(
+class _FakeMediaConfig_27 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -341,8 +354,8 @@ class _FakeMediaConfig_26 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_27 extends _i1.SmartFake implements _i14.FileResponse {
-  _FakeFileResponse_27(
+class _FakeFileResponse_28 extends _i1.SmartFake implements _i15.FileResponse {
+  _FakeFileResponse_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -351,8 +364,8 @@ class _FakeFileResponse_27 extends _i1.SmartFake implements _i14.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_28 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_28(
+class _FakePreviewForUrl_29 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -361,8 +374,8 @@ class _FakePreviewForUrl_28 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeUri_29 extends _i1.SmartFake implements Uri {
-  _FakeUri_29(
+class _FakeUri_30 extends _i1.SmartFake implements Uri {
+  _FakeUri_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -371,9 +384,9 @@ class _FakeUri_29 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_30 extends _i1.SmartFake
+class _FakeCachedPresence_31 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_30(
+  _FakeCachedPresence_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -382,9 +395,9 @@ class _FakeCachedPresence_30 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_31 extends _i1.SmartFake
+class _FakeTurnServerCredentials_32 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_31(
+  _FakeTurnServerCredentials_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -393,9 +406,9 @@ class _FakeTurnServerCredentials_31 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_32 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_33 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_32(
+  _FakeRoomKeysUpdateResponse_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -404,8 +417,8 @@ class _FakeRoomKeysUpdateResponse_32 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_33 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_33(
+class _FakeKeyBackupData_34 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -414,9 +427,9 @@ class _FakeKeyBackupData_33 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_34 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_35 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_34(
+  _FakeGetWellknownSupportResponse_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -425,9 +438,9 @@ class _FakeGetWellknownSupportResponse_34 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_35 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_36 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_35(
+  _FakeGenerateLoginTokenResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -436,9 +449,9 @@ class _FakeGenerateLoginTokenResponse_35 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_36 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_37 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_36(
+  _FakeGetRoomSummaryResponse$3_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -447,9 +460,9 @@ class _FakeGetRoomSummaryResponse$3_36 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_37 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_38 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_37(
+  _FakeGetSpaceHierarchyResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -458,9 +471,9 @@ class _FakeGetSpaceHierarchyResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_38 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_39 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_38(
+  _FakeGetRelatingEventsResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -469,9 +482,9 @@ class _FakeGetRelatingEventsResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_39 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_40 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_39(
+  _FakeGetRelatingEventsWithRelTypeResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -480,9 +493,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -491,9 +504,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_41 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_42 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_41(
+  _FakeGetThreadRootsResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -502,9 +515,9 @@ class _FakeGetThreadRootsResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_42 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_43 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_42(
+  _FakeGetEventByTimestampResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -513,9 +526,9 @@ class _FakeGetEventByTimestampResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_43 extends _i1.SmartFake
+class _FakeRequestTokenResponse_44 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_43(
+  _FakeRequestTokenResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -524,9 +537,9 @@ class _FakeRequestTokenResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_44 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_45 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_44(
+  _FakeTokenOwnerInfo_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -535,8 +548,8 @@ class _FakeTokenOwnerInfo_44 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_45 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_45(
+class _FakeWhoIsInfo_46 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -545,8 +558,8 @@ class _FakeWhoIsInfo_45 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_46 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_46(
+class _FakeCapabilities_47 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -555,8 +568,8 @@ class _FakeCapabilities_46 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_47 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_47(
+class _FakeDevice_48 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -565,9 +578,9 @@ class _FakeDevice_47 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_48 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_49 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_48(
+  _FakeGetRoomIdByAliasResponse_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -576,9 +589,9 @@ class _FakeGetRoomIdByAliasResponse_48 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_49 extends _i1.SmartFake
+class _FakeGetEventsResponse_50 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_49(
+  _FakeGetEventsResponse_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -587,9 +600,9 @@ class _FakeGetEventsResponse_49 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_50 extends _i1.SmartFake
+class _FakePeekEventsResponse_51 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_50(
+  _FakePeekEventsResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -598,8 +611,8 @@ class _FakePeekEventsResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_51 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_51(
+class _FakeMatrixEvent_52 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -608,9 +621,9 @@ class _FakeMatrixEvent_51 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_52 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_53 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_52(
+  _FakeGetKeysChangesResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -619,9 +632,9 @@ class _FakeGetKeysChangesResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_53 extends _i1.SmartFake
+class _FakeClaimKeysResponse_54 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_53(
+  _FakeClaimKeysResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -630,9 +643,9 @@ class _FakeClaimKeysResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_54 extends _i1.SmartFake
+class _FakeQueryKeysResponse_55 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_54(
+  _FakeQueryKeysResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -641,9 +654,9 @@ class _FakeQueryKeysResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_55 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_56 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_55(
+  _FakeGetNotificationsResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -652,9 +665,9 @@ class _FakeGetNotificationsResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_56 extends _i1.SmartFake
+class _FakeGetPresenceResponse_57 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_56(
+  _FakeGetPresenceResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -663,9 +676,9 @@ class _FakeGetPresenceResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_57 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_58 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_57(
+  _FakeGetPublicRoomsResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -674,9 +687,9 @@ class _FakeGetPublicRoomsResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_58 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_59 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_58(
+  _FakeQueryPublicRoomsResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -685,8 +698,8 @@ class _FakeQueryPublicRoomsResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_59 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_59(
+class _FakePushRuleSet_60 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -695,9 +708,9 @@ class _FakePushRuleSet_59 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_60 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_61 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_60(
+  _FakeGetPushRulesGlobalResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -706,8 +719,8 @@ class _FakeGetPushRulesGlobalResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_61 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_61(
+class _FakePushRule_62 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -716,9 +729,9 @@ class _FakePushRule_61 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_62 extends _i1.SmartFake
+class _FakeRefreshResponse_63 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_62(
+  _FakeRefreshResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -727,8 +740,8 @@ class _FakeRefreshResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_63 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_63(
+class _FakeRoomKeys_64 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -737,8 +750,8 @@ class _FakeRoomKeys_63 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_64 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_64(
+class _FakeRoomKeyBackup_65 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -747,9 +760,9 @@ class _FakeRoomKeyBackup_64 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_65 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_66 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_65(
+  _FakeGetRoomKeysVersionCurrentResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -758,9 +771,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_66 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_67 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_66(
+  _FakeGetRoomKeysVersionResponse_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -769,8 +782,8 @@ class _FakeGetRoomKeysVersionResponse_66 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_67 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_67(
+class _FakeEventContext_68 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -779,9 +792,9 @@ class _FakeEventContext_67 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_68 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_69 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_68(
+  _FakeGetRoomEventsResponse_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -790,8 +803,8 @@ class _FakeGetRoomEventsResponse_68 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_69 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_69(
+class _FakeSearchResults_70 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -800,9 +813,9 @@ class _FakeSearchResults_69 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_70 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_71 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_70(
+  _FakeGetProtocolMetadataResponse$2_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -811,9 +824,9 @@ class _FakeGetProtocolMetadataResponse$2_70 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_71 extends _i1.SmartFake
+class _FakeOpenIdCredentials_72 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_71(
+  _FakeOpenIdCredentials_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -822,9 +835,9 @@ class _FakeOpenIdCredentials_71 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_72 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_73 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_72(
+  _FakeSearchUserDirectoryResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -833,9 +846,9 @@ class _FakeSearchUserDirectoryResponse_72 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_73 extends _i1.SmartFake
+class _FakeCreateContentResponse_74 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_73(
+  _FakeCreateContentResponse_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -844,8 +857,8 @@ class _FakeCreateContentResponse_73 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_74 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_74(
+class _FakeRoomSummary_75 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -854,9 +867,9 @@ class _FakeRoomSummary_74 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_75 extends _i1.SmartFake
+class _FakeLatestReceiptState_76 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_75(
+  _FakeLatestReceiptState_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -865,8 +878,8 @@ class _FakeLatestReceiptState_75 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_76 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_76(
+class _FakeTimeline_77 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -875,8 +888,8 @@ class _FakeTimeline_76 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_77 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_77(
+class _FakeUser_78 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -888,7 +901,7 @@ class _FakeUser_77 extends _i1.SmartFake implements _i4.User {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -918,11 +931,11 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -995,43 +1008,56 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as _i7.SelectionService);
 
   @override
-  _i8.SyncService get sync => (super.noSuchMethod(
+  _i8.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_6(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_6(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i8.SpaceAccessService);
+
+  @override
+  _i9.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_6(
+        returnValue: _FakeSyncService_7(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_6(
+        returnValueForMissingStub: _FakeSyncService_7(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i8.SyncService);
+      ) as _i9.SyncService);
 
   @override
-  _i9.AuthService get auth => (super.noSuchMethod(
+  _i10.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_7(
+        returnValue: _FakeAuthService_8(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_7(
+        returnValueForMissingStub: _FakeAuthService_8(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i9.AuthService);
+      ) as _i10.AuthService);
 
   @override
-  _i10.OutboxService get outbox => (super.noSuchMethod(
+  _i11.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_8(
+        returnValue: _FakeOutboxService_9(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_8(
+        returnValueForMissingStub: _FakeOutboxService_9(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i10.OutboxService);
+      ) as _i11.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1095,7 +1121,16 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set sync(_i8.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i8.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i9.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -1104,7 +1139,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set auth(_i9.AuthService? value) => super.noSuchMethod(
+  set auth(_i10.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -1113,7 +1148,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set outbox(_i10.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i11.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -1129,14 +1164,14 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as bool);
 
   @override
-  _i13.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1166,7 +1201,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1176,18 +1211,18 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<bool> login({
+  _i14.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1202,12 +1237,12 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> completeSsoLogin({
+  _i14.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1220,12 +1255,12 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> completeRegistration(
+  _i14.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1235,32 +1270,32 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1269,7 +1304,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1278,17 +1313,17 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1299,7 +1334,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1336,26 +1371,26 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+  _i14.Future<bool> didPushRouteInformation(
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1385,7 +1420,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1394,7 +1429,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1403,16 +1438,16 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i14.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i13.Future<_i17.AppExitResponse>);
+            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i14.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1440,23 +1475,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_9(
+        returnValue: _FakeDatabaseApi_10(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_9(
+        returnValueForMissingStub: _FakeDatabaseApi_10(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i20.KeyVerificationMethod> get verificationMethods =>
+  Set<_i21.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i20.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
-      ) as Set<_i20.KeyVerificationMethod>);
+        returnValue: <_i21.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i21.KeyVerificationMethod>{},
+      ) as Set<_i21.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1517,11 +1552,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_10(
+        returnValue: _FakeFilter_11(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_10(
+        returnValueForMissingStub: _FakeFilter_11(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -1530,11 +1565,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_11(
+        returnValue: _FakeNativeImplementations_12(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_11(
+        returnValueForMissingStub: _FakeNativeImplementations_12(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -1550,11 +1585,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_12(
+        returnValue: _FakeDuration_13(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_12(
+        returnValueForMissingStub: _FakeDuration_13(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -1563,11 +1598,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_12(
+        returnValue: _FakeDuration_13(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_12(
+        returnValueForMissingStub: _FakeDuration_13(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -1576,11 +1611,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1617,11 +1652,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1651,11 +1686,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1664,11 +1699,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1691,11 +1726,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_13(
+        returnValue: _FakePushruleEvaluator_14(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_13(
+        returnValueForMissingStub: _FakePushruleEvaluator_14(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -1716,332 +1751,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i13.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i14.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i11.CachedStreamController<String> get onUserProfileUpdate =>
+  _i12.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_15<String>(
+        returnValue: _FakeCachedStreamController_16<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i13.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i14.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i13.Future<List<_i4.Room>>);
+            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i14.Future<List<_i4.Room>>);
 
   @override
-  _i11.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i12.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_15<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_16<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.EventUpdate>(
+            _FakeCachedStreamController_16<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.EventUpdate>);
+      ) as _i12.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i12.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_15<_i4.Event>(
+        returnValue: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i12.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_15<_i4.Event>(
+        returnValue: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onNotification =>
+  _i12.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_15<_i4.Event>(
+        returnValue: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i12.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_15<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_16<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_16<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i12.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i11.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i12.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_15<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_16<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_15<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_16<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i11.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i12.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i11.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i12.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_15<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_16<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.LoginState>(
+            _FakeCachedStreamController_16<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i11.CachedStreamController<_i4.LoginState>);
+      ) as _i12.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i11.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i12.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_15<bool>(
+        returnValue: _FakeCachedStreamController_16<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i11.CachedStreamController<bool>);
+      ) as _i12.CachedStreamController<bool>);
 
   @override
-  _i11.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i12.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_15<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_16<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i11.CachedStreamController<_i4.SdkError>);
+      ) as _i12.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i11.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i12.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_15<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_16<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.SyncUpdate>(
+            _FakeCachedStreamController_16<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i11.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i12.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i12.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_15<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_16<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_16<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i11.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i12.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.Presence> get onPresence =>
+  _i12.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_15<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_16<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i11.CachedStreamController<_i4.Presence>);
+      ) as _i12.CachedStreamController<_i4.Presence>);
 
   @override
-  _i11.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i12.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_15<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_16<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.CachedPresence>(
+            _FakeCachedStreamController_16<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i11.CachedStreamController<_i4.CachedPresence>);
+      ) as _i12.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i11.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i12.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_15<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_16<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.BasicEvent>(
+            _FakeCachedStreamController_16<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i11.CachedStreamController<_i4.BasicEvent>);
+      ) as _i12.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i11.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
+  _i12.CachedStreamController<_i21.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_15<_i20.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_16<_i21.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i20.RoomKeyRequest>(
+            _FakeCachedStreamController_16<_i21.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i11.CachedStreamController<_i20.RoomKeyRequest>);
+      ) as _i12.CachedStreamController<_i21.RoomKeyRequest>);
 
   @override
-  _i11.CachedStreamController<_i20.KeyVerification>
+  _i12.CachedStreamController<_i21.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_15<_i20.KeyVerification>(
+            returnValue: _FakeCachedStreamController_16<_i21.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_15<_i20.KeyVerification>(
+                _FakeCachedStreamController_16<_i21.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i11.CachedStreamController<_i20.KeyVerification>);
+          ) as _i12.CachedStreamController<_i21.KeyVerification>);
 
   @override
-  _i11.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i12.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_15<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_16<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_15<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_16<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i11.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i12.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i12.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_15<_i4.Event>(
+        returnValue: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<String> get onCancelSendEvent =>
+  _i12.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_15<String>(
+        returnValue: _FakeCachedStreamController_16<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i11.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i12.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_15<
+            returnValue: _FakeCachedStreamController_16<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_15<
+            returnValueForMissingStub: _FakeCachedStreamController_16<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i11.CachedStreamController<
+          ) as _i12.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -2061,11 +2096,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_16(
+        returnValue: _FakeDateTime_17(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_16(
+        returnValueForMissingStub: _FakeDateTime_17(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2138,7 +2173,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i21.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2193,7 +2228,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i13.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i14.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2204,7 +2239,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i13.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i14.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -2315,7 +2350,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -2324,7 +2359,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -2333,7 +2368,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -2360,20 +2395,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Client get httpClient => (super.noSuchMethod(
+  _i13.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_17(
+        returnValue: _FakeClient_18(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_17(
+        returnValueForMissingStub: _FakeClient_18(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i12.Client);
+      ) as _i13.Client);
 
   @override
-  set httpClient(_i12.Client? value) => super.noSuchMethod(
+  set httpClient(_i13.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -2400,7 +2435,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<void> refreshAccessToken(
+  _i14.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2408,9 +2443,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -2428,14 +2463,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2472,33 +2507,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i13.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i14.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_18(
+        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_19(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_18(
+        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_19(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i13.Future<_i4.DiscoveryInformation>);
+      ) as _i14.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i13.Future<
+  _i14.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -2520,7 +2555,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i13.Future<
+        returnValue: _i14.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2528,7 +2563,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_19(
+          _FakeGetVersionsResponse_20(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2543,7 +2578,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i13.Future<
+        returnValueForMissingStub: _i14.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2551,7 +2586,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_19(
+          _FakeGetVersionsResponse_20(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2566,7 +2601,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i13.Future<
+      ) as _i14.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -2575,7 +2610,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i13.Future<_i4.DiscoveryInformation> getWellknown({
+  _i14.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2588,8 +2623,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_18(
+        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_19(
           this,
           Invocation.method(
             #getWellknown,
@@ -2600,8 +2635,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_18(
+        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_19(
           this,
           Invocation.method(
             #getWellknown,
@@ -2612,10 +2647,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.DiscoveryInformation>);
+      ) as _i14.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i13.Future<_i4.RegisterResponse> register({
+  _i14.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -2643,7 +2678,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_20(
+            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_21(
           this,
           Invocation.method(
             #register,
@@ -2662,7 +2697,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_20(
+            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_21(
           this,
           Invocation.method(
             #register,
@@ -2680,10 +2715,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RegisterResponse>);
+      ) as _i14.Future<_i4.RegisterResponse>);
 
   @override
-  _i13.Future<_i4.LoginResponse> login(
+  _i14.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -2713,7 +2748,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_21(
+        returnValue: _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_22(
           this,
           Invocation.method(
             #login,
@@ -2733,7 +2768,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_21(
+            _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_22(
           this,
           Invocation.method(
             #login,
@@ -2752,10 +2787,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.LoginResponse>);
+      ) as _i14.Future<_i4.LoginResponse>);
 
   @override
-  _i13.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i14.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2768,8 +2803,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_22(
+        returnValue: _i14.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_23(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2781,8 +2816,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_22(
+            _i14.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_23(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2793,74 +2828,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i14.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> logoutAll() => (super.noSuchMethod(
+  _i14.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<T> uiaRequestBackground<T>(
-          _i13.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i14.Future<T> uiaRequestBackground<T>(
+          _i14.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i13.Future<T>.value(v),
+              (T v) => _i14.Future<T>.value(v),
             ) ??
-            _FakeFuture_23<T>(
+            _FakeFuture_24<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i13.Future<T>.value(v),
+              (T v) => _i14.Future<T>.value(v),
             ) ??
-            _FakeFuture_23<T>(
+            _FakeFuture_24<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i13.Future<T>);
+      ) as _i14.Future<T>);
 
   @override
-  _i13.Future<String> startDirectChat(
+  _i14.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -2882,7 +2917,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2898,7 +2933,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2913,10 +2948,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<String> createGroupChat({
+  _i14.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -2947,7 +2982,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2968,7 +3003,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2988,10 +3023,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i14.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -3007,7 +3042,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3020,7 +3055,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3032,21 +3067,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i14.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<String> createSpace({
+  _i14.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -3071,7 +3106,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3089,7 +3124,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3106,10 +3141,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i14.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3117,7 +3152,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3126,7 +3161,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3134,10 +3169,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i13.Future<_i4.Profile> fetchOwnProfile({
+  _i14.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3150,7 +3185,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3162,7 +3197,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3173,10 +3208,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i13.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i14.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3190,8 +3225,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i13.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_25(
+        returnValue: _i14.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_26(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3203,8 +3238,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_25(
+            _i14.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_26(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3215,10 +3250,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.CachedProfileInformation>);
+      ) as _i14.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i13.Future<_i4.Profile> getProfileFromUserId(
+  _i14.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3236,7 +3271,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3250,7 +3285,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_14(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3263,7 +3298,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -3285,31 +3320,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i13.Future<List<_i4.Room>>);
+            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i14.Future<List<_i4.Room>>);
 
   @override
-  _i13.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i14.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i13.Future<List<_i4.ArchivedRoom>>);
+            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i14.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i13.Future<_i4.GetVersionsResponse> getVersions({
+  _i14.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3322,8 +3357,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_19(
+        returnValue: _i14.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_20(
           this,
           Invocation.method(
             #getVersions,
@@ -3334,8 +3369,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_19(
+        returnValueForMissingStub: _i14.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_20(
           this,
           Invocation.method(
             #getVersions,
@@ -3346,20 +3381,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetVersionsResponse>);
+      ) as _i14.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i13.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i14.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<_i4.MediaConfig> getConfig({
+  _i14.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3372,7 +3407,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
+        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
           this,
           Invocation.method(
             #getConfig,
@@ -3384,7 +3419,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
+            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
           this,
           Invocation.method(
             #getConfig,
@@ -3395,10 +3430,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.MediaConfig>);
+      ) as _i14.Future<_i4.MediaConfig>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContent(
+  _i14.Future<_i15.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -3418,7 +3453,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContent,
@@ -3434,7 +3469,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContent,
@@ -3449,10 +3484,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentOverrideName(
+  _i14.Future<_i15.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -3474,7 +3509,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3491,7 +3526,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3507,10 +3542,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentThumbnail(
+  _i14.Future<_i15.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -3538,7 +3573,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3558,7 +3593,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3577,10 +3612,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i14.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -3590,7 +3625,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
+        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3599,7 +3634,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
+            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3607,11 +3642,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i13.Future<_i4.PreviewForUrl>);
+      ) as _i14.Future<_i4.PreviewForUrl>);
 
   @override
-  _i13.Future<Uri> uploadContent(
-    _i21.Uint8List? file, {
+  _i14.Future<Uri> uploadContent(
+    _i22.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3624,7 +3659,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i13.Future<Uri>.value(_FakeUri_29(
+        returnValue: _i14.Future<Uri>.value(_FakeUri_30(
           this,
           Invocation.method(
             #uploadContent,
@@ -3635,7 +3670,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_29(
+        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_30(
           this,
           Invocation.method(
             #uploadContent,
@@ -3646,10 +3681,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<Uri>);
+      ) as _i14.Future<Uri>);
 
   @override
-  _i13.Future<void> setTyping(
+  _i14.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -3665,42 +3700,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> exportDump() => (super.noSuchMethod(
+  _i14.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i14.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i14.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Event?> getEventByPushNotification(
+  _i14.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -3716,12 +3751,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
-  _i13.Future<void> init({
+  _i14.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -3756,9 +3791,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -3770,40 +3805,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<void> clear() => (super.noSuchMethod(
+  _i14.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i14.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ensureNotSoftLoggedOut(
+  _i14.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleSync(
+  _i14.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -3813,9 +3848,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -3828,29 +3863,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i13.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i14.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i14.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDevice(
+  _i14.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -3864,12 +3899,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDevicesOfUserIds(
+  _i14.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -3885,12 +3920,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDeviceEncrypted(
+  _i14.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -3910,12 +3945,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDeviceEncryptedChunked(
+  _i14.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -3929,23 +3964,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i14.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> joinRoom(
+  _i14.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -3963,7 +3998,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3977,7 +4012,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3990,10 +4025,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> changePassword(
+  _i14.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -4009,22 +4044,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> clearCache() => (super.noSuchMethod(
+  _i14.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ignoreUser(
+  _i14.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4034,22 +4069,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i14.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i14.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4060,7 +4095,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_30(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_31(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4069,7 +4104,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_30(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_31(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4077,32 +4112,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i13.Future<_i4.CachedPresence>);
+      ) as _i14.Future<_i4.CachedPresence>);
 
   @override
-  _i13.Future<void> abortSync() => (super.noSuchMethod(
+  _i14.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i14.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEventWithMetadata(
+  _i14.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4122,14 +4157,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i12.BaseResponse? response,
-    _i21.Uint8List? body,
+    _i13.BaseResponse? response,
+    _i22.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4161,7 +4196,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i13.Future<Map<String, Object?>> request(
+  _i14.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -4182,13 +4217,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> postPusher(
+  _i14.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -4198,57 +4233,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i14.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i14.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i14.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i13.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_31(
+        returnValue: _i14.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_32(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_31(
+        returnValueForMissingStub: _i14.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_32(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.TurnServerCredentials>);
+      ) as _i14.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4262,8 +4297,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4275,8 +4310,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4287,10 +4322,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4306,8 +4341,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4320,8 +4355,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4333,10 +4368,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i14.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4350,7 +4385,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
+        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4362,7 +4397,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
+            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4373,17 +4408,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.KeyBackupData>);
+      ) as _i14.Future<_i4.KeyBackupData>);
 
   @override
-  _i13.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i14.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i13.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_34(
+        returnValue: _i14.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_35(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -4391,18 +4426,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_34(
+            _i14.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_35(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i14.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i13.Future<int> pingAppservice(
+  _i14.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -4412,12 +4447,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i13.Future<int>.value(0),
-        returnValueForMissingStub: _i13.Future<int>.value(0),
-      ) as _i13.Future<int>);
+        returnValue: _i14.Future<int>.value(0),
+        returnValueForMissingStub: _i14.Future<int>.value(0),
+      ) as _i14.Future<int>);
 
   @override
-  _i13.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i14.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4425,8 +4460,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_35(
+        returnValue: _i14.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_36(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4435,8 +4470,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_35(
+            _i14.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_36(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4444,15 +4479,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i13.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i14.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i13.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i14.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
+        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -4460,17 +4495,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_26(
+            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.MediaConfig>);
+      ) as _i14.Future<_i4.MediaConfig>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentAuthed(
+  _i14.Future<_i15.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -4484,7 +4519,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4496,7 +4531,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4507,10 +4542,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentOverrideNameAuthed(
+  _i14.Future<_i15.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4526,7 +4561,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4539,7 +4574,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4551,10 +4586,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i14.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -4564,7 +4599,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
+        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4573,7 +4608,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_28(
+            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4581,10 +4616,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i13.Future<_i4.PreviewForUrl>);
+      ) as _i14.Future<_i4.PreviewForUrl>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentThumbnailAuthed(
+  _i14.Future<_i15.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -4608,7 +4643,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4626,7 +4661,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_27(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4643,21 +4678,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<bool> registrationTokenValidity(String? token) =>
+  _i14.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i14.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -4667,8 +4702,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_36(
+        returnValue: _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_37(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4677,8 +4712,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_36(
+            _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_37(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4686,10 +4721,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i14.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i13.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i14.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -4707,8 +4742,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_37(
+        returnValue: _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_38(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4722,8 +4757,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_37(
+            _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_38(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4736,10 +4771,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i14.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i14.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -4763,8 +4798,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i13.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_38(
+        returnValue: _i14.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_39(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4782,8 +4817,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_38(
+            _i14.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_39(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4800,10 +4835,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i14.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -4831,8 +4866,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_39(
+                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_40(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4851,8 +4886,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_39(
+                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_40(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4870,10 +4905,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i14.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -4902,9 +4937,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i13.Future<
+            returnValue: _i14.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -4923,9 +4958,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i13.Future<
+            returnValueForMissingStub: _i14.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_40(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -4944,11 +4979,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i13
+          ) as _i14
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i13.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i14.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -4964,8 +4999,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i13.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_41(
+        returnValue: _i14.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_42(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -4978,8 +5013,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_41(
+            _i14.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_42(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -4991,10 +5026,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetThreadRootsResponse>);
+      ) as _i14.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i13.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i14.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -5008,8 +5043,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i13.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_42(
+        returnValue: _i14.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_43(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5021,8 +5056,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_42(
+            _i14.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_43(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5033,33 +5068,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i14.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i14.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i13.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i14.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i13.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i14.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i13.Future<Uri?>.value(),
-        returnValueForMissingStub: _i13.Future<Uri?>.value(),
-      ) as _i13.Future<Uri?>);
+        returnValue: _i14.Future<Uri?>.value(),
+        returnValueForMissingStub: _i14.Future<Uri?>.value(),
+      ) as _i14.Future<Uri?>);
 
   @override
-  _i13.Future<void> add3PID(
+  _i14.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -5073,12 +5108,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> bind3PID(
+  _i14.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5094,12 +5129,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i14.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5113,14 +5148,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5142,8 +5177,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5159,8 +5194,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5176,10 +5211,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5203,8 +5238,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5221,8 +5256,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5239,10 +5274,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i14.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5256,14 +5291,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i14.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -5278,14 +5313,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5307,8 +5342,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5324,8 +5359,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5341,10 +5376,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5368,8 +5403,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5386,8 +5421,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5404,16 +5439,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i14.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_44(
+            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_45(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -5421,22 +5456,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_44(
+            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_45(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.TokenOwnerInfo>);
+      ) as _i14.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i13.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i14.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_45(
+        returnValue: _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_46(
           this,
           Invocation.method(
             #getWhoIs,
@@ -5444,22 +5479,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_45(
+            _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_46(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i13.Future<_i4.WhoIsInfo>);
+      ) as _i14.Future<_i4.WhoIsInfo>);
 
   @override
-  _i13.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i14.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_46(
+        returnValue: _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_47(
           this,
           Invocation.method(
             #getCapabilities,
@@ -5467,17 +5502,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_46(
+            _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_47(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.Capabilities>);
+      ) as _i14.Future<_i4.Capabilities>);
 
   @override
-  _i13.Future<String> createRoom({
+  _i14.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -5510,7 +5545,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5532,7 +5567,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5553,10 +5588,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> deleteDevices(
+  _i14.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5566,22 +5601,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.Device>?>.value(),
-      ) as _i13.Future<List<_i4.Device>?>);
+        returnValue: _i14.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.Device>?>.value(),
+      ) as _i14.Future<List<_i4.Device>?>);
 
   @override
-  _i13.Future<void> deleteDevice(
+  _i14.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5591,34 +5626,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i14.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i13.Future<_i4.Device>.value(_FakeDevice_47(
+        returnValue: _i14.Future<_i4.Device>.value(_FakeDevice_48(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.Device>.value(_FakeDevice_47(
+        returnValueForMissingStub: _i14.Future<_i4.Device>.value(_FakeDevice_48(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i13.Future<_i4.Device>);
+      ) as _i14.Future<_i4.Device>);
 
   @override
-  _i13.Future<void> updateDevice(
+  _i14.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -5628,12 +5663,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i14.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -5648,24 +5683,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i14.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i13.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Visibility?>.value(),
-      ) as _i13.Future<_i4.Visibility?>);
+        returnValue: _i14.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Visibility?>.value(),
+      ) as _i14.Future<_i4.Visibility?>);
 
   @override
-  _i13.Future<void> setRoomVisibilityOnDirectory(
+  _i14.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -5675,30 +5710,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i14.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i14.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_48(
+        returnValue: _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_49(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -5706,18 +5741,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_48(
+            _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_49(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i14.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i13.Future<void> setRoomAlias(
+  _i14.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -5729,12 +5764,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetEventsResponse> getEvents({
+  _i14.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -5748,7 +5783,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_49(
+            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_50(
           this,
           Invocation.method(
             #getEvents,
@@ -5760,7 +5795,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_49(
+            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_50(
           this,
           Invocation.method(
             #getEvents,
@@ -5771,10 +5806,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetEventsResponse>);
+      ) as _i14.Future<_i4.GetEventsResponse>);
 
   @override
-  _i13.Future<_i4.PeekEventsResponse> peekEvents({
+  _i14.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -5789,8 +5824,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i13.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_50(
+        returnValue: _i14.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_51(
           this,
           Invocation.method(
             #peekEvents,
@@ -5802,8 +5837,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_50(
+        returnValueForMissingStub: _i14.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_51(
           this,
           Invocation.method(
             #peekEvents,
@@ -5815,16 +5850,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.PeekEventsResponse>);
+      ) as _i14.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i13.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i14.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
+        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
           this,
           Invocation.method(
             #getOneEvent,
@@ -5832,27 +5867,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
+            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i13.Future<_i4.MatrixEvent>);
+      ) as _i14.Future<_i4.MatrixEvent>);
 
   @override
-  _i13.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i14.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i13.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
-      ) as _i13.Future<List<String>>);
+        returnValue: _i14.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
+      ) as _i14.Future<List<String>>);
 
   @override
-  _i13.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i14.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -5864,8 +5899,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i13.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_52(
+        returnValue: _i14.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_53(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5876,8 +5911,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_52(
+            _i14.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_53(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5887,10 +5922,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.GetKeysChangesResponse>);
+      ) as _i14.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i13.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i14.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -5901,7 +5936,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_53(
+            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_54(
           this,
           Invocation.method(
             #claimKeys,
@@ -5910,7 +5945,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_53(
+            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_54(
           this,
           Invocation.method(
             #claimKeys,
@@ -5918,10 +5953,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i13.Future<_i4.ClaimKeysResponse>);
+      ) as _i14.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i13.Future<void> uploadCrossSigningKeys({
+  _i14.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -5938,12 +5973,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.QueryKeysResponse> queryKeys(
+  _i14.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -5954,7 +5989,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_54(
+            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_55(
           this,
           Invocation.method(
             #queryKeys,
@@ -5963,7 +5998,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_54(
+            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_55(
           this,
           Invocation.method(
             #queryKeys,
@@ -5971,10 +6006,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i13.Future<_i4.QueryKeysResponse>);
+      ) as _i14.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -5982,14 +6017,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i13.Future<
+            returnValue: _i14.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i13.Future<
+            returnValueForMissingStub: _i14.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i13.Future<Map<String, int>> uploadKeys({
+  _i14.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -6004,13 +6039,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i13.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i14.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i13.Future<Map<String, int>>);
+            _i14.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i14.Future<Map<String, int>>);
 
   @override
-  _i13.Future<String> knockRoom(
+  _i14.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -6024,7 +6059,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6036,7 +6071,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6047,20 +6082,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i14.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i13.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i14.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i14.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i13.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i14.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6075,8 +6110,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i13.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_55(
+        returnValue: _i14.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_56(
           this,
           Invocation.method(
             #getNotifications,
@@ -6089,8 +6124,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_55(
+            _i14.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_56(
           this,
           Invocation.method(
             #getNotifications,
@@ -6102,35 +6137,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetNotificationsResponse>);
+      ) as _i14.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i13.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i14.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i13.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_56(
+        returnValue: _i14.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_57(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_56(
+        returnValueForMissingStub: _i14.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_57(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i13.Future<_i4.GetPresenceResponse>);
+      ) as _i14.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i13.Future<void> setPresence(
+  _i14.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -6144,12 +6179,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, Object?>> deleteProfileField(
+  _i14.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6162,13 +6197,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getProfileField(
+  _i14.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6181,13 +6216,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<Map<String, Object?>> setProfileField(
+  _i14.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6202,13 +6237,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i14.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6223,8 +6258,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i13.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_57(
+        returnValue: _i14.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_58(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6237,8 +6272,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_57(
+            _i14.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_58(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6250,10 +6285,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i14.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i13.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i14.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -6274,8 +6309,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i13.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_58(
+        returnValue: _i14.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_59(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6291,8 +6326,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_58(
+            _i14.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_59(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6307,25 +6342,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i14.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i13.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.Pusher>?>.value(),
-      ) as _i13.Future<List<_i4.Pusher>?>);
+        returnValue: _i14.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.Pusher>?>.value(),
+      ) as _i14.Future<List<_i4.Pusher>?>);
 
   @override
-  _i13.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i14.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_59(
+        returnValue: _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_60(
           this,
           Invocation.method(
             #getPushRules,
@@ -6333,24 +6368,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_59(
+            _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_60(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.PushRuleSet>);
+      ) as _i14.Future<_i4.PushRuleSet>);
 
   @override
-  _i13.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i14.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_60(
+        returnValue: _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_61(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -6358,18 +6393,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_60(
+            _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_61(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i14.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i13.Future<void> deletePushRule(
+  _i14.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6381,12 +6416,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.PushRule> getPushRule(
+  _i14.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6398,7 +6433,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<_i4.PushRule>.value(_FakePushRule_61(
+        returnValue: _i14.Future<_i4.PushRule>.value(_FakePushRule_62(
           this,
           Invocation.method(
             #getPushRule,
@@ -6409,7 +6444,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PushRule>.value(_FakePushRule_61(
+            _i14.Future<_i4.PushRule>.value(_FakePushRule_62(
           this,
           Invocation.method(
             #getPushRule,
@@ -6419,10 +6454,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.PushRule>);
+      ) as _i14.Future<_i4.PushRule>);
 
   @override
-  _i13.Future<void> setPushRule(
+  _i14.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -6446,12 +6481,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<Object?>> getPushRuleActions(
+  _i14.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6463,13 +6498,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i14.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i13.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i13.Future<List<Object?>>);
+            _i14.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i14.Future<List<Object?>>);
 
   @override
-  _i13.Future<void> setPushRuleActions(
+  _i14.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -6483,12 +6518,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<bool> isPushRuleEnabled(
+  _i14.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6500,12 +6535,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> setPushRuleEnabled(
+  _i14.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -6519,19 +6554,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i14.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_62(
+            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_63(
           this,
           Invocation.method(
             #refresh,
@@ -6539,28 +6574,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_62(
+            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_63(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i13.Future<_i4.RefreshResponse>);
+      ) as _i14.Future<_i4.RefreshResponse>);
 
   @override
-  _i13.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i14.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i13.Future<bool?>.value(),
-        returnValueForMissingStub: _i13.Future<bool?>.value(),
-      ) as _i13.Future<bool?>);
+        returnValue: _i14.Future<bool?>.value(),
+        returnValueForMissingStub: _i14.Future<bool?>.value(),
+      ) as _i14.Future<bool?>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6582,8 +6617,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6599,8 +6634,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6616,10 +6651,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6643,8 +6678,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6661,8 +6696,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_43(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_44(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6679,17 +6714,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -6697,23 +6732,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i14.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_63(
+        returnValue: _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_64(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -6721,17 +6756,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_63(
+            _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_64(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeys>);
+      ) as _i14.Future<_i4.RoomKeys>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -6743,8 +6778,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6755,8 +6790,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6766,10 +6801,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6781,8 +6816,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6793,8 +6828,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6804,10 +6839,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6819,7 +6854,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_64(
+        returnValue: _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_65(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6830,7 +6865,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_64(
+            _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_65(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6840,10 +6875,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeyBackup>);
+      ) as _i14.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -6857,8 +6892,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6870,8 +6905,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6882,10 +6917,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6899,8 +6934,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -6912,8 +6947,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -6924,10 +6959,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i14.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6941,7 +6976,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
+        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -6953,7 +6988,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_33(
+            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -6964,10 +6999,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.KeyBackupData>);
+      ) as _i14.Future<_i4.KeyBackupData>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6983,8 +7018,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_32(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -6997,8 +7032,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_32(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_33(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7010,18 +7045,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_65(
+                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_66(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -7029,18 +7064,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_65(
+                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_66(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i13.Future<String> postRoomKeysVersion(
+  _i14.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -7052,7 +7087,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7063,7 +7098,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7073,29 +7108,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i14.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i14.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_66(
+        returnValue: _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_67(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7103,18 +7138,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_66(
+            _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_67(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i14.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i14.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -7129,24 +7164,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i14.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i13.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
-      ) as _i13.Future<List<String>>);
+        returnValue: _i14.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
+      ) as _i14.Future<List<String>>);
 
   @override
-  _i13.Future<void> ban(
+  _i14.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7160,12 +7195,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.EventContext> getEventContext(
+  _i14.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7183,7 +7218,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<_i4.EventContext>.value(_FakeEventContext_67(
+        returnValue: _i14.Future<_i4.EventContext>.value(_FakeEventContext_68(
           this,
           Invocation.method(
             #getEventContext,
@@ -7198,7 +7233,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.EventContext>.value(_FakeEventContext_67(
+            _i14.Future<_i4.EventContext>.value(_FakeEventContext_68(
           this,
           Invocation.method(
             #getEventContext,
@@ -7212,10 +7247,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.EventContext>);
+      ) as _i14.Future<_i4.EventContext>);
 
   @override
-  _i13.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i14.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7227,7 +7262,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
+        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7238,7 +7273,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_51(
+            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7248,20 +7283,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.MatrixEvent>);
+      ) as _i14.Future<_i4.MatrixEvent>);
 
   @override
-  _i13.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i14.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> inviteBy3PID(
+  _i14.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -7273,12 +7308,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> inviteUser(
+  _i14.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7292,12 +7327,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> joinRoomById(
+  _i14.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -7311,7 +7346,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7323,7 +7358,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7334,23 +7369,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i14.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i13.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i14.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i13.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i13.Future<Map<String, _i4.RoomMember>?>);
+            _i14.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i14.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i13.Future<void> kick(
+  _i14.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7364,12 +7399,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> leaveRoom(
+  _i14.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -7379,12 +7414,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i14.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -7400,12 +7435,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i13.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i13.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i14.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i14.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i13.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i14.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -7427,8 +7462,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_68(
+        returnValue: _i14.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_69(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7444,8 +7479,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_68(
+        returnValueForMissingStub: _i14.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_69(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7461,10 +7496,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomEventsResponse>);
+      ) as _i14.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i13.Future<void> setReadMarker(
+  _i14.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -7480,12 +7515,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> postReceipt(
+  _i14.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -7501,12 +7536,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEvent(
+  _i14.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -7522,12 +7557,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> reportRoom(
+  _i14.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -7539,12 +7574,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> reportEvent(
+  _i14.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -7562,12 +7597,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> sendMessage(
+  _i14.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -7583,7 +7618,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7596,7 +7631,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7608,23 +7643,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i14.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i13.Future<List<_i4.MatrixEvent>>);
+            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i14.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i14.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -7641,13 +7676,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<String> setRoomStateWithKey(
+  _i14.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -7663,7 +7698,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7676,7 +7711,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7688,10 +7723,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> unban(
+  _i14.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7705,12 +7740,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> upgradeRoom(
+  _i14.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -7724,7 +7759,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7736,7 +7771,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7747,10 +7782,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.SearchResults> search(
+  _i14.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -7760,7 +7795,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_69(
+        returnValue: _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_70(
           this,
           Invocation.method(
             #search,
@@ -7769,7 +7804,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_69(
+            _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_70(
           this,
           Invocation.method(
             #search,
@@ -7777,10 +7812,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i13.Future<_i4.SearchResults>);
+      ) as _i14.Future<_i4.SearchResults>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> sync({
+  _i14.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -7801,7 +7836,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
           this,
           Invocation.method(
             #sync,
@@ -7817,7 +7852,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
           this,
           Invocation.method(
             #sync,
@@ -7832,22 +7867,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i14.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i13.Future<List<_i4.Location>>);
+            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i14.Future<List<_i4.Location>>);
 
   @override
-  _i13.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i14.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -7857,21 +7892,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i13.Future<List<_i4.Location>>);
+            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i14.Future<List<_i4.Location>>);
 
   @override
-  _i13.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i14.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_70(
+        returnValue: _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_71(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -7879,45 +7914,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_70(
+            _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_71(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i13.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i14.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i13.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i14.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -7928,13 +7963,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getAccountData(
+  _i14.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -7947,13 +7982,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> setAccountData(
+  _i14.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -7967,12 +8002,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> defineFilter(
+  _i14.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -7984,7 +8019,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7995,7 +8030,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8005,10 +8040,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.Filter> getFilter(
+  _i14.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -8020,7 +8055,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i13.Future<_i4.Filter>.value(_FakeFilter_10(
+        returnValue: _i14.Future<_i4.Filter>.value(_FakeFilter_11(
           this,
           Invocation.method(
             #getFilter,
@@ -8030,7 +8065,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.Filter>.value(_FakeFilter_10(
+        returnValueForMissingStub: _i14.Future<_i4.Filter>.value(_FakeFilter_11(
           this,
           Invocation.method(
             #getFilter,
@@ -8040,10 +8075,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.Filter>);
+      ) as _i14.Future<_i4.Filter>);
 
   @override
-  _i13.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i14.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8056,7 +8091,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_71(
+            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_72(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8067,7 +8102,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_71(
+            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_72(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8077,10 +8112,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.OpenIdCredentials>);
+      ) as _i14.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i13.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i14.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8095,13 +8130,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> setAccountDataPerRoom(
+  _i14.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8117,12 +8152,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i14.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8134,12 +8169,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i13.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i13.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i13.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i14.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i14.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i14.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i13.Future<void> deleteRoomTag(
+  _i14.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8153,12 +8188,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setRoomTag(
+  _i14.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8174,12 +8209,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i14.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8189,8 +8224,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i13.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_72(
+        returnValue: _i14.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_73(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8199,8 +8234,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_72(
+            _i14.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_73(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8208,10 +8243,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i13.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i14.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> reportUser(
+  _i14.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8224,40 +8259,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i14.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i13.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_73(
+        returnValue: _i14.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_74(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_73(
+        returnValueForMissingStub: _i14.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_74(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.CreateContentResponse>);
+      ) as _i14.Future<_i4.CreateContentResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> uploadContentToMXC(
+  _i14.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i21.Uint8List? body, {
+    _i22.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8275,10 +8310,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [Room].
@@ -8288,11 +8323,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8322,11 +8357,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_74(
+        returnValue: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_74(
+        returnValueForMissingStub: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
@@ -8356,11 +8391,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i13.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i14.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i13.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i13.Completer<dynamic>>[],
-      ) as List<_i13.Completer<dynamic>>);
+        returnValue: <_i14.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i14.Completer<dynamic>>[],
+      ) as List<_i14.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -8379,51 +8414,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i11.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i12.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_15<String>(
+        returnValue: _FakeCachedStreamController_16<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i11.CachedStreamController<String> get onSessionKeyReceived =>
+  _i12.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_15<String>(
+        returnValue: _FakeCachedStreamController_16<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_15<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8439,11 +8474,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8452,11 +8487,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8499,11 +8534,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8512,11 +8547,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_16(
+        returnValue: _FakeDateTime_17(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_16(
+        returnValueForMissingStub: _FakeDateTime_17(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -8546,11 +8581,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_75(
+        returnValue: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_75(
+        returnValueForMissingStub: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8571,22 +8606,29 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i13.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i14.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
         Invocation.getter(#isFavourite),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
@@ -8762,18 +8804,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i22.SpaceParent>[],
-        returnValueForMissingStub: <_i22.SpaceParent>[],
-      ) as List<_i22.SpaceParent>);
+        returnValue: <_i23.SpaceParent>[],
+        returnValueForMissingStub: <_i23.SpaceParent>[],
+      ) as List<_i23.SpaceParent>);
 
   @override
-  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i22.SpaceChild>[],
-        returnValueForMissingStub: <_i22.SpaceChild>[],
-      ) as List<_i22.SpaceChild>);
+        returnValue: <_i23.SpaceChild>[],
+        returnValueForMissingStub: <_i23.SpaceChild>[],
+      ) as List<_i23.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -8886,14 +8928,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i13.Future<void> postLoad() => (super.noSuchMethod(
+  _i14.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -8921,15 +8963,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i13.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i14.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i13.Future<List<_i4.User>>);
+            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i14.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -8940,14 +8982,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8957,18 +8999,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i13.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i14.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Event?> refreshLastEvent(
+  _i14.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8976,9 +9018,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -8990,12 +9032,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i13.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i14.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9003,22 +9045,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i14.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9026,17 +9068,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> addTag(
+  _i14.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -9046,27 +9088,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i14.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i14.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -9074,43 +9116,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_24(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i14.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i14.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i14.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
+        ),
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
+
+  @override
+  _i14.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9118,14 +9170,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -9137,7 +9189,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i13.Future<String?> sendTextEvent(
+  _i14.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -9169,12 +9221,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendReaction(
+  _i14.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -9188,12 +9240,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendLocation(
+  _i14.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -9207,12 +9259,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendFileEvent(
+  _i14.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -9240,25 +9292,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i14.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i13.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i14.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i13.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i14.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i13.Future<_i4.EncryptionHealthState>);
+      ) as _i14.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i13.Future<String?> sendEvent(
+  _i14.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -9282,73 +9334,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i14.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> leave() => (super.noSuchMethod(
+  _i14.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> forget() => (super.noSuchMethod(
+  _i14.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> setPower(
+  _i14.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -9360,7 +9412,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9371,7 +9423,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9381,10 +9433,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> invite(
+  _i14.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -9394,12 +9446,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<int> requestHistory({
+  _i14.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -9416,32 +9468,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<int>.value(0),
-        returnValueForMissingStub: _i13.Future<int>.value(0),
-      ) as _i13.Future<int>);
+        returnValue: _i14.Future<int>.value(0),
+        returnValueForMissingStub: _i14.Future<int>.value(0),
+      ) as _i14.Future<int>);
 
   @override
-  _i13.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i14.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setReadMarker(
+  _i14.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -9455,23 +9507,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i23.TimelineChunk?> getEventContext(String? eventId) =>
+  _i14.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i13.Future<_i23.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i13.Future<_i23.TimelineChunk?>.value(),
-      ) as _i13.Future<_i23.TimelineChunk?>);
+        returnValue: _i14.Future<_i24.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i14.Future<_i24.TimelineChunk?>.value(),
+      ) as _i14.Future<_i24.TimelineChunk?>);
 
   @override
-  _i13.Future<void> postReceipt(
+  _i14.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -9481,12 +9533,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Timeline> getTimeline({
+  _i14.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -9509,7 +9561,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i13.Future<_i4.Timeline>.value(_FakeTimeline_76(
+        returnValue: _i14.Future<_i4.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -9526,7 +9578,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Timeline>.value(_FakeTimeline_76(
+            _i14.Future<_i4.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -9542,7 +9594,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Timeline>);
+      ) as _i14.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -9561,7 +9613,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i13.Future<List<_i4.User>> requestParticipants([
+  _i14.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -9579,10 +9631,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i13.Future<List<_i4.User>>);
+            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i14.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -9590,14 +9642,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9613,14 +9665,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9630,7 +9682,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i13.Future<_i4.User?> requestUser(
+  _i14.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -9646,19 +9698,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i13.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.User?>.value(),
-      ) as _i13.Future<_i4.User?>);
+        returnValue: _i14.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.User?>.value(),
+      ) as _i14.Future<_i4.User?>);
 
   @override
-  _i13.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i14.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -9671,12 +9723,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i13.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i14.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9684,14 +9736,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -9714,14 +9766,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i13.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i14.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -9760,18 +9812,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i13.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i14.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEvent(
+  _i14.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -9785,12 +9837,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> setTyping(
+  _i14.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -9800,12 +9852,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setJoinRules(
+  _i14.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -9819,59 +9871,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i14.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setHistoryVisibility(
+  _i14.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i14.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i14.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i13.Future<List<_i4.DeviceKeys>>);
+            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i14.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i13.Future<void> requestSessionKey(
+  _i14.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -9883,12 +9935,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setSpaceChild(
+  _i14.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -9904,44 +9956,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i14.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i13.Future<Uri>.value(_FakeUri_29(
+        returnValue: _i14.Future<Uri>.value(_FakeUri_30(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_29(
+        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_30(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i13.Future<Uri>);
+      ) as _i14.Future<Uri>);
 
   @override
-  _i13.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i14.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<
+  _i14.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -9968,21 +10020,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i13.Future<
+        returnValue: _i14.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i13.Future<
+        returnValueForMissingStub: _i14.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i13.Future<
+      ) as _i14.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -9994,13 +10046,13 @@ class MockRoom extends _i1.Mock implements _i4.Room {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockFlutterLocalNotificationsPlugin extends _i1.Mock
-    implements _i24.FlutterLocalNotificationsPlugin {
+    implements _i25.FlutterLocalNotificationsPlugin {
   @override
-  _i13.Future<bool?> initialize({
-    required _i25.InitializationSettings? settings,
-    _i26.DidReceiveNotificationResponseCallback?
+  _i14.Future<bool?> initialize({
+    required _i26.InitializationSettings? settings,
+    _i27.DidReceiveNotificationResponseCallback?
         onDidReceiveNotificationResponse,
-    _i26.DidReceiveBackgroundNotificationResponseCallback?
+    _i27.DidReceiveBackgroundNotificationResponseCallback?
         onDidReceiveBackgroundNotificationResponse,
   }) =>
       (super.noSuchMethod(
@@ -10014,29 +10066,29 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
                 onDidReceiveBackgroundNotificationResponse,
           },
         ),
-        returnValue: _i13.Future<bool?>.value(),
-        returnValueForMissingStub: _i13.Future<bool?>.value(),
-      ) as _i13.Future<bool?>);
+        returnValue: _i14.Future<bool?>.value(),
+        returnValueForMissingStub: _i14.Future<bool?>.value(),
+      ) as _i14.Future<bool?>);
 
   @override
-  _i13.Future<_i26.NotificationAppLaunchDetails?>
+  _i14.Future<_i27.NotificationAppLaunchDetails?>
       getNotificationAppLaunchDetails() => (super.noSuchMethod(
             Invocation.method(
               #getNotificationAppLaunchDetails,
               [],
             ),
             returnValue:
-                _i13.Future<_i26.NotificationAppLaunchDetails?>.value(),
+                _i14.Future<_i27.NotificationAppLaunchDetails?>.value(),
             returnValueForMissingStub:
-                _i13.Future<_i26.NotificationAppLaunchDetails?>.value(),
-          ) as _i13.Future<_i26.NotificationAppLaunchDetails?>);
+                _i14.Future<_i27.NotificationAppLaunchDetails?>.value(),
+          ) as _i14.Future<_i27.NotificationAppLaunchDetails?>);
 
   @override
-  _i13.Future<void> show({
+  _i14.Future<void> show({
     required int? id,
     String? title,
     String? body,
-    _i27.NotificationDetails? notificationDetails,
+    _i28.NotificationDetails? notificationDetails,
     String? payload,
   }) =>
       (super.noSuchMethod(
@@ -10051,12 +10103,12 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #payload: payload,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> cancel({
+  _i14.Future<void> cancel({
     required int? id,
     String? tag,
   }) =>
@@ -10069,40 +10121,40 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #tag: tag,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> cancelAll() => (super.noSuchMethod(
+  _i14.Future<void> cancelAll() => (super.noSuchMethod(
         Invocation.method(
           #cancelAll,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> cancelAllPendingNotifications() => (super.noSuchMethod(
+  _i14.Future<void> cancelAllPendingNotifications() => (super.noSuchMethod(
         Invocation.method(
           #cancelAllPendingNotifications,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> zonedSchedule({
+  _i14.Future<void> zonedSchedule({
     required int? id,
-    required _i28.TZDateTime? scheduledDate,
-    required _i27.NotificationDetails? notificationDetails,
-    required _i29.AndroidScheduleMode? androidScheduleMode,
+    required _i29.TZDateTime? scheduledDate,
+    required _i28.NotificationDetails? notificationDetails,
+    required _i30.AndroidScheduleMode? androidScheduleMode,
     String? title,
     String? body,
     String? payload,
-    _i30.DateTimeComponents? matchDateTimeComponents,
+    _i31.DateTimeComponents? matchDateTimeComponents,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -10119,16 +10171,16 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #matchDateTimeComponents: matchDateTimeComponents,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> periodicallyShow({
+  _i14.Future<void> periodicallyShow({
     required int? id,
-    required _i26.RepeatInterval? repeatInterval,
-    required _i27.NotificationDetails? notificationDetails,
-    required _i29.AndroidScheduleMode? androidScheduleMode,
+    required _i27.RepeatInterval? repeatInterval,
+    required _i28.NotificationDetails? notificationDetails,
+    required _i30.AndroidScheduleMode? androidScheduleMode,
     String? title,
     String? body,
     String? payload,
@@ -10147,19 +10199,19 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #payload: payload,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> periodicallyShowWithDuration({
+  _i14.Future<void> periodicallyShowWithDuration({
     required int? id,
     required Duration? repeatDurationInterval,
-    required _i27.NotificationDetails? notificationDetails,
+    required _i28.NotificationDetails? notificationDetails,
     String? title,
     String? body,
-    _i29.AndroidScheduleMode? androidScheduleMode =
-        _i29.AndroidScheduleMode.exact,
+    _i30.AndroidScheduleMode? androidScheduleMode =
+        _i30.AndroidScheduleMode.exact,
     String? payload,
   }) =>
       (super.noSuchMethod(
@@ -10176,36 +10228,36 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #payload: payload,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i26.PendingNotificationRequest>>
+  _i14.Future<List<_i27.PendingNotificationRequest>>
       pendingNotificationRequests() => (super.noSuchMethod(
             Invocation.method(
               #pendingNotificationRequests,
               [],
             ),
             returnValue:
-                _i13.Future<List<_i26.PendingNotificationRequest>>.value(
-                    <_i26.PendingNotificationRequest>[]),
+                _i14.Future<List<_i27.PendingNotificationRequest>>.value(
+                    <_i27.PendingNotificationRequest>[]),
             returnValueForMissingStub:
-                _i13.Future<List<_i26.PendingNotificationRequest>>.value(
-                    <_i26.PendingNotificationRequest>[]),
-          ) as _i13.Future<List<_i26.PendingNotificationRequest>>);
+                _i14.Future<List<_i27.PendingNotificationRequest>>.value(
+                    <_i27.PendingNotificationRequest>[]),
+          ) as _i14.Future<List<_i27.PendingNotificationRequest>>);
 
   @override
-  _i13.Future<List<_i26.ActiveNotification>> getActiveNotifications() =>
+  _i14.Future<List<_i27.ActiveNotification>> getActiveNotifications() =>
       (super.noSuchMethod(
         Invocation.method(
           #getActiveNotifications,
           [],
         ),
-        returnValue: _i13.Future<List<_i26.ActiveNotification>>.value(
-            <_i26.ActiveNotification>[]),
+        returnValue: _i14.Future<List<_i27.ActiveNotification>>.value(
+            <_i27.ActiveNotification>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i26.ActiveNotification>>.value(
-                <_i26.ActiveNotification>[]),
-      ) as _i13.Future<List<_i26.ActiveNotification>>);
+            _i14.Future<List<_i27.ActiveNotification>>.value(
+                <_i27.ActiveNotification>[]),
+      ) as _i14.Future<List<_i27.ActiveNotification>>);
 }

--- a/test/services/outbox_service_test.mocks.dart
+++ b/test/services/outbox_service_test.mocks.dart
@@ -7946,6 +7946,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -8452,6 +8459,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/services/room_list_search_controller_test.mocks.dart
+++ b/test/services/room_list_search_controller_test.mocks.dart
@@ -7926,6 +7926,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -8432,6 +8439,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/services/rtc_membership_service_test.mocks.dart
+++ b/test/services/rtc_membership_service_test.mocks.dart
@@ -7916,6 +7916,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -8422,6 +8429,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/services/space_reparent_controller_test.mocks.dart
+++ b/test/services/space_reparent_controller_test.mocks.dart
@@ -430,6 +430,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -936,6 +943,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/services/thread_summary_test.mocks.dart
+++ b/test/services/thread_summary_test.mocks.dart
@@ -1749,6 +1749,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -2255,6 +2262,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i6.Future<void>.value(),
         returnValueForMissingStub: _i6.Future<void>.value(),

--- a/test/services/typing_controller_test.mocks.dart
+++ b/test/services/typing_controller_test.mocks.dart
@@ -430,6 +430,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -936,6 +943,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/utils/known_contacts_test.mocks.dart
+++ b/test/utils/known_contacts_test.mocks.dart
@@ -7916,6 +7916,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -8422,6 +8429,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/utils/notification_filter_test.mocks.dart
+++ b/test/utils/notification_filter_test.mocks.dart
@@ -1084,6 +1084,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -1590,6 +1597,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/add_existing_rooms_dialog_test.mocks.dart
+++ b/test/widgets/add_existing_rooms_dialog_test.mocks.dart
@@ -3,34 +3,36 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i13;
-import 'dart:typed_data' as _i23;
-import 'dart:ui' as _i17;
+import 'dart:async' as _i14;
+import 'dart:typed_data' as _i24;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
-import 'package:http/http.dart' as _i12;
-import 'package:kohera/core/services/matrix_service.dart' as _i15;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
+import 'package:http/http.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i16;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i7;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i8;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i22;
+import 'package:matrix/encryption.dart' as _i23;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i14;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i11;
-import 'package:matrix/src/utils/space_child.dart' as _i20;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i15;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i12;
+import 'package:matrix/src/utils/space_child.dart' as _i21;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -111,8 +113,9 @@ class _FakeSelectionService_5 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
-  _FakeSyncService_6(
+class _FakeSpaceAccessService_6 extends _i1.SmartFake
+    implements _i8.SpaceAccessService {
+  _FakeSpaceAccessService_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -121,8 +124,8 @@ class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
         );
 }
 
-class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
-  _FakeAuthService_7(
+class _FakeSyncService_7 extends _i1.SmartFake implements _i9.SyncService {
+  _FakeSyncService_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -131,8 +134,8 @@ class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
         );
 }
 
-class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
-  _FakeOutboxService_8(
+class _FakeAuthService_8 extends _i1.SmartFake implements _i10.AuthService {
+  _FakeAuthService_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -141,8 +144,8 @@ class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
         );
 }
 
-class _FakeRoomSummary_9 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_9(
+class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
+  _FakeOutboxService_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -151,9 +154,8 @@ class _FakeRoomSummary_9 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_10<T> extends _i1.SmartFake
-    implements _i11.CachedStreamController<T> {
-  _FakeCachedStreamController_10(
+class _FakeRoomSummary_10 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -162,8 +164,9 @@ class _FakeCachedStreamController_10<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_11 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_11(
+class _FakeCachedStreamController_11<T> extends _i1.SmartFake
+    implements _i12.CachedStreamController<T> {
+  _FakeCachedStreamController_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -172,9 +175,19 @@ class _FakeDateTime_11 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_12 extends _i1.SmartFake
+class _FakeDateTime_12 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_12(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_13 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_12(
+  _FakeLatestReceiptState_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -183,8 +196,8 @@ class _FakeLatestReceiptState_12 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_13 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_13(
+class _FakeSyncUpdate_14 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -193,8 +206,8 @@ class _FakeSyncUpdate_13 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeTimeline_14 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_14(
+class _FakeTimeline_15 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -203,8 +216,8 @@ class _FakeTimeline_14 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_15 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_15(
+class _FakeUser_16 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -213,8 +226,8 @@ class _FakeUser_15 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeUri_16 extends _i1.SmartFake implements Uri {
-  _FakeUri_16(
+class _FakeUri_17 extends _i1.SmartFake implements Uri {
+  _FakeUri_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -223,8 +236,8 @@ class _FakeUri_16 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_17 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_17(
+class _FakeDatabaseApi_18 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -233,8 +246,8 @@ class _FakeDatabaseApi_17 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_18 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_18(
+class _FakeFilter_19 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -243,9 +256,9 @@ class _FakeFilter_18 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_19 extends _i1.SmartFake
+class _FakeNativeImplementations_20 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_19(
+  _FakeNativeImplementations_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -254,8 +267,8 @@ class _FakeNativeImplementations_19 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_20 extends _i1.SmartFake implements Duration {
-  _FakeDuration_20(
+class _FakeDuration_21 extends _i1.SmartFake implements Duration {
+  _FakeDuration_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -264,9 +277,9 @@ class _FakeDuration_20 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_21 extends _i1.SmartFake
+class _FakePushruleEvaluator_22 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_21(
+  _FakePushruleEvaluator_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -275,8 +288,8 @@ class _FakePushruleEvaluator_21 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_22 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_22(
+class _FakeProfile_23 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -285,8 +298,8 @@ class _FakeProfile_22 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeClient_23 extends _i1.SmartFake implements _i12.Client {
-  _FakeClient_23(
+class _FakeClient_24 extends _i1.SmartFake implements _i13.Client {
+  _FakeClient_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -295,9 +308,9 @@ class _FakeClient_23 extends _i1.SmartFake implements _i12.Client {
         );
 }
 
-class _FakeDiscoveryInformation_24 extends _i1.SmartFake
+class _FakeDiscoveryInformation_25 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_24(
+  _FakeDiscoveryInformation_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -306,9 +319,9 @@ class _FakeDiscoveryInformation_24 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_25 extends _i1.SmartFake
+class _FakeGetVersionsResponse_26 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_25(
+  _FakeGetVersionsResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -317,9 +330,9 @@ class _FakeGetVersionsResponse_25 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_26 extends _i1.SmartFake
+class _FakeRegisterResponse_27 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_26(
+  _FakeRegisterResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -328,8 +341,8 @@ class _FakeRegisterResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_27 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_27(
+class _FakeLoginResponse_28 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -338,9 +351,9 @@ class _FakeLoginResponse_27 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_28 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_29 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_28(
+  _FakeGetAuthMetadataResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -349,8 +362,8 @@ class _FakeGetAuthMetadataResponse_28 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_29<T1> extends _i1.SmartFake implements _i13.Future<T1> {
-  _FakeFuture_29(
+class _FakeFuture_30<T1> extends _i1.SmartFake implements _i14.Future<T1> {
+  _FakeFuture_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -359,9 +372,9 @@ class _FakeFuture_29<T1> extends _i1.SmartFake implements _i13.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_30 extends _i1.SmartFake
+class _FakeCachedProfileInformation_31 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_30(
+  _FakeCachedProfileInformation_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -370,8 +383,8 @@ class _FakeCachedProfileInformation_30 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_31 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_31(
+class _FakeMediaConfig_32 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -380,8 +393,8 @@ class _FakeMediaConfig_31 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_32 extends _i1.SmartFake implements _i14.FileResponse {
-  _FakeFileResponse_32(
+class _FakeFileResponse_33 extends _i1.SmartFake implements _i15.FileResponse {
+  _FakeFileResponse_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -390,8 +403,8 @@ class _FakeFileResponse_32 extends _i1.SmartFake implements _i14.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_33 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_33(
+class _FakePreviewForUrl_34 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -400,9 +413,9 @@ class _FakePreviewForUrl_33 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_34 extends _i1.SmartFake
+class _FakeCachedPresence_35 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_34(
+  _FakeCachedPresence_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -411,9 +424,9 @@ class _FakeCachedPresence_34 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_35 extends _i1.SmartFake
+class _FakeTurnServerCredentials_36 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_35(
+  _FakeTurnServerCredentials_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -422,9 +435,9 @@ class _FakeTurnServerCredentials_35 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_37 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_36(
+  _FakeRoomKeysUpdateResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -433,8 +446,8 @@ class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_37(
+class _FakeKeyBackupData_38 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -443,9 +456,9 @@ class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_39 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_38(
+  _FakeGetWellknownSupportResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -454,9 +467,9 @@ class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_40 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_39(
+  _FakeGenerateLoginTokenResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -465,9 +478,9 @@ class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_41 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_40(
+  _FakeGetRoomSummaryResponse$3_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -476,9 +489,9 @@ class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_42 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_41(
+  _FakeGetSpaceHierarchyResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -487,9 +500,9 @@ class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_43 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_42(
+  _FakeGetRelatingEventsResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -498,9 +511,9 @@ class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_44 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_43(
+  _FakeGetRelatingEventsWithRelTypeResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -509,9 +522,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -520,9 +533,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_46 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_45(
+  _FakeGetThreadRootsResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -531,9 +544,9 @@ class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_47 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_46(
+  _FakeGetEventByTimestampResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -542,9 +555,9 @@ class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_47 extends _i1.SmartFake
+class _FakeRequestTokenResponse_48 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_47(
+  _FakeRequestTokenResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -553,9 +566,9 @@ class _FakeRequestTokenResponse_47 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_49 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_48(
+  _FakeTokenOwnerInfo_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -564,8 +577,8 @@ class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_49(
+class _FakeWhoIsInfo_50 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -574,8 +587,8 @@ class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_50(
+class _FakeCapabilities_51 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -584,8 +597,8 @@ class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_51(
+class _FakeDevice_52 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -594,9 +607,9 @@ class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_53 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_52(
+  _FakeGetRoomIdByAliasResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -605,9 +618,9 @@ class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_53 extends _i1.SmartFake
+class _FakeGetEventsResponse_54 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_53(
+  _FakeGetEventsResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -616,9 +629,9 @@ class _FakeGetEventsResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_54 extends _i1.SmartFake
+class _FakePeekEventsResponse_55 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_54(
+  _FakePeekEventsResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -627,8 +640,8 @@ class _FakePeekEventsResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_55(
+class _FakeMatrixEvent_56 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -637,9 +650,9 @@ class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_57 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_56(
+  _FakeGetKeysChangesResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -648,9 +661,9 @@ class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_57 extends _i1.SmartFake
+class _FakeClaimKeysResponse_58 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_57(
+  _FakeClaimKeysResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -659,9 +672,9 @@ class _FakeClaimKeysResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_58 extends _i1.SmartFake
+class _FakeQueryKeysResponse_59 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_58(
+  _FakeQueryKeysResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -670,9 +683,9 @@ class _FakeQueryKeysResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_60 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_59(
+  _FakeGetNotificationsResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -681,9 +694,9 @@ class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_60 extends _i1.SmartFake
+class _FakeGetPresenceResponse_61 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_60(
+  _FakeGetPresenceResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -692,9 +705,9 @@ class _FakeGetPresenceResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_62 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_61(
+  _FakeGetPublicRoomsResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -703,9 +716,9 @@ class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_63 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_62(
+  _FakeQueryPublicRoomsResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -714,8 +727,8 @@ class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_63(
+class _FakePushRuleSet_64 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -724,9 +737,9 @@ class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_65 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_64(
+  _FakeGetPushRulesGlobalResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -735,8 +748,8 @@ class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_65(
+class _FakePushRule_66 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -745,9 +758,9 @@ class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_66 extends _i1.SmartFake
+class _FakeRefreshResponse_67 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_66(
+  _FakeRefreshResponse_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,8 +769,8 @@ class _FakeRefreshResponse_66 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_67(
+class _FakeRoomKeys_68 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -766,8 +779,8 @@ class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_68(
+class _FakeRoomKeyBackup_69 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -776,9 +789,9 @@ class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_70 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_69(
+  _FakeGetRoomKeysVersionCurrentResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -787,9 +800,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_71 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_70(
+  _FakeGetRoomKeysVersionResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,8 +811,8 @@ class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_71(
+class _FakeEventContext_72 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,9 +821,9 @@ class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_73 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_72(
+  _FakeGetRoomEventsResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -819,8 +832,8 @@ class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_73(
+class _FakeSearchResults_74 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,9 +842,9 @@ class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_75 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_74(
+  _FakeGetProtocolMetadataResponse$2_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -840,9 +853,9 @@ class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_75 extends _i1.SmartFake
+class _FakeOpenIdCredentials_76 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_75(
+  _FakeOpenIdCredentials_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -851,9 +864,9 @@ class _FakeOpenIdCredentials_75 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_77 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_76(
+  _FakeSearchUserDirectoryResponse_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -862,9 +875,9 @@ class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_77 extends _i1.SmartFake
+class _FakeCreateContentResponse_78 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_77(
+  _FakeCreateContentResponse_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -876,7 +889,7 @@ class _FakeCreateContentResponse_77 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -906,11 +919,11 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -983,43 +996,56 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as _i7.SelectionService);
 
   @override
-  _i8.SyncService get sync => (super.noSuchMethod(
+  _i8.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_6(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_6(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i8.SpaceAccessService);
+
+  @override
+  _i9.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_6(
+        returnValue: _FakeSyncService_7(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_6(
+        returnValueForMissingStub: _FakeSyncService_7(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i8.SyncService);
+      ) as _i9.SyncService);
 
   @override
-  _i9.AuthService get auth => (super.noSuchMethod(
+  _i10.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_7(
+        returnValue: _FakeAuthService_8(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_7(
+        returnValueForMissingStub: _FakeAuthService_8(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i9.AuthService);
+      ) as _i10.AuthService);
 
   @override
-  _i10.OutboxService get outbox => (super.noSuchMethod(
+  _i11.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_8(
+        returnValue: _FakeOutboxService_9(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_8(
+        returnValueForMissingStub: _FakeOutboxService_9(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i10.OutboxService);
+      ) as _i11.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1083,7 +1109,16 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set sync(_i8.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i8.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i9.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -1092,7 +1127,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set auth(_i9.AuthService? value) => super.noSuchMethod(
+  set auth(_i10.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -1101,7 +1136,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set outbox(_i10.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i11.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -1117,14 +1152,14 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as bool);
 
   @override
-  _i13.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1154,7 +1189,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1164,18 +1199,18 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<bool> login({
+  _i14.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1190,12 +1225,12 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> completeSsoLogin({
+  _i14.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1208,12 +1243,12 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> completeRegistration(
+  _i14.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1223,32 +1258,32 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1257,7 +1292,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1266,17 +1301,17 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1287,7 +1322,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1324,26 +1359,26 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+  _i14.Future<bool> didPushRouteInformation(
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1373,7 +1408,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1382,7 +1417,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1391,16 +1426,16 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i14.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i13.Future<_i17.AppExitResponse>);
+            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i14.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1428,11 +1463,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1462,11 +1497,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_9(
+        returnValue: _FakeRoomSummary_10(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_9(
+        returnValueForMissingStub: _FakeRoomSummary_10(
           this,
           Invocation.getter(#summary),
         ),
@@ -1496,11 +1531,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i13.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i14.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i13.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i13.Completer<dynamic>>[],
-      ) as List<_i13.Completer<dynamic>>);
+        returnValue: <_i14.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i14.Completer<dynamic>>[],
+      ) as List<_i14.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1519,51 +1554,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i11.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i12.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_10<String>(
+        returnValue: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i11.CachedStreamController<String> get onSessionKeyReceived =>
+  _i12.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_10<String>(
+        returnValue: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1579,11 +1614,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1592,11 +1627,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1639,11 +1674,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1652,11 +1687,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_11(
+        returnValue: _FakeDateTime_12(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_11(
+        returnValueForMissingStub: _FakeDateTime_12(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -1686,11 +1721,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_12(
+        returnValue: _FakeLatestReceiptState_13(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_12(
+        returnValueForMissingStub: _FakeLatestReceiptState_13(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -1711,22 +1746,29 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i13.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i14.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
         Invocation.getter(#isFavourite),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
@@ -1902,18 +1944,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i20.SpaceParent>[],
-        returnValueForMissingStub: <_i20.SpaceParent>[],
-      ) as List<_i20.SpaceParent>);
+        returnValue: <_i21.SpaceParent>[],
+        returnValueForMissingStub: <_i21.SpaceParent>[],
+      ) as List<_i21.SpaceParent>);
 
   @override
-  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i20.SpaceChild>[],
-        returnValueForMissingStub: <_i20.SpaceChild>[],
-      ) as List<_i20.SpaceChild>);
+        returnValue: <_i21.SpaceChild>[],
+        returnValueForMissingStub: <_i21.SpaceChild>[],
+      ) as List<_i21.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -2026,14 +2068,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i13.Future<void> postLoad() => (super.noSuchMethod(
+  _i14.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -2061,15 +2103,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i13.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i14.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i13.Future<List<_i4.User>>);
+            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i14.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -2080,14 +2122,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2097,18 +2139,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i13.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i14.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Event?> refreshLastEvent(
+  _i14.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2116,9 +2158,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -2130,12 +2172,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i13.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i14.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2143,22 +2185,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i14.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2166,17 +2208,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> addTag(
+  _i14.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2186,27 +2228,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i14.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i14.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2214,43 +2256,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i14.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i14.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i14.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
+        ),
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
+
+  @override
+  _i14.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2258,14 +2310,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2277,7 +2329,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i13.Future<String?> sendTextEvent(
+  _i14.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2309,12 +2361,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendReaction(
+  _i14.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2328,12 +2380,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendLocation(
+  _i14.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2347,12 +2399,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendFileEvent(
+  _i14.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2380,25 +2432,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i14.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i13.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i14.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i13.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i14.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i13.Future<_i4.EncryptionHealthState>);
+      ) as _i14.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i13.Future<String?> sendEvent(
+  _i14.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -2422,73 +2474,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i14.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> leave() => (super.noSuchMethod(
+  _i14.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> forget() => (super.noSuchMethod(
+  _i14.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> setPower(
+  _i14.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2500,7 +2552,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2511,7 +2563,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2521,10 +2573,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> invite(
+  _i14.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2534,12 +2586,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<int> requestHistory({
+  _i14.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -2556,32 +2608,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<int>.value(0),
-        returnValueForMissingStub: _i13.Future<int>.value(0),
-      ) as _i13.Future<int>);
+        returnValue: _i14.Future<int>.value(0),
+        returnValueForMissingStub: _i14.Future<int>.value(0),
+      ) as _i14.Future<int>);
 
   @override
-  _i13.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i14.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setReadMarker(
+  _i14.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2595,23 +2647,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
+  _i14.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i13.Future<_i21.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i13.Future<_i21.TimelineChunk?>.value(),
-      ) as _i13.Future<_i21.TimelineChunk?>);
+        returnValue: _i14.Future<_i22.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i14.Future<_i22.TimelineChunk?>.value(),
+      ) as _i14.Future<_i22.TimelineChunk?>);
 
   @override
-  _i13.Future<void> postReceipt(
+  _i14.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -2621,12 +2673,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Timeline> getTimeline({
+  _i14.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2649,7 +2701,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i13.Future<_i4.Timeline>.value(_FakeTimeline_14(
+        returnValue: _i14.Future<_i4.Timeline>.value(_FakeTimeline_15(
           this,
           Invocation.method(
             #getTimeline,
@@ -2666,7 +2718,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Timeline>.value(_FakeTimeline_14(
+            _i14.Future<_i4.Timeline>.value(_FakeTimeline_15(
           this,
           Invocation.method(
             #getTimeline,
@@ -2682,7 +2734,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Timeline>);
+      ) as _i14.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -2701,7 +2753,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i13.Future<List<_i4.User>> requestParticipants([
+  _i14.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -2719,10 +2771,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i13.Future<List<_i4.User>>);
+            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i14.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -2730,14 +2782,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_15(
+        returnValue: _FakeUser_16(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_15(
+        returnValueForMissingStub: _FakeUser_16(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -2753,14 +2805,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_15(
+        returnValue: _FakeUser_16(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_15(
+        returnValueForMissingStub: _FakeUser_16(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -2770,7 +2822,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i13.Future<_i4.User?> requestUser(
+  _i14.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2786,19 +2838,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i13.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.User?>.value(),
-      ) as _i13.Future<_i4.User?>);
+        returnValue: _i14.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.User?>.value(),
+      ) as _i14.Future<_i4.User?>);
 
   @override
-  _i13.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i14.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2811,12 +2863,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i13.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i14.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2824,14 +2876,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2854,14 +2906,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i13.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i14.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -2900,18 +2952,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i13.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i14.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEvent(
+  _i14.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -2925,12 +2977,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> setTyping(
+  _i14.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -2940,12 +2992,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setJoinRules(
+  _i14.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -2959,59 +3011,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i14.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setHistoryVisibility(
+  _i14.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i14.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i14.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i13.Future<List<_i4.DeviceKeys>>);
+            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i14.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i13.Future<void> requestSessionKey(
+  _i14.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -3023,12 +3075,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setSpaceChild(
+  _i14.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3044,44 +3096,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i14.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i13.Future<Uri>.value(_FakeUri_16(
+        returnValue: _i14.Future<Uri>.value(_FakeUri_17(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_16(
+        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_17(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i13.Future<Uri>);
+      ) as _i14.Future<Uri>);
 
   @override
-  _i13.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i14.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<
+  _i14.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -3108,21 +3160,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i13.Future<
+        returnValue: _i14.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i13.Future<
+        returnValueForMissingStub: _i14.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i13.Future<
+      ) as _i14.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -3137,23 +3189,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_17(
+        returnValue: _FakeDatabaseApi_18(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_17(
+        returnValueForMissingStub: _FakeDatabaseApi_18(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i22.KeyVerificationMethod> get verificationMethods =>
+  Set<_i23.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i22.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i22.KeyVerificationMethod>{},
-      ) as Set<_i22.KeyVerificationMethod>);
+        returnValue: <_i23.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i23.KeyVerificationMethod>{},
+      ) as Set<_i23.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3214,11 +3266,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_18(
+        returnValue: _FakeFilter_19(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_18(
+        returnValueForMissingStub: _FakeFilter_19(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -3227,11 +3279,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_19(
+        returnValue: _FakeNativeImplementations_20(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_19(
+        returnValueForMissingStub: _FakeNativeImplementations_20(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -3247,11 +3299,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_20(
+        returnValue: _FakeDuration_21(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_20(
+        returnValueForMissingStub: _FakeDuration_21(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3260,11 +3312,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_20(
+        returnValue: _FakeDuration_21(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_20(
+        returnValueForMissingStub: _FakeDuration_21(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3273,11 +3325,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -3314,11 +3366,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3348,11 +3400,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3361,11 +3413,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3388,11 +3440,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_21(
+        returnValue: _FakePushruleEvaluator_22(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_21(
+        returnValueForMissingStub: _FakePushruleEvaluator_22(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -3413,332 +3465,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i13.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i14.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i11.CachedStreamController<String> get onUserProfileUpdate =>
+  _i12.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_10<String>(
+        returnValue: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i13.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i14.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i13.Future<List<_i4.Room>>);
+            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i14.Future<List<_i4.Room>>);
 
   @override
-  _i11.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i12.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_10<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_11<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.EventUpdate>(
+            _FakeCachedStreamController_11<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.EventUpdate>);
+      ) as _i12.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i12.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_10<_i4.Event>(
+        returnValue: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i12.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_10<_i4.Event>(
+        returnValue: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onNotification =>
+  _i12.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_10<_i4.Event>(
+        returnValue: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i12.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_10<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_11<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_11<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i12.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i11.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i12.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_10<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_11<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_10<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_11<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i11.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i12.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i11.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i12.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_10<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_11<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.LoginState>(
+            _FakeCachedStreamController_11<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i11.CachedStreamController<_i4.LoginState>);
+      ) as _i12.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i11.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i12.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_10<bool>(
+        returnValue: _FakeCachedStreamController_11<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i11.CachedStreamController<bool>);
+      ) as _i12.CachedStreamController<bool>);
 
   @override
-  _i11.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i12.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_10<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_11<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i11.CachedStreamController<_i4.SdkError>);
+      ) as _i12.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i11.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i12.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_10<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_11<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.SyncUpdate>(
+            _FakeCachedStreamController_11<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i11.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i12.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i12.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_10<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_11<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_11<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i11.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i12.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.Presence> get onPresence =>
+  _i12.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_10<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_11<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i11.CachedStreamController<_i4.Presence>);
+      ) as _i12.CachedStreamController<_i4.Presence>);
 
   @override
-  _i11.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i12.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_10<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_11<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.CachedPresence>(
+            _FakeCachedStreamController_11<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i11.CachedStreamController<_i4.CachedPresence>);
+      ) as _i12.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i11.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i12.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_10<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_11<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.BasicEvent>(
+            _FakeCachedStreamController_11<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i11.CachedStreamController<_i4.BasicEvent>);
+      ) as _i12.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i11.CachedStreamController<_i22.RoomKeyRequest> get onRoomKeyRequest =>
+  _i12.CachedStreamController<_i23.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_10<_i22.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_11<_i23.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i22.RoomKeyRequest>(
+            _FakeCachedStreamController_11<_i23.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i11.CachedStreamController<_i22.RoomKeyRequest>);
+      ) as _i12.CachedStreamController<_i23.RoomKeyRequest>);
 
   @override
-  _i11.CachedStreamController<_i22.KeyVerification>
+  _i12.CachedStreamController<_i23.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_10<_i22.KeyVerification>(
+            returnValue: _FakeCachedStreamController_11<_i23.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_10<_i22.KeyVerification>(
+                _FakeCachedStreamController_11<_i23.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i11.CachedStreamController<_i22.KeyVerification>);
+          ) as _i12.CachedStreamController<_i23.KeyVerification>);
 
   @override
-  _i11.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i12.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_10<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_11<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_11<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i11.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i12.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i12.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_10<_i4.Event>(
+        returnValue: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<String> get onCancelSendEvent =>
+  _i12.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_10<String>(
+        returnValue: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i11.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i12.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_10<
+            returnValue: _FakeCachedStreamController_11<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_10<
+            returnValueForMissingStub: _FakeCachedStreamController_11<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i11.CachedStreamController<
+          ) as _i12.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -3758,11 +3810,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_11(
+        returnValue: _FakeDateTime_12(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_11(
+        returnValueForMissingStub: _FakeDateTime_12(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3835,7 +3887,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i22.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i23.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3890,7 +3942,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i13.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i14.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -3901,7 +3953,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i13.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i14.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -4012,7 +4064,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -4021,7 +4073,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -4030,7 +4082,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4057,20 +4109,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Client get httpClient => (super.noSuchMethod(
+  _i13.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_23(
+        returnValue: _FakeClient_24(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_23(
+        returnValueForMissingStub: _FakeClient_24(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i12.Client);
+      ) as _i13.Client);
 
   @override
-  set httpClient(_i12.Client? value) => super.noSuchMethod(
+  set httpClient(_i13.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4097,7 +4149,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<void> refreshAccessToken(
+  _i14.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4105,9 +4157,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4125,14 +4177,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4169,33 +4221,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i13.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i14.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i13.Future<_i4.DiscoveryInformation>);
+      ) as _i14.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i13.Future<
+  _i14.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -4217,7 +4269,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i13.Future<
+        returnValue: _i14.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4225,7 +4277,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_25(
+          _FakeGetVersionsResponse_26(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4240,7 +4292,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i13.Future<
+        returnValueForMissingStub: _i14.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4248,7 +4300,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_25(
+          _FakeGetVersionsResponse_26(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4263,7 +4315,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i13.Future<
+      ) as _i14.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -4272,7 +4324,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i13.Future<_i4.DiscoveryInformation> getWellknown({
+  _i14.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4285,8 +4337,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getWellknown,
@@ -4297,8 +4349,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getWellknown,
@@ -4309,10 +4361,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.DiscoveryInformation>);
+      ) as _i14.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i13.Future<_i4.RegisterResponse> register({
+  _i14.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -4340,7 +4392,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
+            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
           this,
           Invocation.method(
             #register,
@@ -4359,7 +4411,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
+            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
           this,
           Invocation.method(
             #register,
@@ -4377,10 +4429,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RegisterResponse>);
+      ) as _i14.Future<_i4.RegisterResponse>);
 
   @override
-  _i13.Future<_i4.LoginResponse> login(
+  _i14.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -4410,7 +4462,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
+        returnValue: _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
           this,
           Invocation.method(
             #login,
@@ -4430,7 +4482,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
+            _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
           this,
           Invocation.method(
             #login,
@@ -4449,10 +4501,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.LoginResponse>);
+      ) as _i14.Future<_i4.LoginResponse>);
 
   @override
-  _i13.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i14.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4465,8 +4517,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_28(
+        returnValue: _i14.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_29(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4478,8 +4530,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_28(
+            _i14.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_29(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4490,74 +4542,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i14.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> logoutAll() => (super.noSuchMethod(
+  _i14.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<T> uiaRequestBackground<T>(
-          _i13.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i14.Future<T> uiaRequestBackground<T>(
+          _i14.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i13.Future<T>.value(v),
+              (T v) => _i14.Future<T>.value(v),
             ) ??
-            _FakeFuture_29<T>(
+            _FakeFuture_30<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i13.Future<T>.value(v),
+              (T v) => _i14.Future<T>.value(v),
             ) ??
-            _FakeFuture_29<T>(
+            _FakeFuture_30<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i13.Future<T>);
+      ) as _i14.Future<T>);
 
   @override
-  _i13.Future<String> startDirectChat(
+  _i14.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -4579,7 +4631,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4595,7 +4647,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4610,10 +4662,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<String> createGroupChat({
+  _i14.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -4644,7 +4696,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4665,7 +4717,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4685,10 +4737,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i14.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4704,7 +4756,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4717,7 +4769,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4729,21 +4781,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i14.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<String> createSpace({
+  _i14.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -4768,7 +4820,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4786,7 +4838,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4803,10 +4855,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i14.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4814,7 +4866,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4823,7 +4875,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4831,10 +4883,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i13.Future<_i4.Profile> fetchOwnProfile({
+  _i14.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4847,7 +4899,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4859,7 +4911,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4870,10 +4922,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i13.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i14.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4887,8 +4939,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i13.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_30(
+        returnValue: _i14.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_31(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4900,8 +4952,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_30(
+            _i14.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_31(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4912,10 +4964,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.CachedProfileInformation>);
+      ) as _i14.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i13.Future<_i4.Profile> getProfileFromUserId(
+  _i14.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -4933,7 +4985,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4947,7 +4999,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4960,7 +5012,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -4982,31 +5034,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i13.Future<List<_i4.Room>>);
+            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i14.Future<List<_i4.Room>>);
 
   @override
-  _i13.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i14.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i13.Future<List<_i4.ArchivedRoom>>);
+            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i14.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i13.Future<_i4.GetVersionsResponse> getVersions({
+  _i14.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5019,8 +5071,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_25(
+        returnValue: _i14.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_26(
           this,
           Invocation.method(
             #getVersions,
@@ -5031,8 +5083,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_25(
+        returnValueForMissingStub: _i14.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_26(
           this,
           Invocation.method(
             #getVersions,
@@ -5043,20 +5095,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetVersionsResponse>);
+      ) as _i14.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i13.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i14.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<_i4.MediaConfig> getConfig({
+  _i14.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5069,7 +5121,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
+        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
           this,
           Invocation.method(
             #getConfig,
@@ -5081,7 +5133,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
+            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
           this,
           Invocation.method(
             #getConfig,
@@ -5092,10 +5144,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.MediaConfig>);
+      ) as _i14.Future<_i4.MediaConfig>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContent(
+  _i14.Future<_i15.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5115,7 +5167,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContent,
@@ -5131,7 +5183,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContent,
@@ -5146,10 +5198,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentOverrideName(
+  _i14.Future<_i15.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5171,7 +5223,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5188,7 +5240,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5204,10 +5256,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentThumbnail(
+  _i14.Future<_i15.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5235,7 +5287,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5255,7 +5307,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5274,10 +5326,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i14.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5287,7 +5339,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
+        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5296,7 +5348,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
+            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5304,11 +5356,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i13.Future<_i4.PreviewForUrl>);
+      ) as _i14.Future<_i4.PreviewForUrl>);
 
   @override
-  _i13.Future<Uri> uploadContent(
-    _i23.Uint8List? file, {
+  _i14.Future<Uri> uploadContent(
+    _i24.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5321,7 +5373,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i13.Future<Uri>.value(_FakeUri_16(
+        returnValue: _i14.Future<Uri>.value(_FakeUri_17(
           this,
           Invocation.method(
             #uploadContent,
@@ -5332,7 +5384,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_16(
+        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_17(
           this,
           Invocation.method(
             #uploadContent,
@@ -5343,10 +5395,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<Uri>);
+      ) as _i14.Future<Uri>);
 
   @override
-  _i13.Future<void> setTyping(
+  _i14.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5362,42 +5414,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> exportDump() => (super.noSuchMethod(
+  _i14.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i14.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i14.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Event?> getEventByPushNotification(
+  _i14.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -5413,12 +5465,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
-  _i13.Future<void> init({
+  _i14.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5453,9 +5505,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5467,40 +5519,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<void> clear() => (super.noSuchMethod(
+  _i14.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i14.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ensureNotSoftLoggedOut(
+  _i14.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleSync(
+  _i14.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -5510,9 +5562,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -5525,29 +5577,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i13.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i14.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i14.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDevice(
+  _i14.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5561,12 +5613,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDevicesOfUserIds(
+  _i14.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5582,12 +5634,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDeviceEncrypted(
+  _i14.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5607,12 +5659,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDeviceEncryptedChunked(
+  _i14.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -5626,23 +5678,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i14.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> joinRoom(
+  _i14.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -5660,7 +5712,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5674,7 +5726,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5687,10 +5739,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> changePassword(
+  _i14.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -5706,22 +5758,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> clearCache() => (super.noSuchMethod(
+  _i14.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ignoreUser(
+  _i14.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5731,22 +5783,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i14.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i14.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5757,7 +5809,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5766,7 +5818,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5774,32 +5826,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i13.Future<_i4.CachedPresence>);
+      ) as _i14.Future<_i4.CachedPresence>);
 
   @override
-  _i13.Future<void> abortSync() => (super.noSuchMethod(
+  _i14.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i14.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEventWithMetadata(
+  _i14.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5819,14 +5871,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i12.BaseResponse? response,
-    _i23.Uint8List? body,
+    _i13.BaseResponse? response,
+    _i24.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5858,7 +5910,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i13.Future<Map<String, Object?>> request(
+  _i14.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -5879,13 +5931,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> postPusher(
+  _i14.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -5895,57 +5947,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i14.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i14.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i14.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i13.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_35(
+        returnValue: _i14.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_36(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_35(
+        returnValueForMissingStub: _i14.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_36(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.TurnServerCredentials>);
+      ) as _i14.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5959,8 +6011,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5972,8 +6024,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5984,10 +6036,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6003,8 +6055,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6017,8 +6069,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6030,10 +6082,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i14.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6047,7 +6099,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6059,7 +6111,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6070,17 +6122,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.KeyBackupData>);
+      ) as _i14.Future<_i4.KeyBackupData>);
 
   @override
-  _i13.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i14.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i13.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_38(
+        returnValue: _i14.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_39(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6088,18 +6140,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_38(
+            _i14.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_39(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i14.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i13.Future<int> pingAppservice(
+  _i14.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6109,12 +6161,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i13.Future<int>.value(0),
-        returnValueForMissingStub: _i13.Future<int>.value(0),
-      ) as _i13.Future<int>);
+        returnValue: _i14.Future<int>.value(0),
+        returnValueForMissingStub: _i14.Future<int>.value(0),
+      ) as _i14.Future<int>);
 
   @override
-  _i13.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i14.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6122,8 +6174,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_39(
+        returnValue: _i14.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_40(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6132,8 +6184,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_39(
+            _i14.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_40(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6141,15 +6193,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i13.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i14.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i13.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i14.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
+        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6157,17 +6209,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
+            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.MediaConfig>);
+      ) as _i14.Future<_i4.MediaConfig>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentAuthed(
+  _i14.Future<_i15.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6181,7 +6233,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6193,7 +6245,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6204,10 +6256,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentOverrideNameAuthed(
+  _i14.Future<_i15.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6223,7 +6275,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6236,7 +6288,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6248,10 +6300,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i14.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6261,7 +6313,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
+        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6270,7 +6322,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
+            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6278,10 +6330,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i13.Future<_i4.PreviewForUrl>);
+      ) as _i14.Future<_i4.PreviewForUrl>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentThumbnailAuthed(
+  _i14.Future<_i15.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -6305,7 +6357,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6323,7 +6375,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6340,21 +6392,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<bool> registrationTokenValidity(String? token) =>
+  _i14.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i14.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6364,8 +6416,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_40(
+        returnValue: _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_41(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6374,8 +6426,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_40(
+            _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_41(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6383,10 +6435,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i14.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i13.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i14.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6404,8 +6456,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_41(
+        returnValue: _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_42(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6419,8 +6471,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_41(
+            _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_42(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6433,10 +6485,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i14.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i14.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -6460,8 +6512,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i13.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_42(
+        returnValue: _i14.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_43(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6479,8 +6531,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_42(
+            _i14.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_43(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6497,10 +6549,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i14.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6528,8 +6580,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_43(
+                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6548,8 +6600,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_43(
+                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6567,10 +6619,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i14.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6599,9 +6651,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i13.Future<
+            returnValue: _i14.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6620,9 +6672,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i13.Future<
+            returnValueForMissingStub: _i14.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6641,11 +6693,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i13
+          ) as _i14
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i13.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i14.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -6661,8 +6713,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i13.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_45(
+        returnValue: _i14.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_46(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6675,8 +6727,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_45(
+            _i14.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_46(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6688,10 +6740,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetThreadRootsResponse>);
+      ) as _i14.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i13.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i14.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -6705,8 +6757,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i13.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_46(
+        returnValue: _i14.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_47(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6718,8 +6770,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_46(
+            _i14.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_47(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6730,33 +6782,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i14.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i14.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i13.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i14.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i13.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i14.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i13.Future<Uri?>.value(),
-        returnValueForMissingStub: _i13.Future<Uri?>.value(),
-      ) as _i13.Future<Uri?>);
+        returnValue: _i14.Future<Uri?>.value(),
+        returnValueForMissingStub: _i14.Future<Uri?>.value(),
+      ) as _i14.Future<Uri?>);
 
   @override
-  _i13.Future<void> add3PID(
+  _i14.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -6770,12 +6822,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> bind3PID(
+  _i14.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6791,12 +6843,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i14.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6810,14 +6862,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6839,8 +6891,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6856,8 +6908,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6873,10 +6925,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6900,8 +6952,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6918,8 +6970,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6936,10 +6988,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i14.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6953,14 +7005,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i14.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -6975,14 +7027,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7004,8 +7056,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7021,8 +7073,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7038,10 +7090,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7065,8 +7117,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7083,8 +7135,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7101,16 +7153,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i14.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
+            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7118,22 +7170,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
+            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.TokenOwnerInfo>);
+      ) as _i14.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i13.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i14.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
+        returnValue: _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7141,22 +7193,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
+            _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i13.Future<_i4.WhoIsInfo>);
+      ) as _i14.Future<_i4.WhoIsInfo>);
 
   @override
-  _i13.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i14.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
+        returnValue: _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7164,17 +7216,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
+            _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.Capabilities>);
+      ) as _i14.Future<_i4.Capabilities>);
 
   @override
-  _i13.Future<String> createRoom({
+  _i14.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -7207,7 +7259,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7229,7 +7281,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7250,10 +7302,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> deleteDevices(
+  _i14.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7263,22 +7315,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.Device>?>.value(),
-      ) as _i13.Future<List<_i4.Device>?>);
+        returnValue: _i14.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.Device>?>.value(),
+      ) as _i14.Future<List<_i4.Device>?>);
 
   @override
-  _i13.Future<void> deleteDevice(
+  _i14.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7288,34 +7340,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i14.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i13.Future<_i4.Device>.value(_FakeDevice_51(
+        returnValue: _i14.Future<_i4.Device>.value(_FakeDevice_52(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.Device>.value(_FakeDevice_51(
+        returnValueForMissingStub: _i14.Future<_i4.Device>.value(_FakeDevice_52(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i13.Future<_i4.Device>);
+      ) as _i14.Future<_i4.Device>);
 
   @override
-  _i13.Future<void> updateDevice(
+  _i14.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7325,12 +7377,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i14.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -7345,24 +7397,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i14.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i13.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Visibility?>.value(),
-      ) as _i13.Future<_i4.Visibility?>);
+        returnValue: _i14.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Visibility?>.value(),
+      ) as _i14.Future<_i4.Visibility?>);
 
   @override
-  _i13.Future<void> setRoomVisibilityOnDirectory(
+  _i14.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -7372,30 +7424,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i14.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i14.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_52(
+        returnValue: _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_53(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7403,18 +7455,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_52(
+            _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_53(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i14.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i13.Future<void> setRoomAlias(
+  _i14.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7426,12 +7478,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetEventsResponse> getEvents({
+  _i14.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7445,7 +7497,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
+            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
           this,
           Invocation.method(
             #getEvents,
@@ -7457,7 +7509,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
+            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
           this,
           Invocation.method(
             #getEvents,
@@ -7468,10 +7520,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetEventsResponse>);
+      ) as _i14.Future<_i4.GetEventsResponse>);
 
   @override
-  _i13.Future<_i4.PeekEventsResponse> peekEvents({
+  _i14.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7486,8 +7538,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i13.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_54(
+        returnValue: _i14.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_55(
           this,
           Invocation.method(
             #peekEvents,
@@ -7499,8 +7551,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_54(
+        returnValueForMissingStub: _i14.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_55(
           this,
           Invocation.method(
             #peekEvents,
@@ -7512,16 +7564,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.PeekEventsResponse>);
+      ) as _i14.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i13.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i14.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7529,27 +7581,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i13.Future<_i4.MatrixEvent>);
+      ) as _i14.Future<_i4.MatrixEvent>);
 
   @override
-  _i13.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i14.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i13.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
-      ) as _i13.Future<List<String>>);
+        returnValue: _i14.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
+      ) as _i14.Future<List<String>>);
 
   @override
-  _i13.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i14.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7561,8 +7613,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i13.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_56(
+        returnValue: _i14.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_57(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7573,8 +7625,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_56(
+            _i14.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_57(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7584,10 +7636,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.GetKeysChangesResponse>);
+      ) as _i14.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i13.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i14.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7598,7 +7650,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
+            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
           this,
           Invocation.method(
             #claimKeys,
@@ -7607,7 +7659,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
+            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
           this,
           Invocation.method(
             #claimKeys,
@@ -7615,10 +7667,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i13.Future<_i4.ClaimKeysResponse>);
+      ) as _i14.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i13.Future<void> uploadCrossSigningKeys({
+  _i14.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -7635,12 +7687,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.QueryKeysResponse> queryKeys(
+  _i14.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7651,7 +7703,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
+            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
           this,
           Invocation.method(
             #queryKeys,
@@ -7660,7 +7712,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
+            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
           this,
           Invocation.method(
             #queryKeys,
@@ -7668,10 +7720,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i13.Future<_i4.QueryKeysResponse>);
+      ) as _i14.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7679,14 +7731,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i13.Future<
+            returnValue: _i14.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i13.Future<
+            returnValueForMissingStub: _i14.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i13.Future<Map<String, int>> uploadKeys({
+  _i14.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -7701,13 +7753,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i13.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i14.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i13.Future<Map<String, int>>);
+            _i14.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i14.Future<Map<String, int>>);
 
   @override
-  _i13.Future<String> knockRoom(
+  _i14.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7721,7 +7773,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7733,7 +7785,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7744,20 +7796,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i14.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i13.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i14.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i14.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i13.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i14.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7772,8 +7824,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i13.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_59(
+        returnValue: _i14.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_60(
           this,
           Invocation.method(
             #getNotifications,
@@ -7786,8 +7838,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_59(
+            _i14.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_60(
           this,
           Invocation.method(
             #getNotifications,
@@ -7799,35 +7851,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetNotificationsResponse>);
+      ) as _i14.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i13.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i14.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i13.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_60(
+        returnValue: _i14.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_61(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_60(
+        returnValueForMissingStub: _i14.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_61(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i13.Future<_i4.GetPresenceResponse>);
+      ) as _i14.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i13.Future<void> setPresence(
+  _i14.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -7841,12 +7893,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, Object?>> deleteProfileField(
+  _i14.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7859,13 +7911,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getProfileField(
+  _i14.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7878,13 +7930,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<Map<String, Object?>> setProfileField(
+  _i14.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7899,13 +7951,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i14.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -7920,8 +7972,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i13.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_61(
+        returnValue: _i14.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_62(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7934,8 +7986,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_61(
+            _i14.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_62(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7947,10 +7999,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i14.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i13.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i14.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -7971,8 +8023,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i13.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_62(
+        returnValue: _i14.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_63(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7988,8 +8040,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_62(
+            _i14.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_63(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8004,25 +8056,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i14.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i13.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.Pusher>?>.value(),
-      ) as _i13.Future<List<_i4.Pusher>?>);
+        returnValue: _i14.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.Pusher>?>.value(),
+      ) as _i14.Future<List<_i4.Pusher>?>);
 
   @override
-  _i13.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i14.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
+        returnValue: _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
           this,
           Invocation.method(
             #getPushRules,
@@ -8030,24 +8082,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
+            _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.PushRuleSet>);
+      ) as _i14.Future<_i4.PushRuleSet>);
 
   @override
-  _i13.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i14.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_64(
+        returnValue: _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_65(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8055,18 +8107,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_64(
+            _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_65(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i14.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i13.Future<void> deletePushRule(
+  _i14.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8078,12 +8130,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.PushRule> getPushRule(
+  _i14.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8095,7 +8147,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<_i4.PushRule>.value(_FakePushRule_65(
+        returnValue: _i14.Future<_i4.PushRule>.value(_FakePushRule_66(
           this,
           Invocation.method(
             #getPushRule,
@@ -8106,7 +8158,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PushRule>.value(_FakePushRule_65(
+            _i14.Future<_i4.PushRule>.value(_FakePushRule_66(
           this,
           Invocation.method(
             #getPushRule,
@@ -8116,10 +8168,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.PushRule>);
+      ) as _i14.Future<_i4.PushRule>);
 
   @override
-  _i13.Future<void> setPushRule(
+  _i14.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -8143,12 +8195,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<Object?>> getPushRuleActions(
+  _i14.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8160,13 +8212,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i14.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i13.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i13.Future<List<Object?>>);
+            _i14.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i14.Future<List<Object?>>);
 
   @override
-  _i13.Future<void> setPushRuleActions(
+  _i14.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -8180,12 +8232,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<bool> isPushRuleEnabled(
+  _i14.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8197,12 +8249,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> setPushRuleEnabled(
+  _i14.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -8216,19 +8268,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i14.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
+            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
           this,
           Invocation.method(
             #refresh,
@@ -8236,28 +8288,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
+            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i13.Future<_i4.RefreshResponse>);
+      ) as _i14.Future<_i4.RefreshResponse>);
 
   @override
-  _i13.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i14.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i13.Future<bool?>.value(),
-        returnValueForMissingStub: _i13.Future<bool?>.value(),
-      ) as _i13.Future<bool?>);
+        returnValue: _i14.Future<bool?>.value(),
+        returnValueForMissingStub: _i14.Future<bool?>.value(),
+      ) as _i14.Future<bool?>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8279,8 +8331,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8296,8 +8348,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8313,10 +8365,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8340,8 +8392,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8358,8 +8410,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8376,17 +8428,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8394,23 +8446,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i14.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
+        returnValue: _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8418,17 +8470,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
+            _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeys>);
+      ) as _i14.Future<_i4.RoomKeys>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -8440,8 +8492,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8452,8 +8504,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8463,10 +8515,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8478,8 +8530,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8490,8 +8542,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8501,10 +8553,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8516,7 +8568,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
+        returnValue: _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8527,7 +8579,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
+            _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8537,10 +8589,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeyBackup>);
+      ) as _i14.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -8554,8 +8606,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8567,8 +8619,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8579,10 +8631,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8596,8 +8648,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8609,8 +8661,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8621,10 +8673,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i14.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8638,7 +8690,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8650,7 +8702,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8661,10 +8713,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.KeyBackupData>);
+      ) as _i14.Future<_i4.KeyBackupData>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8680,8 +8732,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8694,8 +8746,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8707,18 +8759,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_69(
+                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_70(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8726,18 +8778,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_69(
+                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_70(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i13.Future<String> postRoomKeysVersion(
+  _i14.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -8749,7 +8801,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8760,7 +8812,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8770,29 +8822,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i14.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i14.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_70(
+        returnValue: _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_71(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8800,18 +8852,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_70(
+            _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_71(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i14.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i14.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -8826,24 +8878,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i14.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i13.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
-      ) as _i13.Future<List<String>>);
+        returnValue: _i14.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
+      ) as _i14.Future<List<String>>);
 
   @override
-  _i13.Future<void> ban(
+  _i14.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8857,12 +8909,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.EventContext> getEventContext(
+  _i14.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -8880,7 +8932,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<_i4.EventContext>.value(_FakeEventContext_71(
+        returnValue: _i14.Future<_i4.EventContext>.value(_FakeEventContext_72(
           this,
           Invocation.method(
             #getEventContext,
@@ -8895,7 +8947,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.EventContext>.value(_FakeEventContext_71(
+            _i14.Future<_i4.EventContext>.value(_FakeEventContext_72(
           this,
           Invocation.method(
             #getEventContext,
@@ -8909,10 +8961,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.EventContext>);
+      ) as _i14.Future<_i4.EventContext>);
 
   @override
-  _i13.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i14.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -8924,7 +8976,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8935,7 +8987,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8945,20 +8997,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.MatrixEvent>);
+      ) as _i14.Future<_i4.MatrixEvent>);
 
   @override
-  _i13.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i14.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> inviteBy3PID(
+  _i14.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -8970,12 +9022,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> inviteUser(
+  _i14.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8989,12 +9041,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> joinRoomById(
+  _i14.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -9008,7 +9060,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9020,7 +9072,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9031,23 +9083,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i14.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i13.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i14.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i13.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i13.Future<Map<String, _i4.RoomMember>?>);
+            _i14.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i14.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i13.Future<void> kick(
+  _i14.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9061,12 +9113,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> leaveRoom(
+  _i14.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9076,12 +9128,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i14.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -9097,12 +9149,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i13.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i13.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i14.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i14.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i13.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i14.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -9124,8 +9176,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_72(
+        returnValue: _i14.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_73(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9141,8 +9193,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_72(
+        returnValueForMissingStub: _i14.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_73(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9158,10 +9210,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomEventsResponse>);
+      ) as _i14.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i13.Future<void> setReadMarker(
+  _i14.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9177,12 +9229,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> postReceipt(
+  _i14.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -9198,12 +9250,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEvent(
+  _i14.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9219,12 +9271,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> reportRoom(
+  _i14.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9236,12 +9288,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> reportEvent(
+  _i14.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9259,12 +9311,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> sendMessage(
+  _i14.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9280,7 +9332,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9293,7 +9345,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9305,23 +9357,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i14.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i13.Future<List<_i4.MatrixEvent>>);
+            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i14.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i14.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -9338,13 +9390,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<String> setRoomStateWithKey(
+  _i14.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9360,7 +9412,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9373,7 +9425,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9385,10 +9437,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> unban(
+  _i14.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9402,12 +9454,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> upgradeRoom(
+  _i14.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9421,7 +9473,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9433,7 +9485,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9444,10 +9496,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.SearchResults> search(
+  _i14.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -9457,7 +9509,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
+        returnValue: _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
           this,
           Invocation.method(
             #search,
@@ -9466,7 +9518,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
+            _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
           this,
           Invocation.method(
             #search,
@@ -9474,10 +9526,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i13.Future<_i4.SearchResults>);
+      ) as _i14.Future<_i4.SearchResults>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> sync({
+  _i14.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -9498,7 +9550,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #sync,
@@ -9514,7 +9566,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #sync,
@@ -9529,22 +9581,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i14.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i13.Future<List<_i4.Location>>);
+            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i14.Future<List<_i4.Location>>);
 
   @override
-  _i13.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i14.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9554,21 +9606,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i13.Future<List<_i4.Location>>);
+            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i14.Future<List<_i4.Location>>);
 
   @override
-  _i13.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i14.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_74(
+        returnValue: _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_75(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9576,45 +9628,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_74(
+            _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_75(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i13.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i14.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i13.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i14.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9625,13 +9677,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getAccountData(
+  _i14.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9644,13 +9696,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> setAccountData(
+  _i14.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9664,12 +9716,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> defineFilter(
+  _i14.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -9681,7 +9733,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9692,7 +9744,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9702,10 +9754,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.Filter> getFilter(
+  _i14.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9717,7 +9769,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i13.Future<_i4.Filter>.value(_FakeFilter_18(
+        returnValue: _i14.Future<_i4.Filter>.value(_FakeFilter_19(
           this,
           Invocation.method(
             #getFilter,
@@ -9727,7 +9779,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.Filter>.value(_FakeFilter_18(
+        returnValueForMissingStub: _i14.Future<_i4.Filter>.value(_FakeFilter_19(
           this,
           Invocation.method(
             #getFilter,
@@ -9737,10 +9789,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.Filter>);
+      ) as _i14.Future<_i4.Filter>);
 
   @override
-  _i13.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i14.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9753,7 +9805,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
+            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9764,7 +9816,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
+            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9774,10 +9826,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.OpenIdCredentials>);
+      ) as _i14.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i13.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i14.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9792,13 +9844,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> setAccountDataPerRoom(
+  _i14.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9814,12 +9866,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i14.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9831,12 +9883,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i13.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i13.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i13.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i14.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i14.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i14.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i13.Future<void> deleteRoomTag(
+  _i14.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9850,12 +9902,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setRoomTag(
+  _i14.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9871,12 +9923,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i14.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9886,8 +9938,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i13.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_76(
+        returnValue: _i14.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_77(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9896,8 +9948,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_76(
+            _i14.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_77(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9905,10 +9957,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i13.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i14.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> reportUser(
+  _i14.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -9921,40 +9973,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i14.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i13.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_77(
+        returnValue: _i14.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_78(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_77(
+        returnValueForMissingStub: _i14.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_78(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.CreateContentResponse>);
+      ) as _i14.Future<_i4.CreateContentResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> uploadContentToMXC(
+  _i14.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i23.Uint8List? body, {
+    _i24.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -9972,8 +10024,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 }

--- a/test/widgets/add_room_to_space_dialog_test.mocks.dart
+++ b/test/widgets/add_room_to_space_dialog_test.mocks.dart
@@ -3,34 +3,36 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i13;
-import 'dart:typed_data' as _i23;
-import 'dart:ui' as _i17;
+import 'dart:async' as _i14;
+import 'dart:typed_data' as _i24;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
-import 'package:http/http.dart' as _i12;
-import 'package:kohera/core/services/matrix_service.dart' as _i15;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
+import 'package:http/http.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i16;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i7;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i8;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i22;
+import 'package:matrix/encryption.dart' as _i23;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i14;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i11;
-import 'package:matrix/src/utils/space_child.dart' as _i20;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i15;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i12;
+import 'package:matrix/src/utils/space_child.dart' as _i21;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -111,8 +113,9 @@ class _FakeSelectionService_5 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
-  _FakeSyncService_6(
+class _FakeSpaceAccessService_6 extends _i1.SmartFake
+    implements _i8.SpaceAccessService {
+  _FakeSpaceAccessService_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -121,8 +124,8 @@ class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
         );
 }
 
-class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
-  _FakeAuthService_7(
+class _FakeSyncService_7 extends _i1.SmartFake implements _i9.SyncService {
+  _FakeSyncService_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -131,8 +134,8 @@ class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
         );
 }
 
-class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
-  _FakeOutboxService_8(
+class _FakeAuthService_8 extends _i1.SmartFake implements _i10.AuthService {
+  _FakeAuthService_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -141,8 +144,8 @@ class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
         );
 }
 
-class _FakeRoomSummary_9 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_9(
+class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
+  _FakeOutboxService_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -151,9 +154,8 @@ class _FakeRoomSummary_9 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_10<T> extends _i1.SmartFake
-    implements _i11.CachedStreamController<T> {
-  _FakeCachedStreamController_10(
+class _FakeRoomSummary_10 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -162,8 +164,9 @@ class _FakeCachedStreamController_10<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_11 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_11(
+class _FakeCachedStreamController_11<T> extends _i1.SmartFake
+    implements _i12.CachedStreamController<T> {
+  _FakeCachedStreamController_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -172,9 +175,19 @@ class _FakeDateTime_11 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_12 extends _i1.SmartFake
+class _FakeDateTime_12 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_12(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_13 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_12(
+  _FakeLatestReceiptState_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -183,8 +196,8 @@ class _FakeLatestReceiptState_12 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_13 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_13(
+class _FakeSyncUpdate_14 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -193,8 +206,8 @@ class _FakeSyncUpdate_13 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeTimeline_14 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_14(
+class _FakeTimeline_15 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -203,8 +216,8 @@ class _FakeTimeline_14 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_15 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_15(
+class _FakeUser_16 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -213,8 +226,8 @@ class _FakeUser_15 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeUri_16 extends _i1.SmartFake implements Uri {
-  _FakeUri_16(
+class _FakeUri_17 extends _i1.SmartFake implements Uri {
+  _FakeUri_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -223,8 +236,8 @@ class _FakeUri_16 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_17 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_17(
+class _FakeDatabaseApi_18 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -233,8 +246,8 @@ class _FakeDatabaseApi_17 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_18 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_18(
+class _FakeFilter_19 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -243,9 +256,9 @@ class _FakeFilter_18 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_19 extends _i1.SmartFake
+class _FakeNativeImplementations_20 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_19(
+  _FakeNativeImplementations_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -254,8 +267,8 @@ class _FakeNativeImplementations_19 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_20 extends _i1.SmartFake implements Duration {
-  _FakeDuration_20(
+class _FakeDuration_21 extends _i1.SmartFake implements Duration {
+  _FakeDuration_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -264,9 +277,9 @@ class _FakeDuration_20 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_21 extends _i1.SmartFake
+class _FakePushruleEvaluator_22 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_21(
+  _FakePushruleEvaluator_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -275,8 +288,8 @@ class _FakePushruleEvaluator_21 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_22 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_22(
+class _FakeProfile_23 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -285,8 +298,8 @@ class _FakeProfile_22 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeClient_23 extends _i1.SmartFake implements _i12.Client {
-  _FakeClient_23(
+class _FakeClient_24 extends _i1.SmartFake implements _i13.Client {
+  _FakeClient_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -295,9 +308,9 @@ class _FakeClient_23 extends _i1.SmartFake implements _i12.Client {
         );
 }
 
-class _FakeDiscoveryInformation_24 extends _i1.SmartFake
+class _FakeDiscoveryInformation_25 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_24(
+  _FakeDiscoveryInformation_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -306,9 +319,9 @@ class _FakeDiscoveryInformation_24 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_25 extends _i1.SmartFake
+class _FakeGetVersionsResponse_26 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_25(
+  _FakeGetVersionsResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -317,9 +330,9 @@ class _FakeGetVersionsResponse_25 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_26 extends _i1.SmartFake
+class _FakeRegisterResponse_27 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_26(
+  _FakeRegisterResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -328,8 +341,8 @@ class _FakeRegisterResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_27 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_27(
+class _FakeLoginResponse_28 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -338,9 +351,9 @@ class _FakeLoginResponse_27 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_28 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_29 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_28(
+  _FakeGetAuthMetadataResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -349,8 +362,8 @@ class _FakeGetAuthMetadataResponse_28 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_29<T1> extends _i1.SmartFake implements _i13.Future<T1> {
-  _FakeFuture_29(
+class _FakeFuture_30<T1> extends _i1.SmartFake implements _i14.Future<T1> {
+  _FakeFuture_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -359,9 +372,9 @@ class _FakeFuture_29<T1> extends _i1.SmartFake implements _i13.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_30 extends _i1.SmartFake
+class _FakeCachedProfileInformation_31 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_30(
+  _FakeCachedProfileInformation_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -370,8 +383,8 @@ class _FakeCachedProfileInformation_30 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_31 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_31(
+class _FakeMediaConfig_32 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -380,8 +393,8 @@ class _FakeMediaConfig_31 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_32 extends _i1.SmartFake implements _i14.FileResponse {
-  _FakeFileResponse_32(
+class _FakeFileResponse_33 extends _i1.SmartFake implements _i15.FileResponse {
+  _FakeFileResponse_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -390,8 +403,8 @@ class _FakeFileResponse_32 extends _i1.SmartFake implements _i14.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_33 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_33(
+class _FakePreviewForUrl_34 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -400,9 +413,9 @@ class _FakePreviewForUrl_33 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_34 extends _i1.SmartFake
+class _FakeCachedPresence_35 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_34(
+  _FakeCachedPresence_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -411,9 +424,9 @@ class _FakeCachedPresence_34 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_35 extends _i1.SmartFake
+class _FakeTurnServerCredentials_36 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_35(
+  _FakeTurnServerCredentials_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -422,9 +435,9 @@ class _FakeTurnServerCredentials_35 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_37 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_36(
+  _FakeRoomKeysUpdateResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -433,8 +446,8 @@ class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_37(
+class _FakeKeyBackupData_38 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -443,9 +456,9 @@ class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_39 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_38(
+  _FakeGetWellknownSupportResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -454,9 +467,9 @@ class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_40 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_39(
+  _FakeGenerateLoginTokenResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -465,9 +478,9 @@ class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_41 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_40(
+  _FakeGetRoomSummaryResponse$3_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -476,9 +489,9 @@ class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_42 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_41(
+  _FakeGetSpaceHierarchyResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -487,9 +500,9 @@ class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_43 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_42(
+  _FakeGetRelatingEventsResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -498,9 +511,9 @@ class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_44 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_43(
+  _FakeGetRelatingEventsWithRelTypeResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -509,9 +522,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -520,9 +533,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_46 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_45(
+  _FakeGetThreadRootsResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -531,9 +544,9 @@ class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_47 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_46(
+  _FakeGetEventByTimestampResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -542,9 +555,9 @@ class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_47 extends _i1.SmartFake
+class _FakeRequestTokenResponse_48 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_47(
+  _FakeRequestTokenResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -553,9 +566,9 @@ class _FakeRequestTokenResponse_47 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_49 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_48(
+  _FakeTokenOwnerInfo_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -564,8 +577,8 @@ class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_49(
+class _FakeWhoIsInfo_50 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -574,8 +587,8 @@ class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_50(
+class _FakeCapabilities_51 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -584,8 +597,8 @@ class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_51(
+class _FakeDevice_52 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -594,9 +607,9 @@ class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_53 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_52(
+  _FakeGetRoomIdByAliasResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -605,9 +618,9 @@ class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_53 extends _i1.SmartFake
+class _FakeGetEventsResponse_54 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_53(
+  _FakeGetEventsResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -616,9 +629,9 @@ class _FakeGetEventsResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_54 extends _i1.SmartFake
+class _FakePeekEventsResponse_55 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_54(
+  _FakePeekEventsResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -627,8 +640,8 @@ class _FakePeekEventsResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_55(
+class _FakeMatrixEvent_56 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -637,9 +650,9 @@ class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_57 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_56(
+  _FakeGetKeysChangesResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -648,9 +661,9 @@ class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_57 extends _i1.SmartFake
+class _FakeClaimKeysResponse_58 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_57(
+  _FakeClaimKeysResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -659,9 +672,9 @@ class _FakeClaimKeysResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_58 extends _i1.SmartFake
+class _FakeQueryKeysResponse_59 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_58(
+  _FakeQueryKeysResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -670,9 +683,9 @@ class _FakeQueryKeysResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_60 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_59(
+  _FakeGetNotificationsResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -681,9 +694,9 @@ class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_60 extends _i1.SmartFake
+class _FakeGetPresenceResponse_61 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_60(
+  _FakeGetPresenceResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -692,9 +705,9 @@ class _FakeGetPresenceResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_62 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_61(
+  _FakeGetPublicRoomsResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -703,9 +716,9 @@ class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_63 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_62(
+  _FakeQueryPublicRoomsResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -714,8 +727,8 @@ class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_63(
+class _FakePushRuleSet_64 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -724,9 +737,9 @@ class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_65 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_64(
+  _FakeGetPushRulesGlobalResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -735,8 +748,8 @@ class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_65(
+class _FakePushRule_66 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -745,9 +758,9 @@ class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_66 extends _i1.SmartFake
+class _FakeRefreshResponse_67 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_66(
+  _FakeRefreshResponse_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,8 +769,8 @@ class _FakeRefreshResponse_66 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_67(
+class _FakeRoomKeys_68 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -766,8 +779,8 @@ class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_68(
+class _FakeRoomKeyBackup_69 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -776,9 +789,9 @@ class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_70 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_69(
+  _FakeGetRoomKeysVersionCurrentResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -787,9 +800,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_71 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_70(
+  _FakeGetRoomKeysVersionResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,8 +811,8 @@ class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_71(
+class _FakeEventContext_72 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,9 +821,9 @@ class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_73 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_72(
+  _FakeGetRoomEventsResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -819,8 +832,8 @@ class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_73(
+class _FakeSearchResults_74 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,9 +842,9 @@ class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_75 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_74(
+  _FakeGetProtocolMetadataResponse$2_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -840,9 +853,9 @@ class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_75 extends _i1.SmartFake
+class _FakeOpenIdCredentials_76 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_75(
+  _FakeOpenIdCredentials_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -851,9 +864,9 @@ class _FakeOpenIdCredentials_75 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_77 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_76(
+  _FakeSearchUserDirectoryResponse_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -862,9 +875,9 @@ class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_77 extends _i1.SmartFake
+class _FakeCreateContentResponse_78 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_77(
+  _FakeCreateContentResponse_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -876,7 +889,7 @@ class _FakeCreateContentResponse_77 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -906,11 +919,11 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -983,43 +996,56 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as _i7.SelectionService);
 
   @override
-  _i8.SyncService get sync => (super.noSuchMethod(
+  _i8.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_6(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_6(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i8.SpaceAccessService);
+
+  @override
+  _i9.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_6(
+        returnValue: _FakeSyncService_7(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_6(
+        returnValueForMissingStub: _FakeSyncService_7(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i8.SyncService);
+      ) as _i9.SyncService);
 
   @override
-  _i9.AuthService get auth => (super.noSuchMethod(
+  _i10.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_7(
+        returnValue: _FakeAuthService_8(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_7(
+        returnValueForMissingStub: _FakeAuthService_8(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i9.AuthService);
+      ) as _i10.AuthService);
 
   @override
-  _i10.OutboxService get outbox => (super.noSuchMethod(
+  _i11.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_8(
+        returnValue: _FakeOutboxService_9(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_8(
+        returnValueForMissingStub: _FakeOutboxService_9(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i10.OutboxService);
+      ) as _i11.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1083,7 +1109,16 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set sync(_i8.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i8.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i9.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -1092,7 +1127,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set auth(_i9.AuthService? value) => super.noSuchMethod(
+  set auth(_i10.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -1101,7 +1136,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set outbox(_i10.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i11.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -1117,14 +1152,14 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as bool);
 
   @override
-  _i13.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1154,7 +1189,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1164,18 +1199,18 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<bool> login({
+  _i14.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1190,12 +1225,12 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> completeSsoLogin({
+  _i14.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1208,12 +1243,12 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> completeRegistration(
+  _i14.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1223,32 +1258,32 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1257,7 +1292,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1266,17 +1301,17 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1287,7 +1322,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1324,26 +1359,26 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+  _i14.Future<bool> didPushRouteInformation(
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1373,7 +1408,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1382,7 +1417,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1391,16 +1426,16 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i14.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i13.Future<_i17.AppExitResponse>);
+            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i14.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1428,11 +1463,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1462,11 +1497,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_9(
+        returnValue: _FakeRoomSummary_10(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_9(
+        returnValueForMissingStub: _FakeRoomSummary_10(
           this,
           Invocation.getter(#summary),
         ),
@@ -1496,11 +1531,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i13.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i14.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i13.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i13.Completer<dynamic>>[],
-      ) as List<_i13.Completer<dynamic>>);
+        returnValue: <_i14.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i14.Completer<dynamic>>[],
+      ) as List<_i14.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1519,51 +1554,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i11.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i12.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_10<String>(
+        returnValue: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i11.CachedStreamController<String> get onSessionKeyReceived =>
+  _i12.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_10<String>(
+        returnValue: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1579,11 +1614,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1592,11 +1627,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1639,11 +1674,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1652,11 +1687,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_11(
+        returnValue: _FakeDateTime_12(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_11(
+        returnValueForMissingStub: _FakeDateTime_12(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -1686,11 +1721,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_12(
+        returnValue: _FakeLatestReceiptState_13(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_12(
+        returnValueForMissingStub: _FakeLatestReceiptState_13(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -1711,22 +1746,29 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i13.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i14.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
         Invocation.getter(#isFavourite),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
@@ -1902,18 +1944,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i20.SpaceParent>[],
-        returnValueForMissingStub: <_i20.SpaceParent>[],
-      ) as List<_i20.SpaceParent>);
+        returnValue: <_i21.SpaceParent>[],
+        returnValueForMissingStub: <_i21.SpaceParent>[],
+      ) as List<_i21.SpaceParent>);
 
   @override
-  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i20.SpaceChild>[],
-        returnValueForMissingStub: <_i20.SpaceChild>[],
-      ) as List<_i20.SpaceChild>);
+        returnValue: <_i21.SpaceChild>[],
+        returnValueForMissingStub: <_i21.SpaceChild>[],
+      ) as List<_i21.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -2026,14 +2068,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i13.Future<void> postLoad() => (super.noSuchMethod(
+  _i14.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -2061,15 +2103,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i13.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i14.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i13.Future<List<_i4.User>>);
+            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i14.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -2080,14 +2122,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2097,18 +2139,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i13.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i14.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Event?> refreshLastEvent(
+  _i14.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2116,9 +2158,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -2130,12 +2172,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i13.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i14.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2143,22 +2185,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i14.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2166,17 +2208,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> addTag(
+  _i14.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2186,27 +2228,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i14.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i14.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2214,43 +2256,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i14.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i14.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i14.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
+        ),
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
+
+  @override
+  _i14.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2258,14 +2310,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2277,7 +2329,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i13.Future<String?> sendTextEvent(
+  _i14.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2309,12 +2361,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendReaction(
+  _i14.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2328,12 +2380,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendLocation(
+  _i14.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2347,12 +2399,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendFileEvent(
+  _i14.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2380,25 +2432,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i14.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i13.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i14.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i13.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i14.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i13.Future<_i4.EncryptionHealthState>);
+      ) as _i14.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i13.Future<String?> sendEvent(
+  _i14.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -2422,73 +2474,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i14.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> leave() => (super.noSuchMethod(
+  _i14.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> forget() => (super.noSuchMethod(
+  _i14.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> setPower(
+  _i14.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2500,7 +2552,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2511,7 +2563,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2521,10 +2573,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> invite(
+  _i14.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2534,12 +2586,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<int> requestHistory({
+  _i14.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -2556,32 +2608,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<int>.value(0),
-        returnValueForMissingStub: _i13.Future<int>.value(0),
-      ) as _i13.Future<int>);
+        returnValue: _i14.Future<int>.value(0),
+        returnValueForMissingStub: _i14.Future<int>.value(0),
+      ) as _i14.Future<int>);
 
   @override
-  _i13.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i14.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setReadMarker(
+  _i14.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2595,23 +2647,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
+  _i14.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i13.Future<_i21.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i13.Future<_i21.TimelineChunk?>.value(),
-      ) as _i13.Future<_i21.TimelineChunk?>);
+        returnValue: _i14.Future<_i22.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i14.Future<_i22.TimelineChunk?>.value(),
+      ) as _i14.Future<_i22.TimelineChunk?>);
 
   @override
-  _i13.Future<void> postReceipt(
+  _i14.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -2621,12 +2673,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Timeline> getTimeline({
+  _i14.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2649,7 +2701,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i13.Future<_i4.Timeline>.value(_FakeTimeline_14(
+        returnValue: _i14.Future<_i4.Timeline>.value(_FakeTimeline_15(
           this,
           Invocation.method(
             #getTimeline,
@@ -2666,7 +2718,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Timeline>.value(_FakeTimeline_14(
+            _i14.Future<_i4.Timeline>.value(_FakeTimeline_15(
           this,
           Invocation.method(
             #getTimeline,
@@ -2682,7 +2734,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Timeline>);
+      ) as _i14.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -2701,7 +2753,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i13.Future<List<_i4.User>> requestParticipants([
+  _i14.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -2719,10 +2771,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i13.Future<List<_i4.User>>);
+            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i14.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -2730,14 +2782,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_15(
+        returnValue: _FakeUser_16(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_15(
+        returnValueForMissingStub: _FakeUser_16(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -2753,14 +2805,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_15(
+        returnValue: _FakeUser_16(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_15(
+        returnValueForMissingStub: _FakeUser_16(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -2770,7 +2822,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i13.Future<_i4.User?> requestUser(
+  _i14.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2786,19 +2838,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i13.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.User?>.value(),
-      ) as _i13.Future<_i4.User?>);
+        returnValue: _i14.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.User?>.value(),
+      ) as _i14.Future<_i4.User?>);
 
   @override
-  _i13.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i14.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2811,12 +2863,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i13.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i14.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2824,14 +2876,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2854,14 +2906,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i13.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i14.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -2900,18 +2952,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i13.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i14.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEvent(
+  _i14.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -2925,12 +2977,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> setTyping(
+  _i14.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -2940,12 +2992,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setJoinRules(
+  _i14.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -2959,59 +3011,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i14.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setHistoryVisibility(
+  _i14.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i14.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i14.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i13.Future<List<_i4.DeviceKeys>>);
+            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i14.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i13.Future<void> requestSessionKey(
+  _i14.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -3023,12 +3075,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setSpaceChild(
+  _i14.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3044,44 +3096,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i14.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i13.Future<Uri>.value(_FakeUri_16(
+        returnValue: _i14.Future<Uri>.value(_FakeUri_17(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_16(
+        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_17(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i13.Future<Uri>);
+      ) as _i14.Future<Uri>);
 
   @override
-  _i13.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i14.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<
+  _i14.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -3108,21 +3160,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i13.Future<
+        returnValue: _i14.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i13.Future<
+        returnValueForMissingStub: _i14.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i13.Future<
+      ) as _i14.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -3137,23 +3189,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_17(
+        returnValue: _FakeDatabaseApi_18(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_17(
+        returnValueForMissingStub: _FakeDatabaseApi_18(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i22.KeyVerificationMethod> get verificationMethods =>
+  Set<_i23.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i22.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i22.KeyVerificationMethod>{},
-      ) as Set<_i22.KeyVerificationMethod>);
+        returnValue: <_i23.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i23.KeyVerificationMethod>{},
+      ) as Set<_i23.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3214,11 +3266,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_18(
+        returnValue: _FakeFilter_19(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_18(
+        returnValueForMissingStub: _FakeFilter_19(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -3227,11 +3279,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_19(
+        returnValue: _FakeNativeImplementations_20(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_19(
+        returnValueForMissingStub: _FakeNativeImplementations_20(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -3247,11 +3299,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_20(
+        returnValue: _FakeDuration_21(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_20(
+        returnValueForMissingStub: _FakeDuration_21(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3260,11 +3312,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_20(
+        returnValue: _FakeDuration_21(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_20(
+        returnValueForMissingStub: _FakeDuration_21(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3273,11 +3325,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -3314,11 +3366,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3348,11 +3400,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3361,11 +3413,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3388,11 +3440,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_21(
+        returnValue: _FakePushruleEvaluator_22(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_21(
+        returnValueForMissingStub: _FakePushruleEvaluator_22(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -3413,332 +3465,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i13.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i14.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i11.CachedStreamController<String> get onUserProfileUpdate =>
+  _i12.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_10<String>(
+        returnValue: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i13.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i14.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i13.Future<List<_i4.Room>>);
+            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i14.Future<List<_i4.Room>>);
 
   @override
-  _i11.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i12.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_10<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_11<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.EventUpdate>(
+            _FakeCachedStreamController_11<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.EventUpdate>);
+      ) as _i12.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i12.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_10<_i4.Event>(
+        returnValue: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i12.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_10<_i4.Event>(
+        returnValue: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onNotification =>
+  _i12.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_10<_i4.Event>(
+        returnValue: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i12.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_10<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_11<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_11<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i12.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i11.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i12.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_10<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_11<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_10<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_11<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i11.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i12.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i11.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i12.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_10<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_11<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.LoginState>(
+            _FakeCachedStreamController_11<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i11.CachedStreamController<_i4.LoginState>);
+      ) as _i12.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i11.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i12.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_10<bool>(
+        returnValue: _FakeCachedStreamController_11<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i11.CachedStreamController<bool>);
+      ) as _i12.CachedStreamController<bool>);
 
   @override
-  _i11.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i12.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_10<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_11<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i11.CachedStreamController<_i4.SdkError>);
+      ) as _i12.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i11.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i12.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_10<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_11<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.SyncUpdate>(
+            _FakeCachedStreamController_11<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i11.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i12.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i12.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_10<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_11<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_11<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i11.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i12.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.Presence> get onPresence =>
+  _i12.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_10<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_11<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i11.CachedStreamController<_i4.Presence>);
+      ) as _i12.CachedStreamController<_i4.Presence>);
 
   @override
-  _i11.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i12.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_10<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_11<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.CachedPresence>(
+            _FakeCachedStreamController_11<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i11.CachedStreamController<_i4.CachedPresence>);
+      ) as _i12.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i11.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i12.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_10<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_11<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.BasicEvent>(
+            _FakeCachedStreamController_11<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i11.CachedStreamController<_i4.BasicEvent>);
+      ) as _i12.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i11.CachedStreamController<_i22.RoomKeyRequest> get onRoomKeyRequest =>
+  _i12.CachedStreamController<_i23.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_10<_i22.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_11<_i23.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i22.RoomKeyRequest>(
+            _FakeCachedStreamController_11<_i23.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i11.CachedStreamController<_i22.RoomKeyRequest>);
+      ) as _i12.CachedStreamController<_i23.RoomKeyRequest>);
 
   @override
-  _i11.CachedStreamController<_i22.KeyVerification>
+  _i12.CachedStreamController<_i23.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_10<_i22.KeyVerification>(
+            returnValue: _FakeCachedStreamController_11<_i23.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_10<_i22.KeyVerification>(
+                _FakeCachedStreamController_11<_i23.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i11.CachedStreamController<_i22.KeyVerification>);
+          ) as _i12.CachedStreamController<_i23.KeyVerification>);
 
   @override
-  _i11.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i12.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_10<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_11<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_11<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i11.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i12.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i12.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_10<_i4.Event>(
+        returnValue: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<String> get onCancelSendEvent =>
+  _i12.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_10<String>(
+        returnValue: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i11.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i12.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_10<
+            returnValue: _FakeCachedStreamController_11<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_10<
+            returnValueForMissingStub: _FakeCachedStreamController_11<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i11.CachedStreamController<
+          ) as _i12.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -3758,11 +3810,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_11(
+        returnValue: _FakeDateTime_12(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_11(
+        returnValueForMissingStub: _FakeDateTime_12(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3835,7 +3887,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i22.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i23.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3890,7 +3942,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i13.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i14.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -3901,7 +3953,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i13.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i14.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -4012,7 +4064,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -4021,7 +4073,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -4030,7 +4082,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4057,20 +4109,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Client get httpClient => (super.noSuchMethod(
+  _i13.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_23(
+        returnValue: _FakeClient_24(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_23(
+        returnValueForMissingStub: _FakeClient_24(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i12.Client);
+      ) as _i13.Client);
 
   @override
-  set httpClient(_i12.Client? value) => super.noSuchMethod(
+  set httpClient(_i13.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4097,7 +4149,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<void> refreshAccessToken(
+  _i14.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4105,9 +4157,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4125,14 +4177,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4169,33 +4221,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i13.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i14.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i13.Future<_i4.DiscoveryInformation>);
+      ) as _i14.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i13.Future<
+  _i14.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -4217,7 +4269,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i13.Future<
+        returnValue: _i14.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4225,7 +4277,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_25(
+          _FakeGetVersionsResponse_26(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4240,7 +4292,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i13.Future<
+        returnValueForMissingStub: _i14.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4248,7 +4300,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_25(
+          _FakeGetVersionsResponse_26(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4263,7 +4315,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i13.Future<
+      ) as _i14.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -4272,7 +4324,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i13.Future<_i4.DiscoveryInformation> getWellknown({
+  _i14.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4285,8 +4337,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getWellknown,
@@ -4297,8 +4349,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getWellknown,
@@ -4309,10 +4361,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.DiscoveryInformation>);
+      ) as _i14.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i13.Future<_i4.RegisterResponse> register({
+  _i14.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -4340,7 +4392,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
+            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
           this,
           Invocation.method(
             #register,
@@ -4359,7 +4411,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
+            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
           this,
           Invocation.method(
             #register,
@@ -4377,10 +4429,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RegisterResponse>);
+      ) as _i14.Future<_i4.RegisterResponse>);
 
   @override
-  _i13.Future<_i4.LoginResponse> login(
+  _i14.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -4410,7 +4462,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
+        returnValue: _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
           this,
           Invocation.method(
             #login,
@@ -4430,7 +4482,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
+            _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
           this,
           Invocation.method(
             #login,
@@ -4449,10 +4501,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.LoginResponse>);
+      ) as _i14.Future<_i4.LoginResponse>);
 
   @override
-  _i13.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i14.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4465,8 +4517,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_28(
+        returnValue: _i14.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_29(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4478,8 +4530,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_28(
+            _i14.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_29(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4490,74 +4542,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i14.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> logoutAll() => (super.noSuchMethod(
+  _i14.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<T> uiaRequestBackground<T>(
-          _i13.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i14.Future<T> uiaRequestBackground<T>(
+          _i14.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i13.Future<T>.value(v),
+              (T v) => _i14.Future<T>.value(v),
             ) ??
-            _FakeFuture_29<T>(
+            _FakeFuture_30<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i13.Future<T>.value(v),
+              (T v) => _i14.Future<T>.value(v),
             ) ??
-            _FakeFuture_29<T>(
+            _FakeFuture_30<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i13.Future<T>);
+      ) as _i14.Future<T>);
 
   @override
-  _i13.Future<String> startDirectChat(
+  _i14.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -4579,7 +4631,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4595,7 +4647,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4610,10 +4662,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<String> createGroupChat({
+  _i14.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -4644,7 +4696,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4665,7 +4717,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4685,10 +4737,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i14.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4704,7 +4756,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4717,7 +4769,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4729,21 +4781,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i14.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<String> createSpace({
+  _i14.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -4768,7 +4820,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4786,7 +4838,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4803,10 +4855,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i14.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4814,7 +4866,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4823,7 +4875,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4831,10 +4883,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i13.Future<_i4.Profile> fetchOwnProfile({
+  _i14.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4847,7 +4899,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4859,7 +4911,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4870,10 +4922,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i13.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i14.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4887,8 +4939,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i13.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_30(
+        returnValue: _i14.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_31(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4900,8 +4952,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_30(
+            _i14.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_31(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4912,10 +4964,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.CachedProfileInformation>);
+      ) as _i14.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i13.Future<_i4.Profile> getProfileFromUserId(
+  _i14.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -4933,7 +4985,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4947,7 +4999,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4960,7 +5012,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -4982,31 +5034,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i13.Future<List<_i4.Room>>);
+            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i14.Future<List<_i4.Room>>);
 
   @override
-  _i13.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i14.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i13.Future<List<_i4.ArchivedRoom>>);
+            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i14.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i13.Future<_i4.GetVersionsResponse> getVersions({
+  _i14.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5019,8 +5071,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_25(
+        returnValue: _i14.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_26(
           this,
           Invocation.method(
             #getVersions,
@@ -5031,8 +5083,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_25(
+        returnValueForMissingStub: _i14.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_26(
           this,
           Invocation.method(
             #getVersions,
@@ -5043,20 +5095,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetVersionsResponse>);
+      ) as _i14.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i13.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i14.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<_i4.MediaConfig> getConfig({
+  _i14.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5069,7 +5121,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
+        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
           this,
           Invocation.method(
             #getConfig,
@@ -5081,7 +5133,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
+            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
           this,
           Invocation.method(
             #getConfig,
@@ -5092,10 +5144,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.MediaConfig>);
+      ) as _i14.Future<_i4.MediaConfig>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContent(
+  _i14.Future<_i15.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5115,7 +5167,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContent,
@@ -5131,7 +5183,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContent,
@@ -5146,10 +5198,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentOverrideName(
+  _i14.Future<_i15.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5171,7 +5223,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5188,7 +5240,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5204,10 +5256,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentThumbnail(
+  _i14.Future<_i15.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5235,7 +5287,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5255,7 +5307,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5274,10 +5326,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i14.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5287,7 +5339,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
+        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5296,7 +5348,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
+            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5304,11 +5356,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i13.Future<_i4.PreviewForUrl>);
+      ) as _i14.Future<_i4.PreviewForUrl>);
 
   @override
-  _i13.Future<Uri> uploadContent(
-    _i23.Uint8List? file, {
+  _i14.Future<Uri> uploadContent(
+    _i24.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5321,7 +5373,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i13.Future<Uri>.value(_FakeUri_16(
+        returnValue: _i14.Future<Uri>.value(_FakeUri_17(
           this,
           Invocation.method(
             #uploadContent,
@@ -5332,7 +5384,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_16(
+        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_17(
           this,
           Invocation.method(
             #uploadContent,
@@ -5343,10 +5395,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<Uri>);
+      ) as _i14.Future<Uri>);
 
   @override
-  _i13.Future<void> setTyping(
+  _i14.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5362,42 +5414,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> exportDump() => (super.noSuchMethod(
+  _i14.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i14.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i14.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Event?> getEventByPushNotification(
+  _i14.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -5413,12 +5465,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
-  _i13.Future<void> init({
+  _i14.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5453,9 +5505,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5467,40 +5519,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<void> clear() => (super.noSuchMethod(
+  _i14.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i14.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ensureNotSoftLoggedOut(
+  _i14.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleSync(
+  _i14.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -5510,9 +5562,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -5525,29 +5577,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i13.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i14.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i14.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDevice(
+  _i14.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5561,12 +5613,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDevicesOfUserIds(
+  _i14.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5582,12 +5634,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDeviceEncrypted(
+  _i14.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5607,12 +5659,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDeviceEncryptedChunked(
+  _i14.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -5626,23 +5678,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i14.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> joinRoom(
+  _i14.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -5660,7 +5712,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5674,7 +5726,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5687,10 +5739,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> changePassword(
+  _i14.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -5706,22 +5758,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> clearCache() => (super.noSuchMethod(
+  _i14.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ignoreUser(
+  _i14.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5731,22 +5783,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i14.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i14.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5757,7 +5809,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5766,7 +5818,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5774,32 +5826,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i13.Future<_i4.CachedPresence>);
+      ) as _i14.Future<_i4.CachedPresence>);
 
   @override
-  _i13.Future<void> abortSync() => (super.noSuchMethod(
+  _i14.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i14.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEventWithMetadata(
+  _i14.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5819,14 +5871,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i12.BaseResponse? response,
-    _i23.Uint8List? body,
+    _i13.BaseResponse? response,
+    _i24.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5858,7 +5910,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i13.Future<Map<String, Object?>> request(
+  _i14.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -5879,13 +5931,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> postPusher(
+  _i14.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -5895,57 +5947,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i14.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i14.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i14.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i13.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_35(
+        returnValue: _i14.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_36(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_35(
+        returnValueForMissingStub: _i14.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_36(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.TurnServerCredentials>);
+      ) as _i14.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5959,8 +6011,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5972,8 +6024,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5984,10 +6036,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6003,8 +6055,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6017,8 +6069,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6030,10 +6082,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i14.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6047,7 +6099,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6059,7 +6111,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6070,17 +6122,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.KeyBackupData>);
+      ) as _i14.Future<_i4.KeyBackupData>);
 
   @override
-  _i13.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i14.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i13.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_38(
+        returnValue: _i14.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_39(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6088,18 +6140,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_38(
+            _i14.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_39(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i14.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i13.Future<int> pingAppservice(
+  _i14.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6109,12 +6161,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i13.Future<int>.value(0),
-        returnValueForMissingStub: _i13.Future<int>.value(0),
-      ) as _i13.Future<int>);
+        returnValue: _i14.Future<int>.value(0),
+        returnValueForMissingStub: _i14.Future<int>.value(0),
+      ) as _i14.Future<int>);
 
   @override
-  _i13.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i14.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6122,8 +6174,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_39(
+        returnValue: _i14.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_40(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6132,8 +6184,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_39(
+            _i14.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_40(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6141,15 +6193,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i13.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i14.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i13.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i14.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
+        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6157,17 +6209,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
+            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.MediaConfig>);
+      ) as _i14.Future<_i4.MediaConfig>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentAuthed(
+  _i14.Future<_i15.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6181,7 +6233,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6193,7 +6245,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6204,10 +6256,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentOverrideNameAuthed(
+  _i14.Future<_i15.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6223,7 +6275,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6236,7 +6288,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6248,10 +6300,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i14.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6261,7 +6313,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
+        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6270,7 +6322,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
+            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6278,10 +6330,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i13.Future<_i4.PreviewForUrl>);
+      ) as _i14.Future<_i4.PreviewForUrl>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentThumbnailAuthed(
+  _i14.Future<_i15.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -6305,7 +6357,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6323,7 +6375,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6340,21 +6392,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<bool> registrationTokenValidity(String? token) =>
+  _i14.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i14.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6364,8 +6416,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_40(
+        returnValue: _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_41(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6374,8 +6426,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_40(
+            _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_41(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6383,10 +6435,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i14.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i13.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i14.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6404,8 +6456,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_41(
+        returnValue: _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_42(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6419,8 +6471,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_41(
+            _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_42(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6433,10 +6485,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i14.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i14.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -6460,8 +6512,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i13.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_42(
+        returnValue: _i14.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_43(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6479,8 +6531,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_42(
+            _i14.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_43(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6497,10 +6549,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i14.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6528,8 +6580,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_43(
+                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6548,8 +6600,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_43(
+                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6567,10 +6619,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i14.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6599,9 +6651,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i13.Future<
+            returnValue: _i14.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6620,9 +6672,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i13.Future<
+            returnValueForMissingStub: _i14.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6641,11 +6693,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i13
+          ) as _i14
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i13.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i14.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -6661,8 +6713,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i13.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_45(
+        returnValue: _i14.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_46(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6675,8 +6727,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_45(
+            _i14.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_46(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6688,10 +6740,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetThreadRootsResponse>);
+      ) as _i14.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i13.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i14.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -6705,8 +6757,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i13.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_46(
+        returnValue: _i14.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_47(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6718,8 +6770,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_46(
+            _i14.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_47(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6730,33 +6782,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i14.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i14.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i13.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i14.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i13.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i14.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i13.Future<Uri?>.value(),
-        returnValueForMissingStub: _i13.Future<Uri?>.value(),
-      ) as _i13.Future<Uri?>);
+        returnValue: _i14.Future<Uri?>.value(),
+        returnValueForMissingStub: _i14.Future<Uri?>.value(),
+      ) as _i14.Future<Uri?>);
 
   @override
-  _i13.Future<void> add3PID(
+  _i14.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -6770,12 +6822,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> bind3PID(
+  _i14.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6791,12 +6843,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i14.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6810,14 +6862,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6839,8 +6891,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6856,8 +6908,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6873,10 +6925,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6900,8 +6952,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6918,8 +6970,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6936,10 +6988,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i14.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6953,14 +7005,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i14.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -6975,14 +7027,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7004,8 +7056,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7021,8 +7073,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7038,10 +7090,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7065,8 +7117,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7083,8 +7135,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7101,16 +7153,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i14.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
+            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7118,22 +7170,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
+            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.TokenOwnerInfo>);
+      ) as _i14.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i13.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i14.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
+        returnValue: _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7141,22 +7193,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
+            _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i13.Future<_i4.WhoIsInfo>);
+      ) as _i14.Future<_i4.WhoIsInfo>);
 
   @override
-  _i13.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i14.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
+        returnValue: _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7164,17 +7216,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
+            _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.Capabilities>);
+      ) as _i14.Future<_i4.Capabilities>);
 
   @override
-  _i13.Future<String> createRoom({
+  _i14.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -7207,7 +7259,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7229,7 +7281,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7250,10 +7302,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> deleteDevices(
+  _i14.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7263,22 +7315,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.Device>?>.value(),
-      ) as _i13.Future<List<_i4.Device>?>);
+        returnValue: _i14.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.Device>?>.value(),
+      ) as _i14.Future<List<_i4.Device>?>);
 
   @override
-  _i13.Future<void> deleteDevice(
+  _i14.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7288,34 +7340,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i14.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i13.Future<_i4.Device>.value(_FakeDevice_51(
+        returnValue: _i14.Future<_i4.Device>.value(_FakeDevice_52(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.Device>.value(_FakeDevice_51(
+        returnValueForMissingStub: _i14.Future<_i4.Device>.value(_FakeDevice_52(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i13.Future<_i4.Device>);
+      ) as _i14.Future<_i4.Device>);
 
   @override
-  _i13.Future<void> updateDevice(
+  _i14.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7325,12 +7377,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i14.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -7345,24 +7397,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i14.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i13.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Visibility?>.value(),
-      ) as _i13.Future<_i4.Visibility?>);
+        returnValue: _i14.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Visibility?>.value(),
+      ) as _i14.Future<_i4.Visibility?>);
 
   @override
-  _i13.Future<void> setRoomVisibilityOnDirectory(
+  _i14.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -7372,30 +7424,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i14.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i14.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_52(
+        returnValue: _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_53(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7403,18 +7455,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_52(
+            _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_53(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i14.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i13.Future<void> setRoomAlias(
+  _i14.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7426,12 +7478,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetEventsResponse> getEvents({
+  _i14.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7445,7 +7497,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
+            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
           this,
           Invocation.method(
             #getEvents,
@@ -7457,7 +7509,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
+            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
           this,
           Invocation.method(
             #getEvents,
@@ -7468,10 +7520,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetEventsResponse>);
+      ) as _i14.Future<_i4.GetEventsResponse>);
 
   @override
-  _i13.Future<_i4.PeekEventsResponse> peekEvents({
+  _i14.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7486,8 +7538,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i13.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_54(
+        returnValue: _i14.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_55(
           this,
           Invocation.method(
             #peekEvents,
@@ -7499,8 +7551,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_54(
+        returnValueForMissingStub: _i14.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_55(
           this,
           Invocation.method(
             #peekEvents,
@@ -7512,16 +7564,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.PeekEventsResponse>);
+      ) as _i14.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i13.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i14.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7529,27 +7581,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i13.Future<_i4.MatrixEvent>);
+      ) as _i14.Future<_i4.MatrixEvent>);
 
   @override
-  _i13.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i14.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i13.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
-      ) as _i13.Future<List<String>>);
+        returnValue: _i14.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
+      ) as _i14.Future<List<String>>);
 
   @override
-  _i13.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i14.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7561,8 +7613,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i13.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_56(
+        returnValue: _i14.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_57(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7573,8 +7625,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_56(
+            _i14.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_57(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7584,10 +7636,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.GetKeysChangesResponse>);
+      ) as _i14.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i13.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i14.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7598,7 +7650,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
+            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
           this,
           Invocation.method(
             #claimKeys,
@@ -7607,7 +7659,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
+            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
           this,
           Invocation.method(
             #claimKeys,
@@ -7615,10 +7667,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i13.Future<_i4.ClaimKeysResponse>);
+      ) as _i14.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i13.Future<void> uploadCrossSigningKeys({
+  _i14.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -7635,12 +7687,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.QueryKeysResponse> queryKeys(
+  _i14.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7651,7 +7703,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
+            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
           this,
           Invocation.method(
             #queryKeys,
@@ -7660,7 +7712,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
+            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
           this,
           Invocation.method(
             #queryKeys,
@@ -7668,10 +7720,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i13.Future<_i4.QueryKeysResponse>);
+      ) as _i14.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7679,14 +7731,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i13.Future<
+            returnValue: _i14.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i13.Future<
+            returnValueForMissingStub: _i14.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i13.Future<Map<String, int>> uploadKeys({
+  _i14.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -7701,13 +7753,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i13.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i14.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i13.Future<Map<String, int>>);
+            _i14.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i14.Future<Map<String, int>>);
 
   @override
-  _i13.Future<String> knockRoom(
+  _i14.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7721,7 +7773,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7733,7 +7785,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7744,20 +7796,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i14.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i13.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i14.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i14.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i13.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i14.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7772,8 +7824,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i13.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_59(
+        returnValue: _i14.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_60(
           this,
           Invocation.method(
             #getNotifications,
@@ -7786,8 +7838,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_59(
+            _i14.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_60(
           this,
           Invocation.method(
             #getNotifications,
@@ -7799,35 +7851,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetNotificationsResponse>);
+      ) as _i14.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i13.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i14.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i13.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_60(
+        returnValue: _i14.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_61(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_60(
+        returnValueForMissingStub: _i14.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_61(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i13.Future<_i4.GetPresenceResponse>);
+      ) as _i14.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i13.Future<void> setPresence(
+  _i14.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -7841,12 +7893,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, Object?>> deleteProfileField(
+  _i14.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7859,13 +7911,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getProfileField(
+  _i14.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7878,13 +7930,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<Map<String, Object?>> setProfileField(
+  _i14.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7899,13 +7951,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i14.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -7920,8 +7972,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i13.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_61(
+        returnValue: _i14.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_62(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7934,8 +7986,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_61(
+            _i14.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_62(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7947,10 +7999,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i14.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i13.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i14.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -7971,8 +8023,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i13.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_62(
+        returnValue: _i14.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_63(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7988,8 +8040,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_62(
+            _i14.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_63(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8004,25 +8056,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i14.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i13.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.Pusher>?>.value(),
-      ) as _i13.Future<List<_i4.Pusher>?>);
+        returnValue: _i14.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.Pusher>?>.value(),
+      ) as _i14.Future<List<_i4.Pusher>?>);
 
   @override
-  _i13.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i14.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
+        returnValue: _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
           this,
           Invocation.method(
             #getPushRules,
@@ -8030,24 +8082,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
+            _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.PushRuleSet>);
+      ) as _i14.Future<_i4.PushRuleSet>);
 
   @override
-  _i13.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i14.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_64(
+        returnValue: _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_65(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8055,18 +8107,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_64(
+            _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_65(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i14.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i13.Future<void> deletePushRule(
+  _i14.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8078,12 +8130,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.PushRule> getPushRule(
+  _i14.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8095,7 +8147,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<_i4.PushRule>.value(_FakePushRule_65(
+        returnValue: _i14.Future<_i4.PushRule>.value(_FakePushRule_66(
           this,
           Invocation.method(
             #getPushRule,
@@ -8106,7 +8158,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PushRule>.value(_FakePushRule_65(
+            _i14.Future<_i4.PushRule>.value(_FakePushRule_66(
           this,
           Invocation.method(
             #getPushRule,
@@ -8116,10 +8168,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.PushRule>);
+      ) as _i14.Future<_i4.PushRule>);
 
   @override
-  _i13.Future<void> setPushRule(
+  _i14.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -8143,12 +8195,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<Object?>> getPushRuleActions(
+  _i14.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8160,13 +8212,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i14.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i13.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i13.Future<List<Object?>>);
+            _i14.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i14.Future<List<Object?>>);
 
   @override
-  _i13.Future<void> setPushRuleActions(
+  _i14.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -8180,12 +8232,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<bool> isPushRuleEnabled(
+  _i14.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8197,12 +8249,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> setPushRuleEnabled(
+  _i14.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -8216,19 +8268,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i14.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
+            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
           this,
           Invocation.method(
             #refresh,
@@ -8236,28 +8288,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
+            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i13.Future<_i4.RefreshResponse>);
+      ) as _i14.Future<_i4.RefreshResponse>);
 
   @override
-  _i13.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i14.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i13.Future<bool?>.value(),
-        returnValueForMissingStub: _i13.Future<bool?>.value(),
-      ) as _i13.Future<bool?>);
+        returnValue: _i14.Future<bool?>.value(),
+        returnValueForMissingStub: _i14.Future<bool?>.value(),
+      ) as _i14.Future<bool?>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8279,8 +8331,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8296,8 +8348,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8313,10 +8365,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8340,8 +8392,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8358,8 +8410,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8376,17 +8428,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8394,23 +8446,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i14.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
+        returnValue: _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8418,17 +8470,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
+            _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeys>);
+      ) as _i14.Future<_i4.RoomKeys>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -8440,8 +8492,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8452,8 +8504,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8463,10 +8515,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8478,8 +8530,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8490,8 +8542,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8501,10 +8553,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8516,7 +8568,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
+        returnValue: _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8527,7 +8579,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
+            _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8537,10 +8589,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeyBackup>);
+      ) as _i14.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -8554,8 +8606,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8567,8 +8619,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8579,10 +8631,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8596,8 +8648,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8609,8 +8661,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8621,10 +8673,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i14.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8638,7 +8690,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8650,7 +8702,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8661,10 +8713,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.KeyBackupData>);
+      ) as _i14.Future<_i4.KeyBackupData>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8680,8 +8732,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8694,8 +8746,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8707,18 +8759,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_69(
+                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_70(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8726,18 +8778,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_69(
+                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_70(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i13.Future<String> postRoomKeysVersion(
+  _i14.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -8749,7 +8801,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8760,7 +8812,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8770,29 +8822,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i14.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i14.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_70(
+        returnValue: _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_71(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8800,18 +8852,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_70(
+            _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_71(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i14.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i14.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -8826,24 +8878,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i14.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i13.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
-      ) as _i13.Future<List<String>>);
+        returnValue: _i14.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
+      ) as _i14.Future<List<String>>);
 
   @override
-  _i13.Future<void> ban(
+  _i14.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8857,12 +8909,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.EventContext> getEventContext(
+  _i14.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -8880,7 +8932,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<_i4.EventContext>.value(_FakeEventContext_71(
+        returnValue: _i14.Future<_i4.EventContext>.value(_FakeEventContext_72(
           this,
           Invocation.method(
             #getEventContext,
@@ -8895,7 +8947,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.EventContext>.value(_FakeEventContext_71(
+            _i14.Future<_i4.EventContext>.value(_FakeEventContext_72(
           this,
           Invocation.method(
             #getEventContext,
@@ -8909,10 +8961,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.EventContext>);
+      ) as _i14.Future<_i4.EventContext>);
 
   @override
-  _i13.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i14.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -8924,7 +8976,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8935,7 +8987,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8945,20 +8997,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.MatrixEvent>);
+      ) as _i14.Future<_i4.MatrixEvent>);
 
   @override
-  _i13.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i14.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> inviteBy3PID(
+  _i14.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -8970,12 +9022,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> inviteUser(
+  _i14.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8989,12 +9041,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> joinRoomById(
+  _i14.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -9008,7 +9060,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9020,7 +9072,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9031,23 +9083,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i14.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i13.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i14.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i13.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i13.Future<Map<String, _i4.RoomMember>?>);
+            _i14.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i14.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i13.Future<void> kick(
+  _i14.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9061,12 +9113,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> leaveRoom(
+  _i14.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9076,12 +9128,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i14.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -9097,12 +9149,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i13.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i13.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i14.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i14.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i13.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i14.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -9124,8 +9176,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_72(
+        returnValue: _i14.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_73(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9141,8 +9193,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_72(
+        returnValueForMissingStub: _i14.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_73(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9158,10 +9210,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomEventsResponse>);
+      ) as _i14.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i13.Future<void> setReadMarker(
+  _i14.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9177,12 +9229,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> postReceipt(
+  _i14.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -9198,12 +9250,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEvent(
+  _i14.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9219,12 +9271,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> reportRoom(
+  _i14.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9236,12 +9288,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> reportEvent(
+  _i14.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9259,12 +9311,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> sendMessage(
+  _i14.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9280,7 +9332,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9293,7 +9345,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9305,23 +9357,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i14.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i13.Future<List<_i4.MatrixEvent>>);
+            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i14.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i14.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -9338,13 +9390,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<String> setRoomStateWithKey(
+  _i14.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9360,7 +9412,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9373,7 +9425,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9385,10 +9437,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> unban(
+  _i14.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9402,12 +9454,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> upgradeRoom(
+  _i14.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9421,7 +9473,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9433,7 +9485,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9444,10 +9496,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.SearchResults> search(
+  _i14.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -9457,7 +9509,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
+        returnValue: _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
           this,
           Invocation.method(
             #search,
@@ -9466,7 +9518,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
+            _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
           this,
           Invocation.method(
             #search,
@@ -9474,10 +9526,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i13.Future<_i4.SearchResults>);
+      ) as _i14.Future<_i4.SearchResults>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> sync({
+  _i14.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -9498,7 +9550,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #sync,
@@ -9514,7 +9566,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #sync,
@@ -9529,22 +9581,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i14.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i13.Future<List<_i4.Location>>);
+            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i14.Future<List<_i4.Location>>);
 
   @override
-  _i13.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i14.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9554,21 +9606,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i13.Future<List<_i4.Location>>);
+            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i14.Future<List<_i4.Location>>);
 
   @override
-  _i13.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i14.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_74(
+        returnValue: _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_75(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9576,45 +9628,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_74(
+            _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_75(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i13.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i14.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i13.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i14.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9625,13 +9677,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getAccountData(
+  _i14.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9644,13 +9696,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> setAccountData(
+  _i14.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9664,12 +9716,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> defineFilter(
+  _i14.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -9681,7 +9733,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9692,7 +9744,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9702,10 +9754,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.Filter> getFilter(
+  _i14.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9717,7 +9769,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i13.Future<_i4.Filter>.value(_FakeFilter_18(
+        returnValue: _i14.Future<_i4.Filter>.value(_FakeFilter_19(
           this,
           Invocation.method(
             #getFilter,
@@ -9727,7 +9779,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.Filter>.value(_FakeFilter_18(
+        returnValueForMissingStub: _i14.Future<_i4.Filter>.value(_FakeFilter_19(
           this,
           Invocation.method(
             #getFilter,
@@ -9737,10 +9789,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.Filter>);
+      ) as _i14.Future<_i4.Filter>);
 
   @override
-  _i13.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i14.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9753,7 +9805,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
+            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9764,7 +9816,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
+            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9774,10 +9826,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.OpenIdCredentials>);
+      ) as _i14.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i13.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i14.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9792,13 +9844,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> setAccountDataPerRoom(
+  _i14.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9814,12 +9866,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i14.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9831,12 +9883,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i13.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i13.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i13.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i14.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i14.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i14.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i13.Future<void> deleteRoomTag(
+  _i14.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9850,12 +9902,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setRoomTag(
+  _i14.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9871,12 +9923,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i14.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9886,8 +9938,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i13.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_76(
+        returnValue: _i14.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_77(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9896,8 +9948,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_76(
+            _i14.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_77(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9905,10 +9957,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i13.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i14.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> reportUser(
+  _i14.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -9921,40 +9973,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i14.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i13.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_77(
+        returnValue: _i14.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_78(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_77(
+        returnValueForMissingStub: _i14.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_78(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.CreateContentResponse>);
+      ) as _i14.Future<_i4.CreateContentResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> uploadContentToMXC(
+  _i14.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i23.Uint8List? body, {
+    _i24.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -9972,8 +10024,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 }

--- a/test/widgets/admin_settings_section_test.mocks.dart
+++ b/test/widgets/admin_settings_section_test.mocks.dart
@@ -1209,6 +1209,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -1715,6 +1722,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/avatar_edit_overlay_test.mocks.dart
+++ b/test/widgets/avatar_edit_overlay_test.mocks.dart
@@ -1084,6 +1084,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -1590,6 +1597,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/bootstrap_controller_test.mocks.dart
+++ b/test/widgets/bootstrap_controller_test.mocks.dart
@@ -4,34 +4,36 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i22;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i21;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i12;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i15;
-import 'package:matrix/encryption/cross_signing.dart' as _i18;
-import 'package:matrix/encryption/key_verification_manager.dart' as _i17;
-import 'package:matrix/encryption/olm_manager.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption/cross_signing.dart' as _i19;
+import 'package:matrix/encryption/key_verification_manager.dart' as _i18;
+import 'package:matrix/encryption/olm_manager.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -803,8 +805,9 @@ class _FakeSelectionService_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
-  _FakeSyncService_71(
+class _FakeSpaceAccessService_71 extends _i1.SmartFake
+    implements _i12.SpaceAccessService {
+  _FakeSpaceAccessService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -813,8 +816,8 @@ class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
         );
 }
 
-class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
-  _FakeAuthService_72(
+class _FakeSyncService_72 extends _i1.SmartFake implements _i13.SyncService {
+  _FakeSyncService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -823,9 +826,8 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeOutboxService_73 extends _i1.SmartFake
-    implements _i14.OutboxService {
-  _FakeOutboxService_73(
+class _FakeAuthService_73 extends _i1.SmartFake implements _i14.AuthService {
+  _FakeAuthService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -834,8 +836,9 @@ class _FakeOutboxService_73 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyManager_74 extends _i1.SmartFake implements _i15.KeyManager {
-  _FakeKeyManager_74(
+class _FakeOutboxService_74 extends _i1.SmartFake
+    implements _i15.OutboxService {
+  _FakeOutboxService_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -844,8 +847,8 @@ class _FakeKeyManager_74 extends _i1.SmartFake implements _i15.KeyManager {
         );
 }
 
-class _FakeOlmManager_75 extends _i1.SmartFake implements _i16.OlmManager {
-  _FakeOlmManager_75(
+class _FakeKeyManager_75 extends _i1.SmartFake implements _i16.KeyManager {
+  _FakeKeyManager_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -854,9 +857,8 @@ class _FakeOlmManager_75 extends _i1.SmartFake implements _i16.OlmManager {
         );
 }
 
-class _FakeKeyVerificationManager_76 extends _i1.SmartFake
-    implements _i17.KeyVerificationManager {
-  _FakeKeyVerificationManager_76(
+class _FakeOlmManager_76 extends _i1.SmartFake implements _i17.OlmManager {
+  _FakeOlmManager_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -865,8 +867,9 @@ class _FakeKeyVerificationManager_76 extends _i1.SmartFake
         );
 }
 
-class _FakeCrossSigning_77 extends _i1.SmartFake implements _i18.CrossSigning {
-  _FakeCrossSigning_77(
+class _FakeKeyVerificationManager_77 extends _i1.SmartFake
+    implements _i18.KeyVerificationManager {
+  _FakeKeyVerificationManager_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -875,8 +878,8 @@ class _FakeCrossSigning_77 extends _i1.SmartFake implements _i18.CrossSigning {
         );
 }
 
-class _FakeSSSS_78 extends _i1.SmartFake implements _i15.SSSS {
-  _FakeSSSS_78(
+class _FakeCrossSigning_78 extends _i1.SmartFake implements _i19.CrossSigning {
+  _FakeCrossSigning_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -885,8 +888,8 @@ class _FakeSSSS_78 extends _i1.SmartFake implements _i15.SSSS {
         );
 }
 
-class _FakeBootstrap_79 extends _i1.SmartFake implements _i15.Bootstrap {
-  _FakeBootstrap_79(
+class _FakeSSSS_79 extends _i1.SmartFake implements _i16.SSSS {
+  _FakeSSSS_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -895,8 +898,8 @@ class _FakeBootstrap_79 extends _i1.SmartFake implements _i15.Bootstrap {
         );
 }
 
-class _FakeToDeviceEvent_80 extends _i1.SmartFake implements _i2.ToDeviceEvent {
-  _FakeToDeviceEvent_80(
+class _FakeBootstrap_80 extends _i1.SmartFake implements _i16.Bootstrap {
+  _FakeBootstrap_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -905,8 +908,8 @@ class _FakeToDeviceEvent_80 extends _i1.SmartFake implements _i2.ToDeviceEvent {
         );
 }
 
-class _FakeEvent_81 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_81(
+class _FakeToDeviceEvent_81 extends _i1.SmartFake implements _i2.ToDeviceEvent {
+  _FakeToDeviceEvent_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -915,8 +918,8 @@ class _FakeEvent_81 extends _i1.SmartFake implements _i2.Event {
         );
 }
 
-class _FakeEncryption_82 extends _i1.SmartFake implements _i15.Encryption {
-  _FakeEncryption_82(
+class _FakeEvent_82 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -925,9 +928,19 @@ class _FakeEncryption_82 extends _i1.SmartFake implements _i15.Encryption {
         );
 }
 
-class _FakeSecretStorageKeyContent_83 extends _i1.SmartFake
+class _FakeEncryption_83 extends _i1.SmartFake implements _i16.Encryption {
+  _FakeEncryption_83(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeSecretStorageKeyContent_84 extends _i1.SmartFake
     implements _i2.SecretStorageKeyContent {
-  _FakeSecretStorageKeyContent_83(
+  _FakeSecretStorageKeyContent_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -954,12 +967,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i15.KeyVerificationMethod> get verificationMethods =>
+  Set<_i16.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i15.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
-      ) as Set<_i15.KeyVerificationMethod>);
+        returnValue: <_i16.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
+      ) as Set<_i16.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1079,11 +1092,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1120,11 +1133,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1154,11 +1167,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1167,11 +1180,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1457,34 +1470,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i15.KeyVerification>
+  _i3.CachedStreamController<_i16.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i15.KeyVerification>(
+                _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i15.KeyVerification>);
+          ) as _i3.CachedStreamController<_i16.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1640,7 +1653,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1929,14 +1942,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2324,8 +2337,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2341,8 +2354,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2383,7 +2396,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2399,7 +2412,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2448,7 +2461,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2469,7 +2482,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2572,7 +2585,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2590,7 +2603,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3109,7 +3122,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3461,7 +3474,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3475,7 +3488,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3626,7 +3639,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5004,7 +5017,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5026,7 +5039,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5520,7 +5533,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5532,7 +5545,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6540,7 +6553,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6551,7 +6564,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6799,7 +6812,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6811,7 +6824,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7071,7 +7084,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7084,7 +7097,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7151,7 +7164,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7164,7 +7177,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7212,7 +7225,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7224,7 +7237,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7472,7 +7485,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7483,7 +7496,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7745,7 +7758,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7772,7 +7785,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7802,11 +7815,11 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7879,43 +7892,56 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i11.SelectionService);
 
   @override
-  _i12.SyncService get sync => (super.noSuchMethod(
+  _i12.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i12.SpaceAccessService);
+
+  @override
+  _i13.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_71(
+        returnValue: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_71(
+        returnValueForMissingStub: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i12.SyncService);
+      ) as _i13.SyncService);
 
   @override
-  _i13.AuthService get auth => (super.noSuchMethod(
+  _i14.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_72(
+        returnValue: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_72(
+        returnValueForMissingStub: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i13.AuthService);
+      ) as _i14.AuthService);
 
   @override
-  _i14.OutboxService get outbox => (super.noSuchMethod(
+  _i15.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_73(
+        returnValue: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_73(
+        returnValueForMissingStub: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i14.OutboxService);
+      ) as _i15.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7979,7 +8005,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set sync(_i12.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i12.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i13.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7988,7 +8023,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set auth(_i13.AuthService? value) => super.noSuchMethod(
+  set auth(_i14.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7997,7 +8032,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i15.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -8050,7 +8085,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8144,7 +8179,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8153,7 +8188,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8172,7 +8207,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8183,7 +8218,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8231,7 +8266,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8269,7 +8304,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8278,7 +8313,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8287,16 +8322,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i5.Future<_i22.AppExitResponse>);
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i5.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8382,7 +8417,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> runKeyRecovery({_i15.OpenSSSS? ssssKey}) =>
+  _i5.Future<void> runKeyRecovery({_i16.OpenSSSS? ssssKey}) =>
       (super.noSuchMethod(
         Invocation.method(
           #runKeyRecovery,
@@ -8436,7 +8471,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8445,7 +8480,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8475,7 +8510,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
 /// A class which mocks [Encryption].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEncryption extends _i1.Mock implements _i15.Encryption {
+class MockEncryption extends _i1.Mock implements _i16.Encryption {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -8504,85 +8539,85 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
       ) as bool);
 
   @override
-  _i15.KeyManager get keyManager => (super.noSuchMethod(
+  _i16.KeyManager get keyManager => (super.noSuchMethod(
         Invocation.getter(#keyManager),
-        returnValue: _FakeKeyManager_74(
+        returnValue: _FakeKeyManager_75(
           this,
           Invocation.getter(#keyManager),
         ),
-        returnValueForMissingStub: _FakeKeyManager_74(
+        returnValueForMissingStub: _FakeKeyManager_75(
           this,
           Invocation.getter(#keyManager),
         ),
-      ) as _i15.KeyManager);
+      ) as _i16.KeyManager);
 
   @override
-  _i16.OlmManager get olmManager => (super.noSuchMethod(
+  _i17.OlmManager get olmManager => (super.noSuchMethod(
         Invocation.getter(#olmManager),
-        returnValue: _FakeOlmManager_75(
+        returnValue: _FakeOlmManager_76(
           this,
           Invocation.getter(#olmManager),
         ),
-        returnValueForMissingStub: _FakeOlmManager_75(
+        returnValueForMissingStub: _FakeOlmManager_76(
           this,
           Invocation.getter(#olmManager),
         ),
-      ) as _i16.OlmManager);
+      ) as _i17.OlmManager);
 
   @override
-  _i17.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
+  _i18.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
         Invocation.getter(#keyVerificationManager),
-        returnValue: _FakeKeyVerificationManager_76(
+        returnValue: _FakeKeyVerificationManager_77(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-        returnValueForMissingStub: _FakeKeyVerificationManager_76(
+        returnValueForMissingStub: _FakeKeyVerificationManager_77(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-      ) as _i17.KeyVerificationManager);
+      ) as _i18.KeyVerificationManager);
 
   @override
-  _i18.CrossSigning get crossSigning => (super.noSuchMethod(
+  _i19.CrossSigning get crossSigning => (super.noSuchMethod(
         Invocation.getter(#crossSigning),
-        returnValue: _FakeCrossSigning_77(
+        returnValue: _FakeCrossSigning_78(
           this,
           Invocation.getter(#crossSigning),
         ),
-        returnValueForMissingStub: _FakeCrossSigning_77(
+        returnValueForMissingStub: _FakeCrossSigning_78(
           this,
           Invocation.getter(#crossSigning),
         ),
-      ) as _i18.CrossSigning);
+      ) as _i19.CrossSigning);
 
   @override
-  _i15.SSSS get ssss => (super.noSuchMethod(
+  _i16.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_78(
+        returnValue: _FakeSSSS_79(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_78(
+        returnValueForMissingStub: _FakeSSSS_79(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i15.SSSS);
+      ) as _i16.SSSS);
 
   @override
   String get ourDeviceId => (super.noSuchMethod(
         Invocation.getter(#ourDeviceId),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
       ) as String);
 
   @override
-  set keyManager(_i15.KeyManager? value) => super.noSuchMethod(
+  set keyManager(_i16.KeyManager? value) => super.noSuchMethod(
         Invocation.setter(
           #keyManager,
           value,
@@ -8591,7 +8626,7 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
       );
 
   @override
-  set olmManager(_i16.OlmManager? value) => super.noSuchMethod(
+  set olmManager(_i17.OlmManager? value) => super.noSuchMethod(
         Invocation.setter(
           #olmManager,
           value,
@@ -8600,7 +8635,7 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
       );
 
   @override
-  set keyVerificationManager(_i17.KeyVerificationManager? value) =>
+  set keyVerificationManager(_i18.KeyVerificationManager? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #keyVerificationManager,
@@ -8610,7 +8645,7 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
       );
 
   @override
-  set crossSigning(_i18.CrossSigning? value) => super.noSuchMethod(
+  set crossSigning(_i19.CrossSigning? value) => super.noSuchMethod(
         Invocation.setter(
           #crossSigning,
           value,
@@ -8619,7 +8654,7 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
       );
 
   @override
-  set ssss(_i15.SSSS? value) => super.noSuchMethod(
+  set ssss(_i16.SSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #ssss,
           value,
@@ -8658,14 +8693,14 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
       ) as _i5.Future<void>);
 
   @override
-  _i15.Bootstrap bootstrap({void Function(_i15.Bootstrap)? onUpdate}) =>
+  _i16.Bootstrap bootstrap({void Function(_i16.Bootstrap)? onUpdate}) =>
       (super.noSuchMethod(
         Invocation.method(
           #bootstrap,
           [],
           {#onUpdate: onUpdate},
         ),
-        returnValue: _FakeBootstrap_79(
+        returnValue: _FakeBootstrap_80(
           this,
           Invocation.method(
             #bootstrap,
@@ -8673,7 +8708,7 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-        returnValueForMissingStub: _FakeBootstrap_79(
+        returnValueForMissingStub: _FakeBootstrap_80(
           this,
           Invocation.method(
             #bootstrap,
@@ -8681,7 +8716,7 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-      ) as _i15.Bootstrap);
+      ) as _i16.Bootstrap);
 
   @override
   void handleDeviceOneTimeKeysCount(
@@ -8744,7 +8779,7 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
           #decryptToDeviceEvent,
           [event],
         ),
-        returnValue: _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_80(
+        returnValue: _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_81(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -8752,7 +8787,7 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_80(
+            _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_81(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -8767,14 +8802,14 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
           #decryptRoomEventSync,
           [event],
         ),
-        returnValue: _FakeEvent_81(
+        returnValue: _FakeEvent_82(
           this,
           Invocation.method(
             #decryptRoomEventSync,
             [event],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_81(
+        returnValueForMissingStub: _FakeEvent_82(
           this,
           Invocation.method(
             #decryptRoomEventSync,
@@ -8798,7 +8833,7 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
             #updateType: updateType,
           },
         ),
-        returnValue: _i5.Future<_i2.Event>.value(_FakeEvent_81(
+        returnValue: _i5.Future<_i2.Event>.value(_FakeEvent_82(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -8809,7 +8844,7 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
             },
           ),
         )),
-        returnValueForMissingStub: _i5.Future<_i2.Event>.value(_FakeEvent_81(
+        returnValueForMissingStub: _i5.Future<_i2.Event>.value(_FakeEvent_82(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -8891,19 +8926,19 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
 /// A class which mocks [Bootstrap].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBootstrap extends _i1.Mock implements _i15.Bootstrap {
+class MockBootstrap extends _i1.Mock implements _i16.Bootstrap {
   @override
-  _i15.Encryption get encryption => (super.noSuchMethod(
+  _i16.Encryption get encryption => (super.noSuchMethod(
         Invocation.getter(#encryption),
-        returnValue: _FakeEncryption_82(
+        returnValue: _FakeEncryption_83(
           this,
           Invocation.getter(#encryption),
         ),
-        returnValueForMissingStub: _FakeEncryption_82(
+        returnValueForMissingStub: _FakeEncryption_83(
           this,
           Invocation.getter(#encryption),
         ),
-      ) as _i15.Encryption);
+      ) as _i16.Encryption);
 
   @override
   _i2.Client get client => (super.noSuchMethod(
@@ -8919,14 +8954,14 @@ class MockBootstrap extends _i1.Mock implements _i15.Bootstrap {
       ) as _i2.Client);
 
   @override
-  _i15.BootstrapState get state => (super.noSuchMethod(
+  _i16.BootstrapState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i15.BootstrapState.loading,
-        returnValueForMissingStub: _i15.BootstrapState.loading,
-      ) as _i15.BootstrapState);
+        returnValue: _i16.BootstrapState.loading,
+        returnValueForMissingStub: _i16.BootstrapState.loading,
+      ) as _i16.BootstrapState);
 
   @override
-  set onUpdate(void Function(_i15.Bootstrap)? value) => super.noSuchMethod(
+  set onUpdate(void Function(_i16.Bootstrap)? value) => super.noSuchMethod(
         Invocation.setter(
           #onUpdate,
           value,
@@ -8935,7 +8970,7 @@ class MockBootstrap extends _i1.Mock implements _i15.Bootstrap {
       );
 
   @override
-  set oldSsssKeys(Map<String, _i15.OpenSSSS>? value) => super.noSuchMethod(
+  set oldSsssKeys(Map<String, _i16.OpenSSSS>? value) => super.noSuchMethod(
         Invocation.setter(
           #oldSsssKeys,
           value,
@@ -8944,7 +8979,7 @@ class MockBootstrap extends _i1.Mock implements _i15.Bootstrap {
       );
 
   @override
-  set newSsssKey(_i15.OpenSSSS? value) => super.noSuchMethod(
+  set newSsssKey(_i16.OpenSSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #newSsssKey,
           value,
@@ -8962,7 +8997,7 @@ class MockBootstrap extends _i1.Mock implements _i15.Bootstrap {
       );
 
   @override
-  set state(_i15.BootstrapState? newState) => super.noSuchMethod(
+  set state(_i16.BootstrapState? newState) => super.noSuchMethod(
         Invocation.setter(
           #state,
           newState,
@@ -8996,14 +9031,14 @@ class MockBootstrap extends _i1.Mock implements _i15.Bootstrap {
           #mostUsedKey,
           [secrets],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
             [secrets],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
@@ -9170,28 +9205,28 @@ class MockBootstrap extends _i1.Mock implements _i15.Bootstrap {
 /// A class which mocks [OpenSSSS].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockOpenSSSS extends _i1.Mock implements _i15.OpenSSSS {
+class MockOpenSSSS extends _i1.Mock implements _i16.OpenSSSS {
   @override
-  _i15.SSSS get ssss => (super.noSuchMethod(
+  _i16.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_78(
+        returnValue: _FakeSSSS_79(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_78(
+        returnValueForMissingStub: _FakeSSSS_79(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i15.SSSS);
+      ) as _i16.SSSS);
 
   @override
   String get keyId => (super.noSuchMethod(
         Invocation.getter(#keyId),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#keyId),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#keyId),
         ),
@@ -9200,11 +9235,11 @@ class MockOpenSSSS extends _i1.Mock implements _i15.OpenSSSS {
   @override
   _i2.SecretStorageKeyContent get keyData => (super.noSuchMethod(
         Invocation.getter(#keyData),
-        returnValue: _FakeSecretStorageKeyContent_83(
+        returnValue: _FakeSecretStorageKeyContent_84(
           this,
           Invocation.getter(#keyData),
         ),
-        returnValueForMissingStub: _FakeSecretStorageKeyContent_83(
+        returnValueForMissingStub: _FakeSecretStorageKeyContent_84(
           this,
           Invocation.getter(#keyData),
         ),
@@ -9225,7 +9260,7 @@ class MockOpenSSSS extends _i1.Mock implements _i15.OpenSSSS {
       ) as bool);
 
   @override
-  set privateKey(_i20.Uint8List? value) => super.noSuchMethod(
+  set privateKey(_i21.Uint8List? value) => super.noSuchMethod(
         Invocation.setter(
           #privateKey,
           value,
@@ -9256,7 +9291,7 @@ class MockOpenSSSS extends _i1.Mock implements _i15.OpenSSSS {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setPrivateKey(_i20.Uint8List? key) => (super.noSuchMethod(
+  _i5.Future<void> setPrivateKey(_i21.Uint8List? key) => (super.noSuchMethod(
         Invocation.method(
           #setPrivateKey,
           [key],
@@ -9271,7 +9306,7 @@ class MockOpenSSSS extends _i1.Mock implements _i15.OpenSSSS {
           #getStored,
           [type],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #getStored,
@@ -9279,7 +9314,7 @@ class MockOpenSSSS extends _i1.Mock implements _i15.OpenSSSS {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #getStored,

--- a/test/widgets/bootstrap_driver_test.mocks.dart
+++ b/test/widgets/bootstrap_driver_test.mocks.dart
@@ -4,34 +4,36 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i22;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i21;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i12;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i15;
-import 'package:matrix/encryption/cross_signing.dart' as _i18;
-import 'package:matrix/encryption/key_verification_manager.dart' as _i17;
-import 'package:matrix/encryption/olm_manager.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption/cross_signing.dart' as _i19;
+import 'package:matrix/encryption/key_verification_manager.dart' as _i18;
+import 'package:matrix/encryption/olm_manager.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -803,8 +805,9 @@ class _FakeSelectionService_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
-  _FakeSyncService_71(
+class _FakeSpaceAccessService_71 extends _i1.SmartFake
+    implements _i12.SpaceAccessService {
+  _FakeSpaceAccessService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -813,8 +816,8 @@ class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
         );
 }
 
-class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
-  _FakeAuthService_72(
+class _FakeSyncService_72 extends _i1.SmartFake implements _i13.SyncService {
+  _FakeSyncService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -823,9 +826,8 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeOutboxService_73 extends _i1.SmartFake
-    implements _i14.OutboxService {
-  _FakeOutboxService_73(
+class _FakeAuthService_73 extends _i1.SmartFake implements _i14.AuthService {
+  _FakeAuthService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -834,8 +836,9 @@ class _FakeOutboxService_73 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyManager_74 extends _i1.SmartFake implements _i15.KeyManager {
-  _FakeKeyManager_74(
+class _FakeOutboxService_74 extends _i1.SmartFake
+    implements _i15.OutboxService {
+  _FakeOutboxService_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -844,8 +847,8 @@ class _FakeKeyManager_74 extends _i1.SmartFake implements _i15.KeyManager {
         );
 }
 
-class _FakeOlmManager_75 extends _i1.SmartFake implements _i16.OlmManager {
-  _FakeOlmManager_75(
+class _FakeKeyManager_75 extends _i1.SmartFake implements _i16.KeyManager {
+  _FakeKeyManager_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -854,9 +857,8 @@ class _FakeOlmManager_75 extends _i1.SmartFake implements _i16.OlmManager {
         );
 }
 
-class _FakeKeyVerificationManager_76 extends _i1.SmartFake
-    implements _i17.KeyVerificationManager {
-  _FakeKeyVerificationManager_76(
+class _FakeOlmManager_76 extends _i1.SmartFake implements _i17.OlmManager {
+  _FakeOlmManager_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -865,8 +867,9 @@ class _FakeKeyVerificationManager_76 extends _i1.SmartFake
         );
 }
 
-class _FakeCrossSigning_77 extends _i1.SmartFake implements _i18.CrossSigning {
-  _FakeCrossSigning_77(
+class _FakeKeyVerificationManager_77 extends _i1.SmartFake
+    implements _i18.KeyVerificationManager {
+  _FakeKeyVerificationManager_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -875,8 +878,8 @@ class _FakeCrossSigning_77 extends _i1.SmartFake implements _i18.CrossSigning {
         );
 }
 
-class _FakeSSSS_78 extends _i1.SmartFake implements _i15.SSSS {
-  _FakeSSSS_78(
+class _FakeCrossSigning_78 extends _i1.SmartFake implements _i19.CrossSigning {
+  _FakeCrossSigning_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -885,8 +888,8 @@ class _FakeSSSS_78 extends _i1.SmartFake implements _i15.SSSS {
         );
 }
 
-class _FakeBootstrap_79 extends _i1.SmartFake implements _i15.Bootstrap {
-  _FakeBootstrap_79(
+class _FakeSSSS_79 extends _i1.SmartFake implements _i16.SSSS {
+  _FakeSSSS_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -895,8 +898,8 @@ class _FakeBootstrap_79 extends _i1.SmartFake implements _i15.Bootstrap {
         );
 }
 
-class _FakeToDeviceEvent_80 extends _i1.SmartFake implements _i2.ToDeviceEvent {
-  _FakeToDeviceEvent_80(
+class _FakeBootstrap_80 extends _i1.SmartFake implements _i16.Bootstrap {
+  _FakeBootstrap_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -905,8 +908,8 @@ class _FakeToDeviceEvent_80 extends _i1.SmartFake implements _i2.ToDeviceEvent {
         );
 }
 
-class _FakeEvent_81 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_81(
+class _FakeToDeviceEvent_81 extends _i1.SmartFake implements _i2.ToDeviceEvent {
+  _FakeToDeviceEvent_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -915,8 +918,18 @@ class _FakeEvent_81 extends _i1.SmartFake implements _i2.Event {
         );
 }
 
-class _FakeEncryption_82 extends _i1.SmartFake implements _i15.Encryption {
-  _FakeEncryption_82(
+class _FakeEvent_82 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_82(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeEncryption_83 extends _i1.SmartFake implements _i16.Encryption {
+  _FakeEncryption_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -943,12 +956,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i15.KeyVerificationMethod> get verificationMethods =>
+  Set<_i16.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i15.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
-      ) as Set<_i15.KeyVerificationMethod>);
+        returnValue: <_i16.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
+      ) as Set<_i16.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1068,11 +1081,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1109,11 +1122,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1143,11 +1156,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1156,11 +1169,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1446,34 +1459,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i15.KeyVerification>
+  _i3.CachedStreamController<_i16.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i15.KeyVerification>(
+                _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i15.KeyVerification>);
+          ) as _i3.CachedStreamController<_i16.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1629,7 +1642,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1918,14 +1931,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2313,8 +2326,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2330,8 +2343,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2372,7 +2385,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2388,7 +2401,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2437,7 +2450,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2458,7 +2471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2561,7 +2574,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2579,7 +2592,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3098,7 +3111,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3450,7 +3463,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3464,7 +3477,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3615,7 +3628,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4993,7 +5006,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5015,7 +5028,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5509,7 +5522,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5521,7 +5534,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6529,7 +6542,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6540,7 +6553,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6788,7 +6801,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6800,7 +6813,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7060,7 +7073,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7073,7 +7086,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7140,7 +7153,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7153,7 +7166,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7201,7 +7214,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7213,7 +7226,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7461,7 +7474,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7472,7 +7485,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i19.dummyValue<String>(
+            _i5.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7734,7 +7747,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7761,7 +7774,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7791,11 +7804,11 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7868,43 +7881,56 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i11.SelectionService);
 
   @override
-  _i12.SyncService get sync => (super.noSuchMethod(
+  _i12.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i12.SpaceAccessService);
+
+  @override
+  _i13.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_71(
+        returnValue: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_71(
+        returnValueForMissingStub: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i12.SyncService);
+      ) as _i13.SyncService);
 
   @override
-  _i13.AuthService get auth => (super.noSuchMethod(
+  _i14.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_72(
+        returnValue: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_72(
+        returnValueForMissingStub: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i13.AuthService);
+      ) as _i14.AuthService);
 
   @override
-  _i14.OutboxService get outbox => (super.noSuchMethod(
+  _i15.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_73(
+        returnValue: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_73(
+        returnValueForMissingStub: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i14.OutboxService);
+      ) as _i15.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7968,7 +7994,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set sync(_i12.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i12.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i13.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7977,7 +8012,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set auth(_i13.AuthService? value) => super.noSuchMethod(
+  set auth(_i14.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7986,7 +8021,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i15.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -8039,7 +8074,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8133,7 +8168,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8142,7 +8177,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8161,7 +8196,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8172,7 +8207,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8220,7 +8255,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8258,7 +8293,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8267,7 +8302,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8276,16 +8311,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i5.Future<_i22.AppExitResponse>);
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i5.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8309,7 +8344,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 /// A class which mocks [Encryption].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEncryption extends _i1.Mock implements _i15.Encryption {
+class MockEncryption extends _i1.Mock implements _i16.Encryption {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -8338,85 +8373,85 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
       ) as bool);
 
   @override
-  _i15.KeyManager get keyManager => (super.noSuchMethod(
+  _i16.KeyManager get keyManager => (super.noSuchMethod(
         Invocation.getter(#keyManager),
-        returnValue: _FakeKeyManager_74(
+        returnValue: _FakeKeyManager_75(
           this,
           Invocation.getter(#keyManager),
         ),
-        returnValueForMissingStub: _FakeKeyManager_74(
+        returnValueForMissingStub: _FakeKeyManager_75(
           this,
           Invocation.getter(#keyManager),
         ),
-      ) as _i15.KeyManager);
+      ) as _i16.KeyManager);
 
   @override
-  _i16.OlmManager get olmManager => (super.noSuchMethod(
+  _i17.OlmManager get olmManager => (super.noSuchMethod(
         Invocation.getter(#olmManager),
-        returnValue: _FakeOlmManager_75(
+        returnValue: _FakeOlmManager_76(
           this,
           Invocation.getter(#olmManager),
         ),
-        returnValueForMissingStub: _FakeOlmManager_75(
+        returnValueForMissingStub: _FakeOlmManager_76(
           this,
           Invocation.getter(#olmManager),
         ),
-      ) as _i16.OlmManager);
+      ) as _i17.OlmManager);
 
   @override
-  _i17.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
+  _i18.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
         Invocation.getter(#keyVerificationManager),
-        returnValue: _FakeKeyVerificationManager_76(
+        returnValue: _FakeKeyVerificationManager_77(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-        returnValueForMissingStub: _FakeKeyVerificationManager_76(
+        returnValueForMissingStub: _FakeKeyVerificationManager_77(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-      ) as _i17.KeyVerificationManager);
+      ) as _i18.KeyVerificationManager);
 
   @override
-  _i18.CrossSigning get crossSigning => (super.noSuchMethod(
+  _i19.CrossSigning get crossSigning => (super.noSuchMethod(
         Invocation.getter(#crossSigning),
-        returnValue: _FakeCrossSigning_77(
+        returnValue: _FakeCrossSigning_78(
           this,
           Invocation.getter(#crossSigning),
         ),
-        returnValueForMissingStub: _FakeCrossSigning_77(
+        returnValueForMissingStub: _FakeCrossSigning_78(
           this,
           Invocation.getter(#crossSigning),
         ),
-      ) as _i18.CrossSigning);
+      ) as _i19.CrossSigning);
 
   @override
-  _i15.SSSS get ssss => (super.noSuchMethod(
+  _i16.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_78(
+        returnValue: _FakeSSSS_79(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_78(
+        returnValueForMissingStub: _FakeSSSS_79(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i15.SSSS);
+      ) as _i16.SSSS);
 
   @override
   String get ourDeviceId => (super.noSuchMethod(
         Invocation.getter(#ourDeviceId),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
       ) as String);
 
   @override
-  set keyManager(_i15.KeyManager? value) => super.noSuchMethod(
+  set keyManager(_i16.KeyManager? value) => super.noSuchMethod(
         Invocation.setter(
           #keyManager,
           value,
@@ -8425,7 +8460,7 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
       );
 
   @override
-  set olmManager(_i16.OlmManager? value) => super.noSuchMethod(
+  set olmManager(_i17.OlmManager? value) => super.noSuchMethod(
         Invocation.setter(
           #olmManager,
           value,
@@ -8434,7 +8469,7 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
       );
 
   @override
-  set keyVerificationManager(_i17.KeyVerificationManager? value) =>
+  set keyVerificationManager(_i18.KeyVerificationManager? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #keyVerificationManager,
@@ -8444,7 +8479,7 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
       );
 
   @override
-  set crossSigning(_i18.CrossSigning? value) => super.noSuchMethod(
+  set crossSigning(_i19.CrossSigning? value) => super.noSuchMethod(
         Invocation.setter(
           #crossSigning,
           value,
@@ -8453,7 +8488,7 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
       );
 
   @override
-  set ssss(_i15.SSSS? value) => super.noSuchMethod(
+  set ssss(_i16.SSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #ssss,
           value,
@@ -8492,14 +8527,14 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
       ) as _i5.Future<void>);
 
   @override
-  _i15.Bootstrap bootstrap({void Function(_i15.Bootstrap)? onUpdate}) =>
+  _i16.Bootstrap bootstrap({void Function(_i16.Bootstrap)? onUpdate}) =>
       (super.noSuchMethod(
         Invocation.method(
           #bootstrap,
           [],
           {#onUpdate: onUpdate},
         ),
-        returnValue: _FakeBootstrap_79(
+        returnValue: _FakeBootstrap_80(
           this,
           Invocation.method(
             #bootstrap,
@@ -8507,7 +8542,7 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-        returnValueForMissingStub: _FakeBootstrap_79(
+        returnValueForMissingStub: _FakeBootstrap_80(
           this,
           Invocation.method(
             #bootstrap,
@@ -8515,7 +8550,7 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-      ) as _i15.Bootstrap);
+      ) as _i16.Bootstrap);
 
   @override
   void handleDeviceOneTimeKeysCount(
@@ -8578,7 +8613,7 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
           #decryptToDeviceEvent,
           [event],
         ),
-        returnValue: _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_80(
+        returnValue: _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_81(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -8586,7 +8621,7 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_80(
+            _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_81(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -8601,14 +8636,14 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
           #decryptRoomEventSync,
           [event],
         ),
-        returnValue: _FakeEvent_81(
+        returnValue: _FakeEvent_82(
           this,
           Invocation.method(
             #decryptRoomEventSync,
             [event],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_81(
+        returnValueForMissingStub: _FakeEvent_82(
           this,
           Invocation.method(
             #decryptRoomEventSync,
@@ -8632,7 +8667,7 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
             #updateType: updateType,
           },
         ),
-        returnValue: _i5.Future<_i2.Event>.value(_FakeEvent_81(
+        returnValue: _i5.Future<_i2.Event>.value(_FakeEvent_82(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -8643,7 +8678,7 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
             },
           ),
         )),
-        returnValueForMissingStub: _i5.Future<_i2.Event>.value(_FakeEvent_81(
+        returnValueForMissingStub: _i5.Future<_i2.Event>.value(_FakeEvent_82(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -8725,19 +8760,19 @@ class MockEncryption extends _i1.Mock implements _i15.Encryption {
 /// A class which mocks [Bootstrap].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBootstrap extends _i1.Mock implements _i15.Bootstrap {
+class MockBootstrap extends _i1.Mock implements _i16.Bootstrap {
   @override
-  _i15.Encryption get encryption => (super.noSuchMethod(
+  _i16.Encryption get encryption => (super.noSuchMethod(
         Invocation.getter(#encryption),
-        returnValue: _FakeEncryption_82(
+        returnValue: _FakeEncryption_83(
           this,
           Invocation.getter(#encryption),
         ),
-        returnValueForMissingStub: _FakeEncryption_82(
+        returnValueForMissingStub: _FakeEncryption_83(
           this,
           Invocation.getter(#encryption),
         ),
-      ) as _i15.Encryption);
+      ) as _i16.Encryption);
 
   @override
   _i2.Client get client => (super.noSuchMethod(
@@ -8753,14 +8788,14 @@ class MockBootstrap extends _i1.Mock implements _i15.Bootstrap {
       ) as _i2.Client);
 
   @override
-  _i15.BootstrapState get state => (super.noSuchMethod(
+  _i16.BootstrapState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i15.BootstrapState.loading,
-        returnValueForMissingStub: _i15.BootstrapState.loading,
-      ) as _i15.BootstrapState);
+        returnValue: _i16.BootstrapState.loading,
+        returnValueForMissingStub: _i16.BootstrapState.loading,
+      ) as _i16.BootstrapState);
 
   @override
-  set onUpdate(void Function(_i15.Bootstrap)? value) => super.noSuchMethod(
+  set onUpdate(void Function(_i16.Bootstrap)? value) => super.noSuchMethod(
         Invocation.setter(
           #onUpdate,
           value,
@@ -8769,7 +8804,7 @@ class MockBootstrap extends _i1.Mock implements _i15.Bootstrap {
       );
 
   @override
-  set oldSsssKeys(Map<String, _i15.OpenSSSS>? value) => super.noSuchMethod(
+  set oldSsssKeys(Map<String, _i16.OpenSSSS>? value) => super.noSuchMethod(
         Invocation.setter(
           #oldSsssKeys,
           value,
@@ -8778,7 +8813,7 @@ class MockBootstrap extends _i1.Mock implements _i15.Bootstrap {
       );
 
   @override
-  set newSsssKey(_i15.OpenSSSS? value) => super.noSuchMethod(
+  set newSsssKey(_i16.OpenSSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #newSsssKey,
           value,
@@ -8796,7 +8831,7 @@ class MockBootstrap extends _i1.Mock implements _i15.Bootstrap {
       );
 
   @override
-  set state(_i15.BootstrapState? newState) => super.noSuchMethod(
+  set state(_i16.BootstrapState? newState) => super.noSuchMethod(
         Invocation.setter(
           #state,
           newState,
@@ -8830,14 +8865,14 @@ class MockBootstrap extends _i1.Mock implements _i15.Bootstrap {
           #mostUsedKey,
           [secrets],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
             [secrets],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,

--- a/test/widgets/call_event_tile_test.mocks.dart
+++ b/test/widgets/call_event_tile_test.mocks.dart
@@ -2360,6 +2360,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -2866,6 +2873,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/chat/compose_bar_test.mocks.dart
+++ b/test/widgets/chat/compose_bar_test.mocks.dart
@@ -1095,6 +1095,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -1601,6 +1608,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/chat/html_message_text_test.mocks.dart
+++ b/test/widgets/chat/html_message_text_test.mocks.dart
@@ -1094,6 +1094,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -1600,6 +1607,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/chat/mention_autocomplete_controller_test.mocks.dart
+++ b/test/widgets/chat/mention_autocomplete_controller_test.mocks.dart
@@ -1094,6 +1094,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -1600,6 +1607,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/chat/message_action_sheet_test.mocks.dart
+++ b/test/widgets/chat/message_action_sheet_test.mocks.dart
@@ -2402,6 +2402,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -2908,6 +2915,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i6.Future<void>.value(),
         returnValueForMissingStub: _i6.Future<void>.value(),

--- a/test/widgets/chat/message_actions_test.mocks.dart
+++ b/test/widgets/chat/message_actions_test.mocks.dart
@@ -4,33 +4,35 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i12;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i15;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i16;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i23;
+import 'package:matrix/src/utils/space_child.dart' as _i24;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -802,8 +804,9 @@ class _FakeSelectionService_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
-  _FakeSyncService_71(
+class _FakeSpaceAccessService_71 extends _i1.SmartFake
+    implements _i12.SpaceAccessService {
+  _FakeSpaceAccessService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -812,8 +815,8 @@ class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
         );
 }
 
-class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
-  _FakeAuthService_72(
+class _FakeSyncService_72 extends _i1.SmartFake implements _i13.SyncService {
+  _FakeSyncService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -822,9 +825,8 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeOutboxService_73 extends _i1.SmartFake
-    implements _i14.OutboxService {
-  _FakeOutboxService_73(
+class _FakeAuthService_73 extends _i1.SmartFake implements _i14.AuthService {
+  _FakeAuthService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -833,8 +835,9 @@ class _FakeOutboxService_73 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_74(
+class _FakeOutboxService_74 extends _i1.SmartFake
+    implements _i15.OutboxService {
+  _FakeOutboxService_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -843,9 +846,19 @@ class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_75 extends _i1.SmartFake
+class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_76 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_75(
+  _FakeLatestReceiptState_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -854,8 +867,8 @@ class _FakeLatestReceiptState_75 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_76(
+class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -864,8 +877,8 @@ class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_77(
+class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -874,8 +887,8 @@ class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_78 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_78(
+class _FakeRoom_79 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -884,9 +897,9 @@ class _FakeRoom_78 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeTimelineChunk_79 extends _i1.SmartFake
-    implements _i15.TimelineChunk {
-  _FakeTimelineChunk_79(
+class _FakeTimelineChunk_80 extends _i1.SmartFake
+    implements _i16.TimelineChunk {
+  _FakeTimelineChunk_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -895,8 +908,8 @@ class _FakeTimelineChunk_79 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixFile_80 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_80(
+class _FakeMatrixFile_81 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -905,8 +918,8 @@ class _FakeMatrixFile_80 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_81 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_81(
+class _FakeEvent_82 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -933,12 +946,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1058,11 +1071,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1099,11 +1112,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1133,11 +1146,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1146,11 +1159,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1436,34 +1449,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1619,7 +1632,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1908,14 +1921,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2303,8 +2316,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2320,8 +2333,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2362,7 +2375,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2378,7 +2391,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2427,7 +2440,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2448,7 +2461,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2551,7 +2564,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2569,7 +2582,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3088,7 +3101,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3440,7 +3453,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3454,7 +3467,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3605,7 +3618,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4983,7 +4996,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5005,7 +5018,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5499,7 +5512,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5511,7 +5524,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6519,7 +6532,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6530,7 +6543,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6778,7 +6791,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6790,7 +6803,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7050,7 +7063,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7063,7 +7076,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7130,7 +7143,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7143,7 +7156,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7191,7 +7204,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7203,7 +7216,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7451,7 +7464,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7462,7 +7475,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7724,7 +7737,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7751,7 +7764,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7781,11 +7794,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7858,43 +7871,56 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i11.SelectionService);
 
   @override
-  _i12.SyncService get sync => (super.noSuchMethod(
+  _i12.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i12.SpaceAccessService);
+
+  @override
+  _i13.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_71(
+        returnValue: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_71(
+        returnValueForMissingStub: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i12.SyncService);
+      ) as _i13.SyncService);
 
   @override
-  _i13.AuthService get auth => (super.noSuchMethod(
+  _i14.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_72(
+        returnValue: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_72(
+        returnValueForMissingStub: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i13.AuthService);
+      ) as _i14.AuthService);
 
   @override
-  _i14.OutboxService get outbox => (super.noSuchMethod(
+  _i15.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_73(
+        returnValue: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_73(
+        returnValueForMissingStub: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i14.OutboxService);
+      ) as _i15.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7958,7 +7984,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set sync(_i12.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i12.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i13.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7967,7 +8002,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set auth(_i13.AuthService? value) => super.noSuchMethod(
+  set auth(_i14.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7976,7 +8011,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i15.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -8029,7 +8064,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8123,7 +8158,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8132,7 +8167,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8151,7 +8186,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8162,7 +8197,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8210,7 +8245,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8248,7 +8283,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8257,7 +8292,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8266,16 +8301,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8303,11 +8338,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8337,11 +8372,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_74(
+        returnValue: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_74(
+        returnValueForMissingStub: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
@@ -8394,11 +8429,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8434,11 +8469,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8454,11 +8489,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8467,11 +8502,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8514,11 +8549,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8561,11 +8596,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_75(
+        returnValue: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_75(
+        returnValueForMissingStub: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8602,6 +8637,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   bool get isFavourite => (super.noSuchMethod(
         Invocation.getter(#isFavourite),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
@@ -8777,18 +8819,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i23.SpaceParent>[],
-        returnValueForMissingStub: <_i23.SpaceParent>[],
-      ) as List<_i23.SpaceParent>);
+        returnValue: <_i24.SpaceParent>[],
+        returnValueForMissingStub: <_i24.SpaceParent>[],
+      ) as List<_i24.SpaceParent>);
 
   @override
-  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i23.SpaceChild>[],
-        returnValueForMissingStub: <_i23.SpaceChild>[],
-      ) as List<_i23.SpaceChild>);
+        returnValue: <_i24.SpaceChild>[],
+        returnValueForMissingStub: <_i24.SpaceChild>[],
+      ) as List<_i24.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8955,14 +8997,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9010,7 +9052,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9018,7 +9060,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9033,7 +9075,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9041,7 +9083,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9119,13 +9161,23 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   _i5.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9133,7 +9185,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9375,7 +9427,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9386,7 +9438,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9475,15 +9527,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i15.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i16.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i15.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i15.TimelineChunk?>.value(),
-      ) as _i5.Future<_i15.TimelineChunk?>);
+        returnValue: _i5.Future<_i16.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i16.TimelineChunk?>.value(),
+      ) as _i5.Future<_i16.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9524,7 +9576,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -9541,7 +9593,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -9605,14 +9657,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9628,14 +9680,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9691,7 +9743,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9699,7 +9751,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10011,11 +10063,11 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_78(
+        returnValue: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_78(
+        returnValueForMissingStub: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
@@ -10065,17 +10117,17 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       ) as bool);
 
   @override
-  _i15.TimelineChunk get chunk => (super.noSuchMethod(
+  _i16.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_79(
+        returnValue: _FakeTimelineChunk_80(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_79(
+        returnValueForMissingStub: _FakeTimelineChunk_80(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i15.TimelineChunk);
+      ) as _i16.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10178,7 +10230,7 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       );
 
   @override
-  set chunk(_i15.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i16.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,
@@ -10377,11 +10429,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.getter(#sender),
         ),
@@ -10390,11 +10442,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10403,11 +10455,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_78(
+        returnValue: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_78(
+        returnValueForMissingStub: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
@@ -10430,11 +10482,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10443,11 +10495,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10456,11 +10508,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10469,11 +10521,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10482,11 +10534,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10495,11 +10547,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10564,11 +10616,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10577,11 +10629,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10634,11 +10686,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10723,11 +10775,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10745,11 +10797,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10960,7 +11012,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i18.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i19.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10975,7 +11027,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_80(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_81(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10989,7 +11041,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_80(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_81(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -11025,7 +11077,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11040,7 +11092,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11077,7 +11129,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11091,7 +11143,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11128,7 +11180,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11142,7 +11194,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11176,7 +11228,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11189,7 +11241,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11265,14 +11317,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_81(
+        returnValue: _FakeEvent_82(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_81(
+        returnValueForMissingStub: _FakeEvent_82(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -11289,11 +11341,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_78(
+        returnValue: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_78(
+        returnValueForMissingStub: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
@@ -11302,11 +11354,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -11372,11 +11424,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11401,11 +11453,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11423,11 +11475,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11474,7 +11526,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11486,7 +11538,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11556,7 +11608,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11569,7 +11621,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/widgets/chat/message_bubble_body_test.mocks.dart
+++ b/test/widgets/chat/message_bubble_body_test.mocks.dart
@@ -7946,6 +7946,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -8452,6 +8459,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/chat/message_bubble_outbox_status_test.mocks.dart
+++ b/test/widgets/chat/message_bubble_outbox_status_test.mocks.dart
@@ -8862,6 +8862,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -9368,6 +9375,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/chat/pinned_messages_test.mocks.dart
+++ b/test/widgets/chat/pinned_messages_test.mocks.dart
@@ -4,33 +4,35 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i12;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i15;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i16;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i23;
+import 'package:matrix/src/utils/space_child.dart' as _i24;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -802,8 +804,9 @@ class _FakeSelectionService_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
-  _FakeSyncService_71(
+class _FakeSpaceAccessService_71 extends _i1.SmartFake
+    implements _i12.SpaceAccessService {
+  _FakeSpaceAccessService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -812,8 +815,8 @@ class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
         );
 }
 
-class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
-  _FakeAuthService_72(
+class _FakeSyncService_72 extends _i1.SmartFake implements _i13.SyncService {
+  _FakeSyncService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -822,9 +825,8 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeOutboxService_73 extends _i1.SmartFake
-    implements _i14.OutboxService {
-  _FakeOutboxService_73(
+class _FakeAuthService_73 extends _i1.SmartFake implements _i14.AuthService {
+  _FakeAuthService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -833,8 +835,9 @@ class _FakeOutboxService_73 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_74(
+class _FakeOutboxService_74 extends _i1.SmartFake
+    implements _i15.OutboxService {
+  _FakeOutboxService_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -843,9 +846,19 @@ class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_75 extends _i1.SmartFake
+class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_76 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_75(
+  _FakeLatestReceiptState_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -854,8 +867,8 @@ class _FakeLatestReceiptState_75 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_76(
+class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -864,8 +877,8 @@ class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_77(
+class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -874,8 +887,8 @@ class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_78 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_78(
+class _FakeRoom_79 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -884,9 +897,9 @@ class _FakeRoom_78 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeTimelineChunk_79 extends _i1.SmartFake
-    implements _i15.TimelineChunk {
-  _FakeTimelineChunk_79(
+class _FakeTimelineChunk_80 extends _i1.SmartFake
+    implements _i16.TimelineChunk {
+  _FakeTimelineChunk_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -895,8 +908,8 @@ class _FakeTimelineChunk_79 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixFile_80 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_80(
+class _FakeMatrixFile_81 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -905,8 +918,8 @@ class _FakeMatrixFile_80 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_81 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_81(
+class _FakeEvent_82 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -933,12 +946,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1058,11 +1071,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1099,11 +1112,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1133,11 +1146,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1146,11 +1159,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1436,34 +1449,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1619,7 +1632,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1908,14 +1921,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2303,8 +2316,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2320,8 +2333,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2362,7 +2375,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2378,7 +2391,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2427,7 +2440,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2448,7 +2461,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2551,7 +2564,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2569,7 +2582,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3088,7 +3101,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3440,7 +3453,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3454,7 +3467,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3605,7 +3618,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4983,7 +4996,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5005,7 +5018,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5499,7 +5512,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5511,7 +5524,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6519,7 +6532,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6530,7 +6543,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6778,7 +6791,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6790,7 +6803,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7050,7 +7063,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7063,7 +7076,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7130,7 +7143,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7143,7 +7156,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7191,7 +7204,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7203,7 +7216,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7451,7 +7464,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7462,7 +7475,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7724,7 +7737,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7751,7 +7764,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7781,11 +7794,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7858,43 +7871,56 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i11.SelectionService);
 
   @override
-  _i12.SyncService get sync => (super.noSuchMethod(
+  _i12.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i12.SpaceAccessService);
+
+  @override
+  _i13.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_71(
+        returnValue: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_71(
+        returnValueForMissingStub: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i12.SyncService);
+      ) as _i13.SyncService);
 
   @override
-  _i13.AuthService get auth => (super.noSuchMethod(
+  _i14.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_72(
+        returnValue: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_72(
+        returnValueForMissingStub: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i13.AuthService);
+      ) as _i14.AuthService);
 
   @override
-  _i14.OutboxService get outbox => (super.noSuchMethod(
+  _i15.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_73(
+        returnValue: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_73(
+        returnValueForMissingStub: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i14.OutboxService);
+      ) as _i15.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7958,7 +7984,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set sync(_i12.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i12.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i13.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7967,7 +8002,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set auth(_i13.AuthService? value) => super.noSuchMethod(
+  set auth(_i14.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7976,7 +8011,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i15.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -8029,7 +8064,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8123,7 +8158,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8132,7 +8167,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8151,7 +8186,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8162,7 +8197,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8210,7 +8245,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8248,7 +8283,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8257,7 +8292,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8266,16 +8301,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8303,11 +8338,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8337,11 +8372,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_74(
+        returnValue: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_74(
+        returnValueForMissingStub: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
@@ -8394,11 +8429,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8434,11 +8469,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8454,11 +8489,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8467,11 +8502,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8514,11 +8549,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8561,11 +8596,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_75(
+        returnValue: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_75(
+        returnValueForMissingStub: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8602,6 +8637,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   bool get isFavourite => (super.noSuchMethod(
         Invocation.getter(#isFavourite),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
@@ -8777,18 +8819,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i23.SpaceParent>[],
-        returnValueForMissingStub: <_i23.SpaceParent>[],
-      ) as List<_i23.SpaceParent>);
+        returnValue: <_i24.SpaceParent>[],
+        returnValueForMissingStub: <_i24.SpaceParent>[],
+      ) as List<_i24.SpaceParent>);
 
   @override
-  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i23.SpaceChild>[],
-        returnValueForMissingStub: <_i23.SpaceChild>[],
-      ) as List<_i23.SpaceChild>);
+        returnValue: <_i24.SpaceChild>[],
+        returnValueForMissingStub: <_i24.SpaceChild>[],
+      ) as List<_i24.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8955,14 +8997,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9010,7 +9052,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9018,7 +9060,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9033,7 +9075,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9041,7 +9083,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9119,13 +9161,23 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   _i5.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9133,7 +9185,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9375,7 +9427,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9386,7 +9438,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9475,15 +9527,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i15.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i16.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i15.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i15.TimelineChunk?>.value(),
-      ) as _i5.Future<_i15.TimelineChunk?>);
+        returnValue: _i5.Future<_i16.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i16.TimelineChunk?>.value(),
+      ) as _i5.Future<_i16.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9524,7 +9576,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -9541,7 +9593,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -9605,14 +9657,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9628,14 +9680,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9691,7 +9743,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9699,7 +9751,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10011,11 +10063,11 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_78(
+        returnValue: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_78(
+        returnValueForMissingStub: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
@@ -10065,17 +10117,17 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       ) as bool);
 
   @override
-  _i15.TimelineChunk get chunk => (super.noSuchMethod(
+  _i16.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_79(
+        returnValue: _FakeTimelineChunk_80(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_79(
+        returnValueForMissingStub: _FakeTimelineChunk_80(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i15.TimelineChunk);
+      ) as _i16.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10178,7 +10230,7 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       );
 
   @override
-  set chunk(_i15.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i16.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,
@@ -10377,11 +10429,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.getter(#sender),
         ),
@@ -10390,11 +10442,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10403,11 +10455,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_78(
+        returnValue: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_78(
+        returnValueForMissingStub: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
@@ -10430,11 +10482,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10443,11 +10495,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10456,11 +10508,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10469,11 +10521,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10482,11 +10534,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10495,11 +10547,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10564,11 +10616,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10577,11 +10629,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10634,11 +10686,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10723,11 +10775,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10745,11 +10797,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10960,7 +11012,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i18.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i19.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10975,7 +11027,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_80(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_81(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10989,7 +11041,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_80(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_81(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -11025,7 +11077,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11040,7 +11092,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11077,7 +11129,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11091,7 +11143,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11128,7 +11180,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11142,7 +11194,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11176,7 +11228,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11189,7 +11241,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11265,14 +11317,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_81(
+        returnValue: _FakeEvent_82(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_81(
+        returnValueForMissingStub: _FakeEvent_82(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -11289,11 +11341,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_78(
+        returnValue: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_78(
+        returnValueForMissingStub: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
@@ -11302,11 +11354,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -11372,11 +11424,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11401,11 +11453,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11423,11 +11475,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11474,7 +11526,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11486,7 +11538,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11556,7 +11608,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11569,7 +11621,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/widgets/chat/reaction_chips_test.mocks.dart
+++ b/test/widgets/chat/reaction_chips_test.mocks.dart
@@ -9239,6 +9239,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -9745,6 +9752,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+
+  @override
+  _i6.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i6.Future<void>.value(),
         returnValueForMissingStub: _i6.Future<void>.value(),

--- a/test/widgets/chat/read_receipts_test.mocks.dart
+++ b/test/widgets/chat/read_receipts_test.mocks.dart
@@ -1094,6 +1094,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -1600,6 +1607,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/chat/typing_indicator_test.mocks.dart
+++ b/test/widgets/chat/typing_indicator_test.mocks.dart
@@ -451,6 +451,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -957,6 +964,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/chat/video_bubble_test.mocks.dart
+++ b/test/widgets/chat/video_bubble_test.mocks.dart
@@ -1460,6 +1460,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -1966,6 +1973,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/create_subspace_dialog_test.mocks.dart
+++ b/test/widgets/create_subspace_dialog_test.mocks.dart
@@ -8612,6 +8612,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -9118,6 +9125,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/homeserver_controller_test.mocks.dart
+++ b/test/widgets/homeserver_controller_test.mocks.dart
@@ -3,20 +3,22 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i14;
-import 'dart:ui' as _i15;
+import 'dart:async' as _i15;
+import 'dart:ui' as _i16;
 
-import 'package:flutter/services.dart' as _i16;
-import 'package:flutter/widgets.dart' as _i17;
-import 'package:kohera/core/models/server_auth_capabilities.dart' as _i11;
-import 'package:kohera/core/services/matrix_service.dart' as _i12;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
+import 'package:flutter/services.dart' as _i17;
+import 'package:flutter/widgets.dart' as _i18;
+import 'package:kohera/core/models/server_auth_capabilities.dart' as _i12;
+import 'package:kohera/core/services/matrix_service.dart' as _i13;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i7;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i8;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
@@ -24,7 +26,7 @@ import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
 import 'package:matrix/matrix.dart' as _i4;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i13;
+import 'package:mockito/src/dummies.dart' as _i14;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -105,8 +107,9 @@ class _FakeSelectionService_5 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
-  _FakeSyncService_6(
+class _FakeSpaceAccessService_6 extends _i1.SmartFake
+    implements _i8.SpaceAccessService {
+  _FakeSpaceAccessService_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -115,8 +118,8 @@ class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
         );
 }
 
-class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
-  _FakeAuthService_7(
+class _FakeSyncService_7 extends _i1.SmartFake implements _i9.SyncService {
+  _FakeSyncService_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -125,8 +128,8 @@ class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
         );
 }
 
-class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
-  _FakeOutboxService_8(
+class _FakeAuthService_8 extends _i1.SmartFake implements _i10.AuthService {
+  _FakeAuthService_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -135,9 +138,19 @@ class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
         );
 }
 
-class _FakeServerAuthCapabilities_9 extends _i1.SmartFake
-    implements _i11.ServerAuthCapabilities {
-  _FakeServerAuthCapabilities_9(
+class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
+  _FakeOutboxService_9(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeServerAuthCapabilities_10 extends _i1.SmartFake
+    implements _i12.ServerAuthCapabilities {
+  _FakeServerAuthCapabilities_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -149,7 +162,7 @@ class _FakeServerAuthCapabilities_9 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -179,11 +192,11 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i13.dummyValue<String>(
+        returnValue: _i14.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i13.dummyValue<String>(
+        returnValueForMissingStub: _i14.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -256,43 +269,56 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       ) as _i7.SelectionService);
 
   @override
-  _i8.SyncService get sync => (super.noSuchMethod(
+  _i8.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_6(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_6(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i8.SpaceAccessService);
+
+  @override
+  _i9.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_6(
+        returnValue: _FakeSyncService_7(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_6(
+        returnValueForMissingStub: _FakeSyncService_7(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i8.SyncService);
+      ) as _i9.SyncService);
 
   @override
-  _i9.AuthService get auth => (super.noSuchMethod(
+  _i10.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_7(
+        returnValue: _FakeAuthService_8(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_7(
+        returnValueForMissingStub: _FakeAuthService_8(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i9.AuthService);
+      ) as _i10.AuthService);
 
   @override
-  _i10.OutboxService get outbox => (super.noSuchMethod(
+  _i11.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_8(
+        returnValue: _FakeOutboxService_9(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_8(
+        returnValueForMissingStub: _FakeOutboxService_9(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i10.OutboxService);
+      ) as _i11.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -356,7 +382,16 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
-  set sync(_i8.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i8.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i9.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -365,7 +400,7 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
-  set auth(_i9.AuthService? value) => super.noSuchMethod(
+  set auth(_i10.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -374,7 +409,7 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
-  set outbox(_i10.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i11.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -390,14 +425,14 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       ) as bool);
 
   @override
-  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i15.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -427,7 +462,7 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i15.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i16.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -437,18 +472,18 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
-  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i15.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> login({
+  _i15.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -463,12 +498,12 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> completeSsoLogin({
+  _i15.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -481,12 +516,12 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> completeRegistration(
+  _i15.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -496,32 +531,32 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i15.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  void addListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -530,7 +565,7 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
-  void removeListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -539,17 +574,17 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i15.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i16.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i17.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -560,7 +595,7 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i16.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i17.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -597,26 +632,26 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i15.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> didPushRouteInformation(
-          _i17.RouteInformation? routeInformation) =>
+  _i15.Future<bool> didPushRouteInformation(
+          _i18.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -646,7 +681,7 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i15.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i16.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -655,7 +690,7 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i15.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i16.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -664,16 +699,16 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
-  _i14.Future<_i15.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i15.Future<_i16.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i14.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
+            _i15.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i14.Future<_i15.AppExitResponse>.value(_i15.AppExitResponse.exit),
-      ) as _i14.Future<_i15.AppExitResponse>);
+            _i15.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
+      ) as _i15.Future<_i16.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -697,7 +732,7 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
 /// A class which mocks [AuthService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAuthService extends _i1.Mock implements _i9.AuthService {
+class MockAuthService extends _i1.Mock implements _i10.AuthService {
   @override
   bool get isLoggedIn => (super.noSuchMethod(
         Invocation.getter(#isLoggedIn),
@@ -731,7 +766,7 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
       ) as bool);
 
   @override
-  _i14.Future<bool> login({
+  _i15.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -746,12 +781,12 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
             #password: password,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> completeSsoLogin({
+  _i15.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -764,12 +799,12 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> completeRegistration(
+  _i15.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -779,9 +814,9 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
           [response],
           {#password: password},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void activateRestoredSession() => super.noSuchMethod(
@@ -793,37 +828,37 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
       );
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleServerLogout() => (super.noSuchMethod(
+  _i15.Future<void> handleServerLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleServerLogout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> saveSessionBackup() => (super.noSuchMethod(
+  _i15.Future<void> saveSessionBackup() => (super.noSuchMethod(
         Invocation.method(
           #saveSessionBackup,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i11.ServerAuthCapabilities> getServerAuthCapabilities(
+  _i15.Future<_i12.ServerAuthCapabilities> getServerAuthCapabilities(
     String? homeserver, {
     required bool? isLoggedIn,
   }) =>
@@ -833,8 +868,8 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
           [homeserver],
           {#isLoggedIn: isLoggedIn},
         ),
-        returnValue: _i14.Future<_i11.ServerAuthCapabilities>.value(
-            _FakeServerAuthCapabilities_9(
+        returnValue: _i15.Future<_i12.ServerAuthCapabilities>.value(
+            _FakeServerAuthCapabilities_10(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -843,8 +878,8 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i11.ServerAuthCapabilities>.value(
-                _FakeServerAuthCapabilities_9(
+            _i15.Future<_i12.ServerAuthCapabilities>.value(
+                _FakeServerAuthCapabilities_10(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -852,7 +887,7 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
             {#isLoggedIn: isLoggedIn},
           ),
         )),
-      ) as _i14.Future<_i11.ServerAuthCapabilities>);
+      ) as _i15.Future<_i12.ServerAuthCapabilities>);
 
   @override
   bool isPermanentAuthFailure(Object? error) => (super.noSuchMethod(
@@ -865,37 +900,37 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
       ) as bool);
 
   @override
-  _i14.Future<void> clearSessionKeys() => (super.noSuchMethod(
+  _i15.Future<void> clearSessionKeys() => (super.noSuchMethod(
         Invocation.method(
           #clearSessionKeys,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> migrateStorageKeys() => (super.noSuchMethod(
+  _i15.Future<void> migrateStorageKeys() => (super.noSuchMethod(
         Invocation.method(
           #migrateStorageKeys,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> persistCredentials() => (super.noSuchMethod(
+  _i15.Future<void> persistCredentials() => (super.noSuchMethod(
         Invocation.method(
           #persistCredentials,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  void addListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -904,7 +939,7 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
       );
 
   @override
-  void removeListener(_i15.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/test/widgets/inbox_screen_test.mocks.dart
+++ b/test/widgets/inbox_screen_test.mocks.dart
@@ -7916,6 +7916,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -8422,6 +8429,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/invite_dialog_test.mocks.dart
+++ b/test/widgets/invite_dialog_test.mocks.dart
@@ -3,34 +3,36 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i13;
-import 'dart:typed_data' as _i23;
-import 'dart:ui' as _i17;
+import 'dart:async' as _i14;
+import 'dart:typed_data' as _i24;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
-import 'package:http/http.dart' as _i12;
-import 'package:kohera/core/services/matrix_service.dart' as _i15;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
+import 'package:http/http.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i16;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i7;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i8;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i22;
+import 'package:matrix/encryption.dart' as _i23;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i14;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i11;
-import 'package:matrix/src/utils/space_child.dart' as _i20;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i15;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i12;
+import 'package:matrix/src/utils/space_child.dart' as _i21;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -111,8 +113,9 @@ class _FakeSelectionService_5 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
-  _FakeSyncService_6(
+class _FakeSpaceAccessService_6 extends _i1.SmartFake
+    implements _i8.SpaceAccessService {
+  _FakeSpaceAccessService_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -121,8 +124,8 @@ class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
         );
 }
 
-class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
-  _FakeAuthService_7(
+class _FakeSyncService_7 extends _i1.SmartFake implements _i9.SyncService {
+  _FakeSyncService_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -131,8 +134,8 @@ class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
         );
 }
 
-class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
-  _FakeOutboxService_8(
+class _FakeAuthService_8 extends _i1.SmartFake implements _i10.AuthService {
+  _FakeAuthService_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -141,8 +144,8 @@ class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
         );
 }
 
-class _FakeRoomSummary_9 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_9(
+class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
+  _FakeOutboxService_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -151,9 +154,8 @@ class _FakeRoomSummary_9 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_10<T> extends _i1.SmartFake
-    implements _i11.CachedStreamController<T> {
-  _FakeCachedStreamController_10(
+class _FakeRoomSummary_10 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -162,8 +164,9 @@ class _FakeCachedStreamController_10<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_11 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_11(
+class _FakeCachedStreamController_11<T> extends _i1.SmartFake
+    implements _i12.CachedStreamController<T> {
+  _FakeCachedStreamController_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -172,9 +175,19 @@ class _FakeDateTime_11 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_12 extends _i1.SmartFake
+class _FakeDateTime_12 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_12(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_13 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_12(
+  _FakeLatestReceiptState_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -183,8 +196,8 @@ class _FakeLatestReceiptState_12 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_13 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_13(
+class _FakeSyncUpdate_14 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -193,8 +206,8 @@ class _FakeSyncUpdate_13 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeTimeline_14 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_14(
+class _FakeTimeline_15 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -203,8 +216,8 @@ class _FakeTimeline_14 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_15 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_15(
+class _FakeUser_16 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -213,8 +226,8 @@ class _FakeUser_15 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeUri_16 extends _i1.SmartFake implements Uri {
-  _FakeUri_16(
+class _FakeUri_17 extends _i1.SmartFake implements Uri {
+  _FakeUri_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -223,8 +236,8 @@ class _FakeUri_16 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_17 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_17(
+class _FakeDatabaseApi_18 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -233,8 +246,8 @@ class _FakeDatabaseApi_17 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_18 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_18(
+class _FakeFilter_19 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -243,9 +256,9 @@ class _FakeFilter_18 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_19 extends _i1.SmartFake
+class _FakeNativeImplementations_20 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_19(
+  _FakeNativeImplementations_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -254,8 +267,8 @@ class _FakeNativeImplementations_19 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_20 extends _i1.SmartFake implements Duration {
-  _FakeDuration_20(
+class _FakeDuration_21 extends _i1.SmartFake implements Duration {
+  _FakeDuration_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -264,9 +277,9 @@ class _FakeDuration_20 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_21 extends _i1.SmartFake
+class _FakePushruleEvaluator_22 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_21(
+  _FakePushruleEvaluator_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -275,8 +288,8 @@ class _FakePushruleEvaluator_21 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_22 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_22(
+class _FakeProfile_23 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -285,8 +298,8 @@ class _FakeProfile_22 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeClient_23 extends _i1.SmartFake implements _i12.Client {
-  _FakeClient_23(
+class _FakeClient_24 extends _i1.SmartFake implements _i13.Client {
+  _FakeClient_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -295,9 +308,9 @@ class _FakeClient_23 extends _i1.SmartFake implements _i12.Client {
         );
 }
 
-class _FakeDiscoveryInformation_24 extends _i1.SmartFake
+class _FakeDiscoveryInformation_25 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_24(
+  _FakeDiscoveryInformation_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -306,9 +319,9 @@ class _FakeDiscoveryInformation_24 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_25 extends _i1.SmartFake
+class _FakeGetVersionsResponse_26 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_25(
+  _FakeGetVersionsResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -317,9 +330,9 @@ class _FakeGetVersionsResponse_25 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_26 extends _i1.SmartFake
+class _FakeRegisterResponse_27 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_26(
+  _FakeRegisterResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -328,8 +341,8 @@ class _FakeRegisterResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_27 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_27(
+class _FakeLoginResponse_28 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -338,9 +351,9 @@ class _FakeLoginResponse_27 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_28 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_29 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_28(
+  _FakeGetAuthMetadataResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -349,8 +362,8 @@ class _FakeGetAuthMetadataResponse_28 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_29<T1> extends _i1.SmartFake implements _i13.Future<T1> {
-  _FakeFuture_29(
+class _FakeFuture_30<T1> extends _i1.SmartFake implements _i14.Future<T1> {
+  _FakeFuture_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -359,9 +372,9 @@ class _FakeFuture_29<T1> extends _i1.SmartFake implements _i13.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_30 extends _i1.SmartFake
+class _FakeCachedProfileInformation_31 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_30(
+  _FakeCachedProfileInformation_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -370,8 +383,8 @@ class _FakeCachedProfileInformation_30 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_31 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_31(
+class _FakeMediaConfig_32 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -380,8 +393,8 @@ class _FakeMediaConfig_31 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_32 extends _i1.SmartFake implements _i14.FileResponse {
-  _FakeFileResponse_32(
+class _FakeFileResponse_33 extends _i1.SmartFake implements _i15.FileResponse {
+  _FakeFileResponse_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -390,8 +403,8 @@ class _FakeFileResponse_32 extends _i1.SmartFake implements _i14.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_33 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_33(
+class _FakePreviewForUrl_34 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -400,9 +413,9 @@ class _FakePreviewForUrl_33 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_34 extends _i1.SmartFake
+class _FakeCachedPresence_35 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_34(
+  _FakeCachedPresence_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -411,9 +424,9 @@ class _FakeCachedPresence_34 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_35 extends _i1.SmartFake
+class _FakeTurnServerCredentials_36 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_35(
+  _FakeTurnServerCredentials_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -422,9 +435,9 @@ class _FakeTurnServerCredentials_35 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_37 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_36(
+  _FakeRoomKeysUpdateResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -433,8 +446,8 @@ class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_37(
+class _FakeKeyBackupData_38 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -443,9 +456,9 @@ class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_39 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_38(
+  _FakeGetWellknownSupportResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -454,9 +467,9 @@ class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_40 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_39(
+  _FakeGenerateLoginTokenResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -465,9 +478,9 @@ class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_41 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_40(
+  _FakeGetRoomSummaryResponse$3_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -476,9 +489,9 @@ class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_42 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_41(
+  _FakeGetSpaceHierarchyResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -487,9 +500,9 @@ class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_43 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_42(
+  _FakeGetRelatingEventsResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -498,9 +511,9 @@ class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_44 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_43(
+  _FakeGetRelatingEventsWithRelTypeResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -509,9 +522,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -520,9 +533,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_46 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_45(
+  _FakeGetThreadRootsResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -531,9 +544,9 @@ class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_47 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_46(
+  _FakeGetEventByTimestampResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -542,9 +555,9 @@ class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_47 extends _i1.SmartFake
+class _FakeRequestTokenResponse_48 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_47(
+  _FakeRequestTokenResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -553,9 +566,9 @@ class _FakeRequestTokenResponse_47 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_49 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_48(
+  _FakeTokenOwnerInfo_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -564,8 +577,8 @@ class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_49(
+class _FakeWhoIsInfo_50 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -574,8 +587,8 @@ class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_50(
+class _FakeCapabilities_51 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -584,8 +597,8 @@ class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_51(
+class _FakeDevice_52 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -594,9 +607,9 @@ class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_53 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_52(
+  _FakeGetRoomIdByAliasResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -605,9 +618,9 @@ class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_53 extends _i1.SmartFake
+class _FakeGetEventsResponse_54 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_53(
+  _FakeGetEventsResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -616,9 +629,9 @@ class _FakeGetEventsResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_54 extends _i1.SmartFake
+class _FakePeekEventsResponse_55 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_54(
+  _FakePeekEventsResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -627,8 +640,8 @@ class _FakePeekEventsResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_55(
+class _FakeMatrixEvent_56 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -637,9 +650,9 @@ class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_57 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_56(
+  _FakeGetKeysChangesResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -648,9 +661,9 @@ class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_57 extends _i1.SmartFake
+class _FakeClaimKeysResponse_58 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_57(
+  _FakeClaimKeysResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -659,9 +672,9 @@ class _FakeClaimKeysResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_58 extends _i1.SmartFake
+class _FakeQueryKeysResponse_59 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_58(
+  _FakeQueryKeysResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -670,9 +683,9 @@ class _FakeQueryKeysResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_60 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_59(
+  _FakeGetNotificationsResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -681,9 +694,9 @@ class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_60 extends _i1.SmartFake
+class _FakeGetPresenceResponse_61 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_60(
+  _FakeGetPresenceResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -692,9 +705,9 @@ class _FakeGetPresenceResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_62 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_61(
+  _FakeGetPublicRoomsResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -703,9 +716,9 @@ class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_63 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_62(
+  _FakeQueryPublicRoomsResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -714,8 +727,8 @@ class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_63(
+class _FakePushRuleSet_64 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -724,9 +737,9 @@ class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_65 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_64(
+  _FakeGetPushRulesGlobalResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -735,8 +748,8 @@ class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_65(
+class _FakePushRule_66 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -745,9 +758,9 @@ class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_66 extends _i1.SmartFake
+class _FakeRefreshResponse_67 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_66(
+  _FakeRefreshResponse_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,8 +769,8 @@ class _FakeRefreshResponse_66 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_67(
+class _FakeRoomKeys_68 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -766,8 +779,8 @@ class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_68(
+class _FakeRoomKeyBackup_69 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -776,9 +789,9 @@ class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_70 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_69(
+  _FakeGetRoomKeysVersionCurrentResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -787,9 +800,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_71 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_70(
+  _FakeGetRoomKeysVersionResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,8 +811,8 @@ class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_71(
+class _FakeEventContext_72 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,9 +821,9 @@ class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_73 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_72(
+  _FakeGetRoomEventsResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -819,8 +832,8 @@ class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_73(
+class _FakeSearchResults_74 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,9 +842,9 @@ class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_75 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_74(
+  _FakeGetProtocolMetadataResponse$2_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -840,9 +853,9 @@ class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_75 extends _i1.SmartFake
+class _FakeOpenIdCredentials_76 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_75(
+  _FakeOpenIdCredentials_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -851,9 +864,9 @@ class _FakeOpenIdCredentials_75 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_77 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_76(
+  _FakeSearchUserDirectoryResponse_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -862,9 +875,9 @@ class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_77 extends _i1.SmartFake
+class _FakeCreateContentResponse_78 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_77(
+  _FakeCreateContentResponse_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -876,7 +889,7 @@ class _FakeCreateContentResponse_77 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -906,11 +919,11 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -983,43 +996,56 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as _i7.SelectionService);
 
   @override
-  _i8.SyncService get sync => (super.noSuchMethod(
+  _i8.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_6(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_6(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i8.SpaceAccessService);
+
+  @override
+  _i9.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_6(
+        returnValue: _FakeSyncService_7(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_6(
+        returnValueForMissingStub: _FakeSyncService_7(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i8.SyncService);
+      ) as _i9.SyncService);
 
   @override
-  _i9.AuthService get auth => (super.noSuchMethod(
+  _i10.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_7(
+        returnValue: _FakeAuthService_8(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_7(
+        returnValueForMissingStub: _FakeAuthService_8(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i9.AuthService);
+      ) as _i10.AuthService);
 
   @override
-  _i10.OutboxService get outbox => (super.noSuchMethod(
+  _i11.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_8(
+        returnValue: _FakeOutboxService_9(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_8(
+        returnValueForMissingStub: _FakeOutboxService_9(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i10.OutboxService);
+      ) as _i11.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1083,7 +1109,16 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set sync(_i8.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i8.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i9.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -1092,7 +1127,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set auth(_i9.AuthService? value) => super.noSuchMethod(
+  set auth(_i10.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -1101,7 +1136,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set outbox(_i10.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i11.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -1117,14 +1152,14 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as bool);
 
   @override
-  _i13.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1154,7 +1189,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1164,18 +1199,18 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<bool> login({
+  _i14.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1190,12 +1225,12 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> completeSsoLogin({
+  _i14.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1208,12 +1243,12 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> completeRegistration(
+  _i14.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1223,32 +1258,32 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1257,7 +1292,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1266,17 +1301,17 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1287,7 +1322,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1324,26 +1359,26 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+  _i14.Future<bool> didPushRouteInformation(
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1373,7 +1408,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1382,7 +1417,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1391,16 +1426,16 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i14.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i13.Future<_i17.AppExitResponse>);
+            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i14.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1428,11 +1463,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1462,11 +1497,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_9(
+        returnValue: _FakeRoomSummary_10(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_9(
+        returnValueForMissingStub: _FakeRoomSummary_10(
           this,
           Invocation.getter(#summary),
         ),
@@ -1496,11 +1531,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i13.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i14.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i13.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i13.Completer<dynamic>>[],
-      ) as List<_i13.Completer<dynamic>>);
+        returnValue: <_i14.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i14.Completer<dynamic>>[],
+      ) as List<_i14.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1519,51 +1554,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i11.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i12.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_10<String>(
+        returnValue: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i11.CachedStreamController<String> get onSessionKeyReceived =>
+  _i12.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_10<String>(
+        returnValue: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1579,11 +1614,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1592,11 +1627,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1639,11 +1674,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1652,11 +1687,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_11(
+        returnValue: _FakeDateTime_12(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_11(
+        returnValueForMissingStub: _FakeDateTime_12(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -1686,11 +1721,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_12(
+        returnValue: _FakeLatestReceiptState_13(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_12(
+        returnValueForMissingStub: _FakeLatestReceiptState_13(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -1711,22 +1746,29 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i13.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i14.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
         Invocation.getter(#isFavourite),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
@@ -1902,18 +1944,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i20.SpaceParent>[],
-        returnValueForMissingStub: <_i20.SpaceParent>[],
-      ) as List<_i20.SpaceParent>);
+        returnValue: <_i21.SpaceParent>[],
+        returnValueForMissingStub: <_i21.SpaceParent>[],
+      ) as List<_i21.SpaceParent>);
 
   @override
-  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i20.SpaceChild>[],
-        returnValueForMissingStub: <_i20.SpaceChild>[],
-      ) as List<_i20.SpaceChild>);
+        returnValue: <_i21.SpaceChild>[],
+        returnValueForMissingStub: <_i21.SpaceChild>[],
+      ) as List<_i21.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -2026,14 +2068,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i13.Future<void> postLoad() => (super.noSuchMethod(
+  _i14.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -2061,15 +2103,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i13.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i14.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i13.Future<List<_i4.User>>);
+            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i14.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -2080,14 +2122,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2097,18 +2139,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i13.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i14.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Event?> refreshLastEvent(
+  _i14.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2116,9 +2158,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -2130,12 +2172,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i13.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i14.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2143,22 +2185,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i14.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2166,17 +2208,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> addTag(
+  _i14.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2186,27 +2228,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i14.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i14.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2214,43 +2256,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i14.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i14.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i14.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
+        ),
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
+
+  @override
+  _i14.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2258,14 +2310,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2277,7 +2329,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i13.Future<String?> sendTextEvent(
+  _i14.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2309,12 +2361,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendReaction(
+  _i14.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2328,12 +2380,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendLocation(
+  _i14.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2347,12 +2399,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendFileEvent(
+  _i14.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2380,25 +2432,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i14.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i13.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i14.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i13.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i14.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i13.Future<_i4.EncryptionHealthState>);
+      ) as _i14.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i13.Future<String?> sendEvent(
+  _i14.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -2422,73 +2474,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i14.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> leave() => (super.noSuchMethod(
+  _i14.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> forget() => (super.noSuchMethod(
+  _i14.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> setPower(
+  _i14.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2500,7 +2552,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2511,7 +2563,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2521,10 +2573,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> invite(
+  _i14.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2534,12 +2586,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<int> requestHistory({
+  _i14.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -2556,32 +2608,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<int>.value(0),
-        returnValueForMissingStub: _i13.Future<int>.value(0),
-      ) as _i13.Future<int>);
+        returnValue: _i14.Future<int>.value(0),
+        returnValueForMissingStub: _i14.Future<int>.value(0),
+      ) as _i14.Future<int>);
 
   @override
-  _i13.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i14.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setReadMarker(
+  _i14.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2595,23 +2647,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
+  _i14.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i13.Future<_i21.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i13.Future<_i21.TimelineChunk?>.value(),
-      ) as _i13.Future<_i21.TimelineChunk?>);
+        returnValue: _i14.Future<_i22.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i14.Future<_i22.TimelineChunk?>.value(),
+      ) as _i14.Future<_i22.TimelineChunk?>);
 
   @override
-  _i13.Future<void> postReceipt(
+  _i14.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -2621,12 +2673,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Timeline> getTimeline({
+  _i14.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2649,7 +2701,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i13.Future<_i4.Timeline>.value(_FakeTimeline_14(
+        returnValue: _i14.Future<_i4.Timeline>.value(_FakeTimeline_15(
           this,
           Invocation.method(
             #getTimeline,
@@ -2666,7 +2718,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Timeline>.value(_FakeTimeline_14(
+            _i14.Future<_i4.Timeline>.value(_FakeTimeline_15(
           this,
           Invocation.method(
             #getTimeline,
@@ -2682,7 +2734,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Timeline>);
+      ) as _i14.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -2701,7 +2753,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i13.Future<List<_i4.User>> requestParticipants([
+  _i14.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -2719,10 +2771,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i13.Future<List<_i4.User>>);
+            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i14.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -2730,14 +2782,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_15(
+        returnValue: _FakeUser_16(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_15(
+        returnValueForMissingStub: _FakeUser_16(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -2753,14 +2805,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_15(
+        returnValue: _FakeUser_16(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_15(
+        returnValueForMissingStub: _FakeUser_16(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -2770,7 +2822,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i13.Future<_i4.User?> requestUser(
+  _i14.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2786,19 +2838,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i13.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.User?>.value(),
-      ) as _i13.Future<_i4.User?>);
+        returnValue: _i14.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.User?>.value(),
+      ) as _i14.Future<_i4.User?>);
 
   @override
-  _i13.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i14.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2811,12 +2863,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i13.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i14.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2824,14 +2876,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2854,14 +2906,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i13.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i14.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -2900,18 +2952,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i13.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i14.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEvent(
+  _i14.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -2925,12 +2977,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> setTyping(
+  _i14.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -2940,12 +2992,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setJoinRules(
+  _i14.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -2959,59 +3011,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i14.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setHistoryVisibility(
+  _i14.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i14.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i14.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i13.Future<List<_i4.DeviceKeys>>);
+            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i14.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i13.Future<void> requestSessionKey(
+  _i14.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -3023,12 +3075,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setSpaceChild(
+  _i14.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3044,44 +3096,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i14.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i13.Future<Uri>.value(_FakeUri_16(
+        returnValue: _i14.Future<Uri>.value(_FakeUri_17(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_16(
+        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_17(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i13.Future<Uri>);
+      ) as _i14.Future<Uri>);
 
   @override
-  _i13.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i14.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<
+  _i14.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -3108,21 +3160,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i13.Future<
+        returnValue: _i14.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i13.Future<
+        returnValueForMissingStub: _i14.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i13.Future<
+      ) as _i14.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -3137,23 +3189,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_17(
+        returnValue: _FakeDatabaseApi_18(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_17(
+        returnValueForMissingStub: _FakeDatabaseApi_18(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i22.KeyVerificationMethod> get verificationMethods =>
+  Set<_i23.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i22.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i22.KeyVerificationMethod>{},
-      ) as Set<_i22.KeyVerificationMethod>);
+        returnValue: <_i23.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i23.KeyVerificationMethod>{},
+      ) as Set<_i23.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3214,11 +3266,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_18(
+        returnValue: _FakeFilter_19(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_18(
+        returnValueForMissingStub: _FakeFilter_19(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -3227,11 +3279,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_19(
+        returnValue: _FakeNativeImplementations_20(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_19(
+        returnValueForMissingStub: _FakeNativeImplementations_20(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -3247,11 +3299,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_20(
+        returnValue: _FakeDuration_21(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_20(
+        returnValueForMissingStub: _FakeDuration_21(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3260,11 +3312,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_20(
+        returnValue: _FakeDuration_21(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_20(
+        returnValueForMissingStub: _FakeDuration_21(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3273,11 +3325,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -3314,11 +3366,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3348,11 +3400,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3361,11 +3413,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3388,11 +3440,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_21(
+        returnValue: _FakePushruleEvaluator_22(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_21(
+        returnValueForMissingStub: _FakePushruleEvaluator_22(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -3413,332 +3465,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i13.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i14.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i11.CachedStreamController<String> get onUserProfileUpdate =>
+  _i12.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_10<String>(
+        returnValue: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i13.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i14.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i13.Future<List<_i4.Room>>);
+            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i14.Future<List<_i4.Room>>);
 
   @override
-  _i11.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i12.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_10<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_11<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.EventUpdate>(
+            _FakeCachedStreamController_11<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.EventUpdate>);
+      ) as _i12.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i12.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_10<_i4.Event>(
+        returnValue: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i12.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_10<_i4.Event>(
+        returnValue: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onNotification =>
+  _i12.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_10<_i4.Event>(
+        returnValue: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i12.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_10<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_11<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_11<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i12.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i11.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i12.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_10<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_11<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_10<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_11<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i11.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i12.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i11.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i12.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_10<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_11<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.LoginState>(
+            _FakeCachedStreamController_11<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i11.CachedStreamController<_i4.LoginState>);
+      ) as _i12.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i11.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i12.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_10<bool>(
+        returnValue: _FakeCachedStreamController_11<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i11.CachedStreamController<bool>);
+      ) as _i12.CachedStreamController<bool>);
 
   @override
-  _i11.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i12.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_10<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_11<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i11.CachedStreamController<_i4.SdkError>);
+      ) as _i12.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i11.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i12.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_10<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_11<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.SyncUpdate>(
+            _FakeCachedStreamController_11<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i11.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i12.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i12.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_10<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_11<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_11<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i11.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i12.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.Presence> get onPresence =>
+  _i12.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_10<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_11<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i11.CachedStreamController<_i4.Presence>);
+      ) as _i12.CachedStreamController<_i4.Presence>);
 
   @override
-  _i11.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i12.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_10<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_11<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.CachedPresence>(
+            _FakeCachedStreamController_11<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i11.CachedStreamController<_i4.CachedPresence>);
+      ) as _i12.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i11.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i12.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_10<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_11<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.BasicEvent>(
+            _FakeCachedStreamController_11<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i11.CachedStreamController<_i4.BasicEvent>);
+      ) as _i12.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i11.CachedStreamController<_i22.RoomKeyRequest> get onRoomKeyRequest =>
+  _i12.CachedStreamController<_i23.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_10<_i22.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_11<_i23.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i22.RoomKeyRequest>(
+            _FakeCachedStreamController_11<_i23.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i11.CachedStreamController<_i22.RoomKeyRequest>);
+      ) as _i12.CachedStreamController<_i23.RoomKeyRequest>);
 
   @override
-  _i11.CachedStreamController<_i22.KeyVerification>
+  _i12.CachedStreamController<_i23.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_10<_i22.KeyVerification>(
+            returnValue: _FakeCachedStreamController_11<_i23.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_10<_i22.KeyVerification>(
+                _FakeCachedStreamController_11<_i23.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i11.CachedStreamController<_i22.KeyVerification>);
+          ) as _i12.CachedStreamController<_i23.KeyVerification>);
 
   @override
-  _i11.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i12.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_10<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_11<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_11<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i11.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i12.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i12.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_10<_i4.Event>(
+        returnValue: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<String> get onCancelSendEvent =>
+  _i12.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_10<String>(
+        returnValue: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i11.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i12.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_10<
+            returnValue: _FakeCachedStreamController_11<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_10<
+            returnValueForMissingStub: _FakeCachedStreamController_11<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i11.CachedStreamController<
+          ) as _i12.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -3758,11 +3810,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_11(
+        returnValue: _FakeDateTime_12(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_11(
+        returnValueForMissingStub: _FakeDateTime_12(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3835,7 +3887,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i22.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i23.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3890,7 +3942,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i13.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i14.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -3901,7 +3953,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i13.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i14.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -4012,7 +4064,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -4021,7 +4073,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -4030,7 +4082,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4057,20 +4109,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Client get httpClient => (super.noSuchMethod(
+  _i13.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_23(
+        returnValue: _FakeClient_24(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_23(
+        returnValueForMissingStub: _FakeClient_24(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i12.Client);
+      ) as _i13.Client);
 
   @override
-  set httpClient(_i12.Client? value) => super.noSuchMethod(
+  set httpClient(_i13.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4097,7 +4149,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<void> refreshAccessToken(
+  _i14.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4105,9 +4157,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4125,14 +4177,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4169,33 +4221,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i13.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i14.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i13.Future<_i4.DiscoveryInformation>);
+      ) as _i14.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i13.Future<
+  _i14.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -4217,7 +4269,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i13.Future<
+        returnValue: _i14.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4225,7 +4277,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_25(
+          _FakeGetVersionsResponse_26(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4240,7 +4292,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i13.Future<
+        returnValueForMissingStub: _i14.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4248,7 +4300,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_25(
+          _FakeGetVersionsResponse_26(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4263,7 +4315,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i13.Future<
+      ) as _i14.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -4272,7 +4324,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i13.Future<_i4.DiscoveryInformation> getWellknown({
+  _i14.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4285,8 +4337,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getWellknown,
@@ -4297,8 +4349,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getWellknown,
@@ -4309,10 +4361,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.DiscoveryInformation>);
+      ) as _i14.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i13.Future<_i4.RegisterResponse> register({
+  _i14.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -4340,7 +4392,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
+            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
           this,
           Invocation.method(
             #register,
@@ -4359,7 +4411,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
+            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
           this,
           Invocation.method(
             #register,
@@ -4377,10 +4429,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RegisterResponse>);
+      ) as _i14.Future<_i4.RegisterResponse>);
 
   @override
-  _i13.Future<_i4.LoginResponse> login(
+  _i14.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -4410,7 +4462,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
+        returnValue: _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
           this,
           Invocation.method(
             #login,
@@ -4430,7 +4482,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
+            _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
           this,
           Invocation.method(
             #login,
@@ -4449,10 +4501,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.LoginResponse>);
+      ) as _i14.Future<_i4.LoginResponse>);
 
   @override
-  _i13.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i14.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4465,8 +4517,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_28(
+        returnValue: _i14.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_29(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4478,8 +4530,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_28(
+            _i14.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_29(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4490,74 +4542,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i14.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> logoutAll() => (super.noSuchMethod(
+  _i14.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<T> uiaRequestBackground<T>(
-          _i13.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i14.Future<T> uiaRequestBackground<T>(
+          _i14.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i13.Future<T>.value(v),
+              (T v) => _i14.Future<T>.value(v),
             ) ??
-            _FakeFuture_29<T>(
+            _FakeFuture_30<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i13.Future<T>.value(v),
+              (T v) => _i14.Future<T>.value(v),
             ) ??
-            _FakeFuture_29<T>(
+            _FakeFuture_30<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i13.Future<T>);
+      ) as _i14.Future<T>);
 
   @override
-  _i13.Future<String> startDirectChat(
+  _i14.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -4579,7 +4631,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4595,7 +4647,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4610,10 +4662,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<String> createGroupChat({
+  _i14.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -4644,7 +4696,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4665,7 +4717,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4685,10 +4737,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i14.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4704,7 +4756,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4717,7 +4769,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4729,21 +4781,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i14.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<String> createSpace({
+  _i14.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -4768,7 +4820,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4786,7 +4838,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4803,10 +4855,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i14.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4814,7 +4866,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4823,7 +4875,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4831,10 +4883,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i13.Future<_i4.Profile> fetchOwnProfile({
+  _i14.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4847,7 +4899,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4859,7 +4911,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4870,10 +4922,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i13.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i14.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4887,8 +4939,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i13.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_30(
+        returnValue: _i14.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_31(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4900,8 +4952,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_30(
+            _i14.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_31(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4912,10 +4964,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.CachedProfileInformation>);
+      ) as _i14.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i13.Future<_i4.Profile> getProfileFromUserId(
+  _i14.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -4933,7 +4985,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4947,7 +4999,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4960,7 +5012,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -4982,31 +5034,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i13.Future<List<_i4.Room>>);
+            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i14.Future<List<_i4.Room>>);
 
   @override
-  _i13.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i14.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i13.Future<List<_i4.ArchivedRoom>>);
+            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i14.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i13.Future<_i4.GetVersionsResponse> getVersions({
+  _i14.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5019,8 +5071,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_25(
+        returnValue: _i14.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_26(
           this,
           Invocation.method(
             #getVersions,
@@ -5031,8 +5083,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_25(
+        returnValueForMissingStub: _i14.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_26(
           this,
           Invocation.method(
             #getVersions,
@@ -5043,20 +5095,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetVersionsResponse>);
+      ) as _i14.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i13.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i14.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<_i4.MediaConfig> getConfig({
+  _i14.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5069,7 +5121,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
+        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
           this,
           Invocation.method(
             #getConfig,
@@ -5081,7 +5133,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
+            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
           this,
           Invocation.method(
             #getConfig,
@@ -5092,10 +5144,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.MediaConfig>);
+      ) as _i14.Future<_i4.MediaConfig>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContent(
+  _i14.Future<_i15.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5115,7 +5167,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContent,
@@ -5131,7 +5183,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContent,
@@ -5146,10 +5198,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentOverrideName(
+  _i14.Future<_i15.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5171,7 +5223,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5188,7 +5240,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5204,10 +5256,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentThumbnail(
+  _i14.Future<_i15.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5235,7 +5287,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5255,7 +5307,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5274,10 +5326,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i14.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5287,7 +5339,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
+        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5296,7 +5348,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
+            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5304,11 +5356,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i13.Future<_i4.PreviewForUrl>);
+      ) as _i14.Future<_i4.PreviewForUrl>);
 
   @override
-  _i13.Future<Uri> uploadContent(
-    _i23.Uint8List? file, {
+  _i14.Future<Uri> uploadContent(
+    _i24.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5321,7 +5373,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i13.Future<Uri>.value(_FakeUri_16(
+        returnValue: _i14.Future<Uri>.value(_FakeUri_17(
           this,
           Invocation.method(
             #uploadContent,
@@ -5332,7 +5384,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_16(
+        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_17(
           this,
           Invocation.method(
             #uploadContent,
@@ -5343,10 +5395,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<Uri>);
+      ) as _i14.Future<Uri>);
 
   @override
-  _i13.Future<void> setTyping(
+  _i14.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5362,42 +5414,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> exportDump() => (super.noSuchMethod(
+  _i14.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i14.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i14.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Event?> getEventByPushNotification(
+  _i14.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -5413,12 +5465,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
-  _i13.Future<void> init({
+  _i14.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5453,9 +5505,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5467,40 +5519,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<void> clear() => (super.noSuchMethod(
+  _i14.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i14.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ensureNotSoftLoggedOut(
+  _i14.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleSync(
+  _i14.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -5510,9 +5562,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -5525,29 +5577,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i13.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i14.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i14.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDevice(
+  _i14.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5561,12 +5613,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDevicesOfUserIds(
+  _i14.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5582,12 +5634,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDeviceEncrypted(
+  _i14.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5607,12 +5659,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDeviceEncryptedChunked(
+  _i14.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -5626,23 +5678,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i14.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> joinRoom(
+  _i14.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -5660,7 +5712,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5674,7 +5726,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5687,10 +5739,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> changePassword(
+  _i14.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -5706,22 +5758,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> clearCache() => (super.noSuchMethod(
+  _i14.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ignoreUser(
+  _i14.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5731,22 +5783,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i14.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i14.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5757,7 +5809,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5766,7 +5818,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5774,32 +5826,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i13.Future<_i4.CachedPresence>);
+      ) as _i14.Future<_i4.CachedPresence>);
 
   @override
-  _i13.Future<void> abortSync() => (super.noSuchMethod(
+  _i14.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i14.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEventWithMetadata(
+  _i14.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5819,14 +5871,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i12.BaseResponse? response,
-    _i23.Uint8List? body,
+    _i13.BaseResponse? response,
+    _i24.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5858,7 +5910,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i13.Future<Map<String, Object?>> request(
+  _i14.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -5879,13 +5931,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> postPusher(
+  _i14.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -5895,57 +5947,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i14.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i14.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i14.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i13.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_35(
+        returnValue: _i14.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_36(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_35(
+        returnValueForMissingStub: _i14.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_36(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.TurnServerCredentials>);
+      ) as _i14.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5959,8 +6011,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5972,8 +6024,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5984,10 +6036,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6003,8 +6055,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6017,8 +6069,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6030,10 +6082,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i14.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6047,7 +6099,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6059,7 +6111,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6070,17 +6122,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.KeyBackupData>);
+      ) as _i14.Future<_i4.KeyBackupData>);
 
   @override
-  _i13.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i14.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i13.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_38(
+        returnValue: _i14.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_39(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6088,18 +6140,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_38(
+            _i14.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_39(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i14.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i13.Future<int> pingAppservice(
+  _i14.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6109,12 +6161,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i13.Future<int>.value(0),
-        returnValueForMissingStub: _i13.Future<int>.value(0),
-      ) as _i13.Future<int>);
+        returnValue: _i14.Future<int>.value(0),
+        returnValueForMissingStub: _i14.Future<int>.value(0),
+      ) as _i14.Future<int>);
 
   @override
-  _i13.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i14.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6122,8 +6174,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_39(
+        returnValue: _i14.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_40(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6132,8 +6184,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_39(
+            _i14.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_40(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6141,15 +6193,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i13.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i14.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i13.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i14.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
+        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6157,17 +6209,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
+            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.MediaConfig>);
+      ) as _i14.Future<_i4.MediaConfig>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentAuthed(
+  _i14.Future<_i15.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6181,7 +6233,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6193,7 +6245,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6204,10 +6256,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentOverrideNameAuthed(
+  _i14.Future<_i15.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6223,7 +6275,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6236,7 +6288,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6248,10 +6300,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i14.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6261,7 +6313,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
+        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6270,7 +6322,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
+            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6278,10 +6330,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i13.Future<_i4.PreviewForUrl>);
+      ) as _i14.Future<_i4.PreviewForUrl>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentThumbnailAuthed(
+  _i14.Future<_i15.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -6305,7 +6357,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6323,7 +6375,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6340,21 +6392,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<bool> registrationTokenValidity(String? token) =>
+  _i14.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i14.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6364,8 +6416,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_40(
+        returnValue: _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_41(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6374,8 +6426,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_40(
+            _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_41(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6383,10 +6435,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i14.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i13.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i14.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6404,8 +6456,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_41(
+        returnValue: _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_42(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6419,8 +6471,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_41(
+            _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_42(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6433,10 +6485,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i14.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i14.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -6460,8 +6512,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i13.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_42(
+        returnValue: _i14.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_43(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6479,8 +6531,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_42(
+            _i14.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_43(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6497,10 +6549,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i14.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6528,8 +6580,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_43(
+                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6548,8 +6600,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_43(
+                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6567,10 +6619,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i14.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6599,9 +6651,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i13.Future<
+            returnValue: _i14.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6620,9 +6672,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i13.Future<
+            returnValueForMissingStub: _i14.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6641,11 +6693,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i13
+          ) as _i14
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i13.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i14.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -6661,8 +6713,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i13.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_45(
+        returnValue: _i14.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_46(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6675,8 +6727,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_45(
+            _i14.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_46(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6688,10 +6740,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetThreadRootsResponse>);
+      ) as _i14.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i13.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i14.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -6705,8 +6757,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i13.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_46(
+        returnValue: _i14.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_47(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6718,8 +6770,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_46(
+            _i14.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_47(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6730,33 +6782,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i14.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i14.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i13.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i14.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i13.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i14.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i13.Future<Uri?>.value(),
-        returnValueForMissingStub: _i13.Future<Uri?>.value(),
-      ) as _i13.Future<Uri?>);
+        returnValue: _i14.Future<Uri?>.value(),
+        returnValueForMissingStub: _i14.Future<Uri?>.value(),
+      ) as _i14.Future<Uri?>);
 
   @override
-  _i13.Future<void> add3PID(
+  _i14.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -6770,12 +6822,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> bind3PID(
+  _i14.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6791,12 +6843,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i14.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6810,14 +6862,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6839,8 +6891,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6856,8 +6908,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6873,10 +6925,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6900,8 +6952,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6918,8 +6970,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6936,10 +6988,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i14.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6953,14 +7005,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i14.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -6975,14 +7027,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7004,8 +7056,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7021,8 +7073,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7038,10 +7090,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7065,8 +7117,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7083,8 +7135,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7101,16 +7153,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i14.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
+            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7118,22 +7170,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
+            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.TokenOwnerInfo>);
+      ) as _i14.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i13.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i14.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
+        returnValue: _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7141,22 +7193,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
+            _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i13.Future<_i4.WhoIsInfo>);
+      ) as _i14.Future<_i4.WhoIsInfo>);
 
   @override
-  _i13.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i14.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
+        returnValue: _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7164,17 +7216,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
+            _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.Capabilities>);
+      ) as _i14.Future<_i4.Capabilities>);
 
   @override
-  _i13.Future<String> createRoom({
+  _i14.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -7207,7 +7259,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7229,7 +7281,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7250,10 +7302,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> deleteDevices(
+  _i14.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7263,22 +7315,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.Device>?>.value(),
-      ) as _i13.Future<List<_i4.Device>?>);
+        returnValue: _i14.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.Device>?>.value(),
+      ) as _i14.Future<List<_i4.Device>?>);
 
   @override
-  _i13.Future<void> deleteDevice(
+  _i14.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7288,34 +7340,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i14.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i13.Future<_i4.Device>.value(_FakeDevice_51(
+        returnValue: _i14.Future<_i4.Device>.value(_FakeDevice_52(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.Device>.value(_FakeDevice_51(
+        returnValueForMissingStub: _i14.Future<_i4.Device>.value(_FakeDevice_52(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i13.Future<_i4.Device>);
+      ) as _i14.Future<_i4.Device>);
 
   @override
-  _i13.Future<void> updateDevice(
+  _i14.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7325,12 +7377,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i14.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -7345,24 +7397,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i14.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i13.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Visibility?>.value(),
-      ) as _i13.Future<_i4.Visibility?>);
+        returnValue: _i14.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Visibility?>.value(),
+      ) as _i14.Future<_i4.Visibility?>);
 
   @override
-  _i13.Future<void> setRoomVisibilityOnDirectory(
+  _i14.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -7372,30 +7424,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i14.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i14.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_52(
+        returnValue: _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_53(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7403,18 +7455,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_52(
+            _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_53(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i14.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i13.Future<void> setRoomAlias(
+  _i14.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7426,12 +7478,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetEventsResponse> getEvents({
+  _i14.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7445,7 +7497,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
+            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
           this,
           Invocation.method(
             #getEvents,
@@ -7457,7 +7509,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
+            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
           this,
           Invocation.method(
             #getEvents,
@@ -7468,10 +7520,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetEventsResponse>);
+      ) as _i14.Future<_i4.GetEventsResponse>);
 
   @override
-  _i13.Future<_i4.PeekEventsResponse> peekEvents({
+  _i14.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7486,8 +7538,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i13.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_54(
+        returnValue: _i14.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_55(
           this,
           Invocation.method(
             #peekEvents,
@@ -7499,8 +7551,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_54(
+        returnValueForMissingStub: _i14.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_55(
           this,
           Invocation.method(
             #peekEvents,
@@ -7512,16 +7564,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.PeekEventsResponse>);
+      ) as _i14.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i13.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i14.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7529,27 +7581,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i13.Future<_i4.MatrixEvent>);
+      ) as _i14.Future<_i4.MatrixEvent>);
 
   @override
-  _i13.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i14.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i13.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
-      ) as _i13.Future<List<String>>);
+        returnValue: _i14.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
+      ) as _i14.Future<List<String>>);
 
   @override
-  _i13.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i14.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7561,8 +7613,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i13.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_56(
+        returnValue: _i14.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_57(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7573,8 +7625,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_56(
+            _i14.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_57(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7584,10 +7636,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.GetKeysChangesResponse>);
+      ) as _i14.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i13.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i14.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7598,7 +7650,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
+            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
           this,
           Invocation.method(
             #claimKeys,
@@ -7607,7 +7659,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
+            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
           this,
           Invocation.method(
             #claimKeys,
@@ -7615,10 +7667,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i13.Future<_i4.ClaimKeysResponse>);
+      ) as _i14.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i13.Future<void> uploadCrossSigningKeys({
+  _i14.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -7635,12 +7687,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.QueryKeysResponse> queryKeys(
+  _i14.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7651,7 +7703,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
+            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
           this,
           Invocation.method(
             #queryKeys,
@@ -7660,7 +7712,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
+            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
           this,
           Invocation.method(
             #queryKeys,
@@ -7668,10 +7720,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i13.Future<_i4.QueryKeysResponse>);
+      ) as _i14.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7679,14 +7731,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i13.Future<
+            returnValue: _i14.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i13.Future<
+            returnValueForMissingStub: _i14.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i13.Future<Map<String, int>> uploadKeys({
+  _i14.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -7701,13 +7753,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i13.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i14.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i13.Future<Map<String, int>>);
+            _i14.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i14.Future<Map<String, int>>);
 
   @override
-  _i13.Future<String> knockRoom(
+  _i14.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7721,7 +7773,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7733,7 +7785,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7744,20 +7796,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i14.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i13.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i14.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i14.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i13.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i14.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7772,8 +7824,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i13.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_59(
+        returnValue: _i14.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_60(
           this,
           Invocation.method(
             #getNotifications,
@@ -7786,8 +7838,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_59(
+            _i14.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_60(
           this,
           Invocation.method(
             #getNotifications,
@@ -7799,35 +7851,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetNotificationsResponse>);
+      ) as _i14.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i13.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i14.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i13.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_60(
+        returnValue: _i14.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_61(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_60(
+        returnValueForMissingStub: _i14.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_61(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i13.Future<_i4.GetPresenceResponse>);
+      ) as _i14.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i13.Future<void> setPresence(
+  _i14.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -7841,12 +7893,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, Object?>> deleteProfileField(
+  _i14.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7859,13 +7911,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getProfileField(
+  _i14.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7878,13 +7930,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<Map<String, Object?>> setProfileField(
+  _i14.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7899,13 +7951,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i14.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -7920,8 +7972,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i13.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_61(
+        returnValue: _i14.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_62(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7934,8 +7986,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_61(
+            _i14.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_62(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7947,10 +7999,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i14.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i13.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i14.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -7971,8 +8023,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i13.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_62(
+        returnValue: _i14.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_63(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7988,8 +8040,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_62(
+            _i14.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_63(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8004,25 +8056,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i14.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i13.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.Pusher>?>.value(),
-      ) as _i13.Future<List<_i4.Pusher>?>);
+        returnValue: _i14.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.Pusher>?>.value(),
+      ) as _i14.Future<List<_i4.Pusher>?>);
 
   @override
-  _i13.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i14.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
+        returnValue: _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
           this,
           Invocation.method(
             #getPushRules,
@@ -8030,24 +8082,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
+            _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.PushRuleSet>);
+      ) as _i14.Future<_i4.PushRuleSet>);
 
   @override
-  _i13.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i14.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_64(
+        returnValue: _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_65(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8055,18 +8107,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_64(
+            _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_65(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i14.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i13.Future<void> deletePushRule(
+  _i14.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8078,12 +8130,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.PushRule> getPushRule(
+  _i14.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8095,7 +8147,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<_i4.PushRule>.value(_FakePushRule_65(
+        returnValue: _i14.Future<_i4.PushRule>.value(_FakePushRule_66(
           this,
           Invocation.method(
             #getPushRule,
@@ -8106,7 +8158,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PushRule>.value(_FakePushRule_65(
+            _i14.Future<_i4.PushRule>.value(_FakePushRule_66(
           this,
           Invocation.method(
             #getPushRule,
@@ -8116,10 +8168,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.PushRule>);
+      ) as _i14.Future<_i4.PushRule>);
 
   @override
-  _i13.Future<void> setPushRule(
+  _i14.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -8143,12 +8195,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<Object?>> getPushRuleActions(
+  _i14.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8160,13 +8212,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i14.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i13.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i13.Future<List<Object?>>);
+            _i14.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i14.Future<List<Object?>>);
 
   @override
-  _i13.Future<void> setPushRuleActions(
+  _i14.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -8180,12 +8232,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<bool> isPushRuleEnabled(
+  _i14.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8197,12 +8249,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> setPushRuleEnabled(
+  _i14.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -8216,19 +8268,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i14.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
+            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
           this,
           Invocation.method(
             #refresh,
@@ -8236,28 +8288,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
+            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i13.Future<_i4.RefreshResponse>);
+      ) as _i14.Future<_i4.RefreshResponse>);
 
   @override
-  _i13.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i14.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i13.Future<bool?>.value(),
-        returnValueForMissingStub: _i13.Future<bool?>.value(),
-      ) as _i13.Future<bool?>);
+        returnValue: _i14.Future<bool?>.value(),
+        returnValueForMissingStub: _i14.Future<bool?>.value(),
+      ) as _i14.Future<bool?>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8279,8 +8331,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8296,8 +8348,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8313,10 +8365,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8340,8 +8392,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8358,8 +8410,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8376,17 +8428,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8394,23 +8446,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i14.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
+        returnValue: _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8418,17 +8470,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
+            _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeys>);
+      ) as _i14.Future<_i4.RoomKeys>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -8440,8 +8492,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8452,8 +8504,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8463,10 +8515,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8478,8 +8530,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8490,8 +8542,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8501,10 +8553,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8516,7 +8568,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
+        returnValue: _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8527,7 +8579,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
+            _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8537,10 +8589,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeyBackup>);
+      ) as _i14.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -8554,8 +8606,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8567,8 +8619,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8579,10 +8631,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8596,8 +8648,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8609,8 +8661,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8621,10 +8673,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i14.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8638,7 +8690,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8650,7 +8702,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8661,10 +8713,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.KeyBackupData>);
+      ) as _i14.Future<_i4.KeyBackupData>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8680,8 +8732,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8694,8 +8746,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8707,18 +8759,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_69(
+                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_70(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8726,18 +8778,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_69(
+                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_70(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i13.Future<String> postRoomKeysVersion(
+  _i14.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -8749,7 +8801,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8760,7 +8812,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8770,29 +8822,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i14.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i14.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_70(
+        returnValue: _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_71(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8800,18 +8852,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_70(
+            _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_71(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i14.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i14.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -8826,24 +8878,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i14.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i13.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
-      ) as _i13.Future<List<String>>);
+        returnValue: _i14.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
+      ) as _i14.Future<List<String>>);
 
   @override
-  _i13.Future<void> ban(
+  _i14.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8857,12 +8909,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.EventContext> getEventContext(
+  _i14.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -8880,7 +8932,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<_i4.EventContext>.value(_FakeEventContext_71(
+        returnValue: _i14.Future<_i4.EventContext>.value(_FakeEventContext_72(
           this,
           Invocation.method(
             #getEventContext,
@@ -8895,7 +8947,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.EventContext>.value(_FakeEventContext_71(
+            _i14.Future<_i4.EventContext>.value(_FakeEventContext_72(
           this,
           Invocation.method(
             #getEventContext,
@@ -8909,10 +8961,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.EventContext>);
+      ) as _i14.Future<_i4.EventContext>);
 
   @override
-  _i13.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i14.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -8924,7 +8976,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8935,7 +8987,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8945,20 +8997,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.MatrixEvent>);
+      ) as _i14.Future<_i4.MatrixEvent>);
 
   @override
-  _i13.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i14.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> inviteBy3PID(
+  _i14.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -8970,12 +9022,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> inviteUser(
+  _i14.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8989,12 +9041,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> joinRoomById(
+  _i14.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -9008,7 +9060,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9020,7 +9072,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9031,23 +9083,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i14.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i13.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i14.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i13.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i13.Future<Map<String, _i4.RoomMember>?>);
+            _i14.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i14.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i13.Future<void> kick(
+  _i14.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9061,12 +9113,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> leaveRoom(
+  _i14.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9076,12 +9128,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i14.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -9097,12 +9149,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i13.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i13.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i14.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i14.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i13.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i14.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -9124,8 +9176,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_72(
+        returnValue: _i14.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_73(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9141,8 +9193,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_72(
+        returnValueForMissingStub: _i14.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_73(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9158,10 +9210,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomEventsResponse>);
+      ) as _i14.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i13.Future<void> setReadMarker(
+  _i14.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9177,12 +9229,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> postReceipt(
+  _i14.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -9198,12 +9250,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEvent(
+  _i14.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9219,12 +9271,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> reportRoom(
+  _i14.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9236,12 +9288,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> reportEvent(
+  _i14.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9259,12 +9311,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> sendMessage(
+  _i14.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9280,7 +9332,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9293,7 +9345,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9305,23 +9357,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i14.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i13.Future<List<_i4.MatrixEvent>>);
+            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i14.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i14.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -9338,13 +9390,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<String> setRoomStateWithKey(
+  _i14.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9360,7 +9412,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9373,7 +9425,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9385,10 +9437,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> unban(
+  _i14.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9402,12 +9454,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> upgradeRoom(
+  _i14.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9421,7 +9473,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9433,7 +9485,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9444,10 +9496,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.SearchResults> search(
+  _i14.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -9457,7 +9509,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
+        returnValue: _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
           this,
           Invocation.method(
             #search,
@@ -9466,7 +9518,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
+            _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
           this,
           Invocation.method(
             #search,
@@ -9474,10 +9526,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i13.Future<_i4.SearchResults>);
+      ) as _i14.Future<_i4.SearchResults>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> sync({
+  _i14.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -9498,7 +9550,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #sync,
@@ -9514,7 +9566,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #sync,
@@ -9529,22 +9581,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i14.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i13.Future<List<_i4.Location>>);
+            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i14.Future<List<_i4.Location>>);
 
   @override
-  _i13.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i14.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9554,21 +9606,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i13.Future<List<_i4.Location>>);
+            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i14.Future<List<_i4.Location>>);
 
   @override
-  _i13.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i14.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_74(
+        returnValue: _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_75(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9576,45 +9628,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_74(
+            _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_75(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i13.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i14.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i13.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i14.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9625,13 +9677,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getAccountData(
+  _i14.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9644,13 +9696,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> setAccountData(
+  _i14.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9664,12 +9716,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> defineFilter(
+  _i14.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -9681,7 +9733,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9692,7 +9744,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9702,10 +9754,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.Filter> getFilter(
+  _i14.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9717,7 +9769,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i13.Future<_i4.Filter>.value(_FakeFilter_18(
+        returnValue: _i14.Future<_i4.Filter>.value(_FakeFilter_19(
           this,
           Invocation.method(
             #getFilter,
@@ -9727,7 +9779,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.Filter>.value(_FakeFilter_18(
+        returnValueForMissingStub: _i14.Future<_i4.Filter>.value(_FakeFilter_19(
           this,
           Invocation.method(
             #getFilter,
@@ -9737,10 +9789,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.Filter>);
+      ) as _i14.Future<_i4.Filter>);
 
   @override
-  _i13.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i14.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9753,7 +9805,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
+            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9764,7 +9816,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
+            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9774,10 +9826,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.OpenIdCredentials>);
+      ) as _i14.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i13.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i14.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9792,13 +9844,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> setAccountDataPerRoom(
+  _i14.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9814,12 +9866,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i14.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9831,12 +9883,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i13.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i13.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i13.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i14.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i14.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i14.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i13.Future<void> deleteRoomTag(
+  _i14.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9850,12 +9902,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setRoomTag(
+  _i14.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9871,12 +9923,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i14.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9886,8 +9938,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i13.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_76(
+        returnValue: _i14.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_77(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9896,8 +9948,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_76(
+            _i14.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_77(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9905,10 +9957,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i13.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i14.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> reportUser(
+  _i14.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -9921,40 +9973,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i14.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i13.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_77(
+        returnValue: _i14.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_78(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_77(
+        returnValueForMissingStub: _i14.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_78(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.CreateContentResponse>);
+      ) as _i14.Future<_i4.CreateContentResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> uploadContentToMXC(
+  _i14.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i23.Uint8List? body, {
+    _i24.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -9972,8 +10024,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 }

--- a/test/widgets/invite_tile_test.mocks.dart
+++ b/test/widgets/invite_tile_test.mocks.dart
@@ -3,34 +3,36 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i13;
-import 'dart:typed_data' as _i23;
-import 'dart:ui' as _i17;
+import 'dart:async' as _i14;
+import 'dart:typed_data' as _i24;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
-import 'package:http/http.dart' as _i12;
-import 'package:kohera/core/services/matrix_service.dart' as _i15;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
+import 'package:http/http.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i16;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i7;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i8;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i22;
+import 'package:matrix/encryption.dart' as _i23;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i14;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i11;
-import 'package:matrix/src/utils/space_child.dart' as _i20;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i15;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i12;
+import 'package:matrix/src/utils/space_child.dart' as _i21;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -111,8 +113,9 @@ class _FakeSelectionService_5 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
-  _FakeSyncService_6(
+class _FakeSpaceAccessService_6 extends _i1.SmartFake
+    implements _i8.SpaceAccessService {
+  _FakeSpaceAccessService_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -121,8 +124,8 @@ class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
         );
 }
 
-class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
-  _FakeAuthService_7(
+class _FakeSyncService_7 extends _i1.SmartFake implements _i9.SyncService {
+  _FakeSyncService_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -131,8 +134,8 @@ class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
         );
 }
 
-class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
-  _FakeOutboxService_8(
+class _FakeAuthService_8 extends _i1.SmartFake implements _i10.AuthService {
+  _FakeAuthService_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -141,8 +144,8 @@ class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
         );
 }
 
-class _FakeRoomSummary_9 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_9(
+class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
+  _FakeOutboxService_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -151,9 +154,8 @@ class _FakeRoomSummary_9 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_10<T> extends _i1.SmartFake
-    implements _i11.CachedStreamController<T> {
-  _FakeCachedStreamController_10(
+class _FakeRoomSummary_10 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -162,8 +164,9 @@ class _FakeCachedStreamController_10<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_11 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_11(
+class _FakeCachedStreamController_11<T> extends _i1.SmartFake
+    implements _i12.CachedStreamController<T> {
+  _FakeCachedStreamController_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -172,9 +175,19 @@ class _FakeDateTime_11 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_12 extends _i1.SmartFake
+class _FakeDateTime_12 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_12(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_13 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_12(
+  _FakeLatestReceiptState_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -183,8 +196,8 @@ class _FakeLatestReceiptState_12 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_13 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_13(
+class _FakeSyncUpdate_14 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -193,8 +206,8 @@ class _FakeSyncUpdate_13 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeTimeline_14 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_14(
+class _FakeTimeline_15 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -203,8 +216,8 @@ class _FakeTimeline_14 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_15 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_15(
+class _FakeUser_16 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -213,8 +226,8 @@ class _FakeUser_15 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeUri_16 extends _i1.SmartFake implements Uri {
-  _FakeUri_16(
+class _FakeUri_17 extends _i1.SmartFake implements Uri {
+  _FakeUri_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -223,8 +236,8 @@ class _FakeUri_16 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_17 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_17(
+class _FakeDatabaseApi_18 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -233,8 +246,8 @@ class _FakeDatabaseApi_17 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_18 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_18(
+class _FakeFilter_19 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -243,9 +256,9 @@ class _FakeFilter_18 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_19 extends _i1.SmartFake
+class _FakeNativeImplementations_20 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_19(
+  _FakeNativeImplementations_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -254,8 +267,8 @@ class _FakeNativeImplementations_19 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_20 extends _i1.SmartFake implements Duration {
-  _FakeDuration_20(
+class _FakeDuration_21 extends _i1.SmartFake implements Duration {
+  _FakeDuration_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -264,9 +277,9 @@ class _FakeDuration_20 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_21 extends _i1.SmartFake
+class _FakePushruleEvaluator_22 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_21(
+  _FakePushruleEvaluator_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -275,8 +288,8 @@ class _FakePushruleEvaluator_21 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_22 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_22(
+class _FakeProfile_23 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -285,8 +298,8 @@ class _FakeProfile_22 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeClient_23 extends _i1.SmartFake implements _i12.Client {
-  _FakeClient_23(
+class _FakeClient_24 extends _i1.SmartFake implements _i13.Client {
+  _FakeClient_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -295,9 +308,9 @@ class _FakeClient_23 extends _i1.SmartFake implements _i12.Client {
         );
 }
 
-class _FakeDiscoveryInformation_24 extends _i1.SmartFake
+class _FakeDiscoveryInformation_25 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_24(
+  _FakeDiscoveryInformation_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -306,9 +319,9 @@ class _FakeDiscoveryInformation_24 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_25 extends _i1.SmartFake
+class _FakeGetVersionsResponse_26 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_25(
+  _FakeGetVersionsResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -317,9 +330,9 @@ class _FakeGetVersionsResponse_25 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_26 extends _i1.SmartFake
+class _FakeRegisterResponse_27 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_26(
+  _FakeRegisterResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -328,8 +341,8 @@ class _FakeRegisterResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_27 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_27(
+class _FakeLoginResponse_28 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -338,9 +351,9 @@ class _FakeLoginResponse_27 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_28 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_29 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_28(
+  _FakeGetAuthMetadataResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -349,8 +362,8 @@ class _FakeGetAuthMetadataResponse_28 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_29<T1> extends _i1.SmartFake implements _i13.Future<T1> {
-  _FakeFuture_29(
+class _FakeFuture_30<T1> extends _i1.SmartFake implements _i14.Future<T1> {
+  _FakeFuture_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -359,9 +372,9 @@ class _FakeFuture_29<T1> extends _i1.SmartFake implements _i13.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_30 extends _i1.SmartFake
+class _FakeCachedProfileInformation_31 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_30(
+  _FakeCachedProfileInformation_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -370,8 +383,8 @@ class _FakeCachedProfileInformation_30 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_31 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_31(
+class _FakeMediaConfig_32 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -380,8 +393,8 @@ class _FakeMediaConfig_31 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_32 extends _i1.SmartFake implements _i14.FileResponse {
-  _FakeFileResponse_32(
+class _FakeFileResponse_33 extends _i1.SmartFake implements _i15.FileResponse {
+  _FakeFileResponse_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -390,8 +403,8 @@ class _FakeFileResponse_32 extends _i1.SmartFake implements _i14.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_33 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_33(
+class _FakePreviewForUrl_34 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -400,9 +413,9 @@ class _FakePreviewForUrl_33 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_34 extends _i1.SmartFake
+class _FakeCachedPresence_35 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_34(
+  _FakeCachedPresence_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -411,9 +424,9 @@ class _FakeCachedPresence_34 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_35 extends _i1.SmartFake
+class _FakeTurnServerCredentials_36 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_35(
+  _FakeTurnServerCredentials_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -422,9 +435,9 @@ class _FakeTurnServerCredentials_35 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_37 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_36(
+  _FakeRoomKeysUpdateResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -433,8 +446,8 @@ class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_37(
+class _FakeKeyBackupData_38 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -443,9 +456,9 @@ class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_39 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_38(
+  _FakeGetWellknownSupportResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -454,9 +467,9 @@ class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_40 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_39(
+  _FakeGenerateLoginTokenResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -465,9 +478,9 @@ class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_41 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_40(
+  _FakeGetRoomSummaryResponse$3_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -476,9 +489,9 @@ class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_42 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_41(
+  _FakeGetSpaceHierarchyResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -487,9 +500,9 @@ class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_43 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_42(
+  _FakeGetRelatingEventsResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -498,9 +511,9 @@ class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_44 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_43(
+  _FakeGetRelatingEventsWithRelTypeResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -509,9 +522,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -520,9 +533,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_46 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_45(
+  _FakeGetThreadRootsResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -531,9 +544,9 @@ class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_47 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_46(
+  _FakeGetEventByTimestampResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -542,9 +555,9 @@ class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_47 extends _i1.SmartFake
+class _FakeRequestTokenResponse_48 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_47(
+  _FakeRequestTokenResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -553,9 +566,9 @@ class _FakeRequestTokenResponse_47 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_49 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_48(
+  _FakeTokenOwnerInfo_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -564,8 +577,8 @@ class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_49(
+class _FakeWhoIsInfo_50 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -574,8 +587,8 @@ class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_50(
+class _FakeCapabilities_51 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -584,8 +597,8 @@ class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_51(
+class _FakeDevice_52 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -594,9 +607,9 @@ class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_53 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_52(
+  _FakeGetRoomIdByAliasResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -605,9 +618,9 @@ class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_53 extends _i1.SmartFake
+class _FakeGetEventsResponse_54 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_53(
+  _FakeGetEventsResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -616,9 +629,9 @@ class _FakeGetEventsResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_54 extends _i1.SmartFake
+class _FakePeekEventsResponse_55 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_54(
+  _FakePeekEventsResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -627,8 +640,8 @@ class _FakePeekEventsResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_55(
+class _FakeMatrixEvent_56 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -637,9 +650,9 @@ class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_57 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_56(
+  _FakeGetKeysChangesResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -648,9 +661,9 @@ class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_57 extends _i1.SmartFake
+class _FakeClaimKeysResponse_58 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_57(
+  _FakeClaimKeysResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -659,9 +672,9 @@ class _FakeClaimKeysResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_58 extends _i1.SmartFake
+class _FakeQueryKeysResponse_59 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_58(
+  _FakeQueryKeysResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -670,9 +683,9 @@ class _FakeQueryKeysResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_60 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_59(
+  _FakeGetNotificationsResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -681,9 +694,9 @@ class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_60 extends _i1.SmartFake
+class _FakeGetPresenceResponse_61 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_60(
+  _FakeGetPresenceResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -692,9 +705,9 @@ class _FakeGetPresenceResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_62 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_61(
+  _FakeGetPublicRoomsResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -703,9 +716,9 @@ class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_63 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_62(
+  _FakeQueryPublicRoomsResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -714,8 +727,8 @@ class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_63(
+class _FakePushRuleSet_64 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -724,9 +737,9 @@ class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_65 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_64(
+  _FakeGetPushRulesGlobalResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -735,8 +748,8 @@ class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_65(
+class _FakePushRule_66 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -745,9 +758,9 @@ class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_66 extends _i1.SmartFake
+class _FakeRefreshResponse_67 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_66(
+  _FakeRefreshResponse_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,8 +769,8 @@ class _FakeRefreshResponse_66 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_67(
+class _FakeRoomKeys_68 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -766,8 +779,8 @@ class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_68(
+class _FakeRoomKeyBackup_69 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -776,9 +789,9 @@ class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_70 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_69(
+  _FakeGetRoomKeysVersionCurrentResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -787,9 +800,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_71 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_70(
+  _FakeGetRoomKeysVersionResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,8 +811,8 @@ class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_71(
+class _FakeEventContext_72 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,9 +821,9 @@ class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_73 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_72(
+  _FakeGetRoomEventsResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -819,8 +832,8 @@ class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_73(
+class _FakeSearchResults_74 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,9 +842,9 @@ class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_75 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_74(
+  _FakeGetProtocolMetadataResponse$2_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -840,9 +853,9 @@ class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_75 extends _i1.SmartFake
+class _FakeOpenIdCredentials_76 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_75(
+  _FakeOpenIdCredentials_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -851,9 +864,9 @@ class _FakeOpenIdCredentials_75 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_77 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_76(
+  _FakeSearchUserDirectoryResponse_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -862,9 +875,9 @@ class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_77 extends _i1.SmartFake
+class _FakeCreateContentResponse_78 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_77(
+  _FakeCreateContentResponse_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -876,7 +889,7 @@ class _FakeCreateContentResponse_77 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -906,11 +919,11 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -983,43 +996,56 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as _i7.SelectionService);
 
   @override
-  _i8.SyncService get sync => (super.noSuchMethod(
+  _i8.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_6(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_6(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i8.SpaceAccessService);
+
+  @override
+  _i9.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_6(
+        returnValue: _FakeSyncService_7(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_6(
+        returnValueForMissingStub: _FakeSyncService_7(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i8.SyncService);
+      ) as _i9.SyncService);
 
   @override
-  _i9.AuthService get auth => (super.noSuchMethod(
+  _i10.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_7(
+        returnValue: _FakeAuthService_8(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_7(
+        returnValueForMissingStub: _FakeAuthService_8(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i9.AuthService);
+      ) as _i10.AuthService);
 
   @override
-  _i10.OutboxService get outbox => (super.noSuchMethod(
+  _i11.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_8(
+        returnValue: _FakeOutboxService_9(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_8(
+        returnValueForMissingStub: _FakeOutboxService_9(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i10.OutboxService);
+      ) as _i11.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1083,7 +1109,16 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set sync(_i8.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i8.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i9.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -1092,7 +1127,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set auth(_i9.AuthService? value) => super.noSuchMethod(
+  set auth(_i10.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -1101,7 +1136,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set outbox(_i10.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i11.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -1117,14 +1152,14 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as bool);
 
   @override
-  _i13.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1154,7 +1189,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1164,18 +1199,18 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<bool> login({
+  _i14.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1190,12 +1225,12 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> completeSsoLogin({
+  _i14.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1208,12 +1243,12 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> completeRegistration(
+  _i14.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1223,32 +1258,32 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1257,7 +1292,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1266,17 +1301,17 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1287,7 +1322,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1324,26 +1359,26 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+  _i14.Future<bool> didPushRouteInformation(
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1373,7 +1408,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1382,7 +1417,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1391,16 +1426,16 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i14.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i13.Future<_i17.AppExitResponse>);
+            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i14.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1428,11 +1463,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1462,11 +1497,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_9(
+        returnValue: _FakeRoomSummary_10(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_9(
+        returnValueForMissingStub: _FakeRoomSummary_10(
           this,
           Invocation.getter(#summary),
         ),
@@ -1496,11 +1531,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i13.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i14.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i13.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i13.Completer<dynamic>>[],
-      ) as List<_i13.Completer<dynamic>>);
+        returnValue: <_i14.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i14.Completer<dynamic>>[],
+      ) as List<_i14.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1519,51 +1554,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i11.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i12.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_10<String>(
+        returnValue: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i11.CachedStreamController<String> get onSessionKeyReceived =>
+  _i12.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_10<String>(
+        returnValue: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1579,11 +1614,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1592,11 +1627,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1639,11 +1674,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1652,11 +1687,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_11(
+        returnValue: _FakeDateTime_12(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_11(
+        returnValueForMissingStub: _FakeDateTime_12(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -1686,11 +1721,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_12(
+        returnValue: _FakeLatestReceiptState_13(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_12(
+        returnValueForMissingStub: _FakeLatestReceiptState_13(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -1711,22 +1746,29 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i13.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i14.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
         Invocation.getter(#isFavourite),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
@@ -1902,18 +1944,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i20.SpaceParent>[],
-        returnValueForMissingStub: <_i20.SpaceParent>[],
-      ) as List<_i20.SpaceParent>);
+        returnValue: <_i21.SpaceParent>[],
+        returnValueForMissingStub: <_i21.SpaceParent>[],
+      ) as List<_i21.SpaceParent>);
 
   @override
-  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i20.SpaceChild>[],
-        returnValueForMissingStub: <_i20.SpaceChild>[],
-      ) as List<_i20.SpaceChild>);
+        returnValue: <_i21.SpaceChild>[],
+        returnValueForMissingStub: <_i21.SpaceChild>[],
+      ) as List<_i21.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -2026,14 +2068,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i13.Future<void> postLoad() => (super.noSuchMethod(
+  _i14.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -2061,15 +2103,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i13.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i14.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i13.Future<List<_i4.User>>);
+            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i14.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -2080,14 +2122,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2097,18 +2139,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i13.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i14.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Event?> refreshLastEvent(
+  _i14.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2116,9 +2158,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -2130,12 +2172,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i13.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i14.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2143,22 +2185,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i14.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2166,17 +2208,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> addTag(
+  _i14.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2186,27 +2228,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i14.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i14.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2214,43 +2256,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i14.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i14.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i14.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
+        ),
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
+
+  @override
+  _i14.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2258,14 +2310,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2277,7 +2329,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i13.Future<String?> sendTextEvent(
+  _i14.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2309,12 +2361,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendReaction(
+  _i14.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2328,12 +2380,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendLocation(
+  _i14.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2347,12 +2399,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendFileEvent(
+  _i14.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2380,25 +2432,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i14.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i13.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i14.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i13.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i14.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i13.Future<_i4.EncryptionHealthState>);
+      ) as _i14.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i13.Future<String?> sendEvent(
+  _i14.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -2422,73 +2474,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i14.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> leave() => (super.noSuchMethod(
+  _i14.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> forget() => (super.noSuchMethod(
+  _i14.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> setPower(
+  _i14.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2500,7 +2552,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2511,7 +2563,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2521,10 +2573,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> invite(
+  _i14.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2534,12 +2586,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<int> requestHistory({
+  _i14.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -2556,32 +2608,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<int>.value(0),
-        returnValueForMissingStub: _i13.Future<int>.value(0),
-      ) as _i13.Future<int>);
+        returnValue: _i14.Future<int>.value(0),
+        returnValueForMissingStub: _i14.Future<int>.value(0),
+      ) as _i14.Future<int>);
 
   @override
-  _i13.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i14.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setReadMarker(
+  _i14.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2595,23 +2647,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
+  _i14.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i13.Future<_i21.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i13.Future<_i21.TimelineChunk?>.value(),
-      ) as _i13.Future<_i21.TimelineChunk?>);
+        returnValue: _i14.Future<_i22.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i14.Future<_i22.TimelineChunk?>.value(),
+      ) as _i14.Future<_i22.TimelineChunk?>);
 
   @override
-  _i13.Future<void> postReceipt(
+  _i14.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -2621,12 +2673,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Timeline> getTimeline({
+  _i14.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2649,7 +2701,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i13.Future<_i4.Timeline>.value(_FakeTimeline_14(
+        returnValue: _i14.Future<_i4.Timeline>.value(_FakeTimeline_15(
           this,
           Invocation.method(
             #getTimeline,
@@ -2666,7 +2718,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Timeline>.value(_FakeTimeline_14(
+            _i14.Future<_i4.Timeline>.value(_FakeTimeline_15(
           this,
           Invocation.method(
             #getTimeline,
@@ -2682,7 +2734,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Timeline>);
+      ) as _i14.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -2701,7 +2753,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i13.Future<List<_i4.User>> requestParticipants([
+  _i14.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -2719,10 +2771,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i13.Future<List<_i4.User>>);
+            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i14.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -2730,14 +2782,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_15(
+        returnValue: _FakeUser_16(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_15(
+        returnValueForMissingStub: _FakeUser_16(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -2753,14 +2805,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_15(
+        returnValue: _FakeUser_16(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_15(
+        returnValueForMissingStub: _FakeUser_16(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -2770,7 +2822,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i13.Future<_i4.User?> requestUser(
+  _i14.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2786,19 +2838,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i13.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.User?>.value(),
-      ) as _i13.Future<_i4.User?>);
+        returnValue: _i14.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.User?>.value(),
+      ) as _i14.Future<_i4.User?>);
 
   @override
-  _i13.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i14.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2811,12 +2863,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i13.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i14.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2824,14 +2876,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2854,14 +2906,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i13.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i14.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -2900,18 +2952,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i13.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i14.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEvent(
+  _i14.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -2925,12 +2977,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> setTyping(
+  _i14.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -2940,12 +2992,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setJoinRules(
+  _i14.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -2959,59 +3011,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i14.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setHistoryVisibility(
+  _i14.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i14.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i14.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i13.Future<List<_i4.DeviceKeys>>);
+            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i14.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i13.Future<void> requestSessionKey(
+  _i14.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -3023,12 +3075,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setSpaceChild(
+  _i14.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3044,44 +3096,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i14.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i13.Future<Uri>.value(_FakeUri_16(
+        returnValue: _i14.Future<Uri>.value(_FakeUri_17(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_16(
+        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_17(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i13.Future<Uri>);
+      ) as _i14.Future<Uri>);
 
   @override
-  _i13.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i14.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<
+  _i14.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -3108,21 +3160,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i13.Future<
+        returnValue: _i14.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i13.Future<
+        returnValueForMissingStub: _i14.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i13.Future<
+      ) as _i14.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -3137,23 +3189,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_17(
+        returnValue: _FakeDatabaseApi_18(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_17(
+        returnValueForMissingStub: _FakeDatabaseApi_18(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i22.KeyVerificationMethod> get verificationMethods =>
+  Set<_i23.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i22.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i22.KeyVerificationMethod>{},
-      ) as Set<_i22.KeyVerificationMethod>);
+        returnValue: <_i23.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i23.KeyVerificationMethod>{},
+      ) as Set<_i23.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3214,11 +3266,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_18(
+        returnValue: _FakeFilter_19(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_18(
+        returnValueForMissingStub: _FakeFilter_19(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -3227,11 +3279,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_19(
+        returnValue: _FakeNativeImplementations_20(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_19(
+        returnValueForMissingStub: _FakeNativeImplementations_20(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -3247,11 +3299,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_20(
+        returnValue: _FakeDuration_21(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_20(
+        returnValueForMissingStub: _FakeDuration_21(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3260,11 +3312,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_20(
+        returnValue: _FakeDuration_21(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_20(
+        returnValueForMissingStub: _FakeDuration_21(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3273,11 +3325,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -3314,11 +3366,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3348,11 +3400,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3361,11 +3413,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3388,11 +3440,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_21(
+        returnValue: _FakePushruleEvaluator_22(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_21(
+        returnValueForMissingStub: _FakePushruleEvaluator_22(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -3413,332 +3465,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i13.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i14.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i11.CachedStreamController<String> get onUserProfileUpdate =>
+  _i12.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_10<String>(
+        returnValue: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i13.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i14.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i13.Future<List<_i4.Room>>);
+            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i14.Future<List<_i4.Room>>);
 
   @override
-  _i11.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i12.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_10<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_11<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.EventUpdate>(
+            _FakeCachedStreamController_11<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.EventUpdate>);
+      ) as _i12.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i12.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_10<_i4.Event>(
+        returnValue: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i12.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_10<_i4.Event>(
+        returnValue: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onNotification =>
+  _i12.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_10<_i4.Event>(
+        returnValue: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i12.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_10<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_11<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_11<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i12.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i11.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i12.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_10<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_11<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_10<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_11<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i11.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i12.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i11.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i12.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_10<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_11<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.LoginState>(
+            _FakeCachedStreamController_11<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i11.CachedStreamController<_i4.LoginState>);
+      ) as _i12.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i11.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i12.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_10<bool>(
+        returnValue: _FakeCachedStreamController_11<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i11.CachedStreamController<bool>);
+      ) as _i12.CachedStreamController<bool>);
 
   @override
-  _i11.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i12.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_10<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_11<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i11.CachedStreamController<_i4.SdkError>);
+      ) as _i12.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i11.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i12.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_10<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_11<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.SyncUpdate>(
+            _FakeCachedStreamController_11<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i11.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i12.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i12.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_10<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_11<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_11<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i11.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i12.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.Presence> get onPresence =>
+  _i12.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_10<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_11<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i11.CachedStreamController<_i4.Presence>);
+      ) as _i12.CachedStreamController<_i4.Presence>);
 
   @override
-  _i11.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i12.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_10<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_11<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.CachedPresence>(
+            _FakeCachedStreamController_11<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i11.CachedStreamController<_i4.CachedPresence>);
+      ) as _i12.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i11.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i12.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_10<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_11<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.BasicEvent>(
+            _FakeCachedStreamController_11<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i11.CachedStreamController<_i4.BasicEvent>);
+      ) as _i12.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i11.CachedStreamController<_i22.RoomKeyRequest> get onRoomKeyRequest =>
+  _i12.CachedStreamController<_i23.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_10<_i22.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_11<_i23.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i22.RoomKeyRequest>(
+            _FakeCachedStreamController_11<_i23.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i11.CachedStreamController<_i22.RoomKeyRequest>);
+      ) as _i12.CachedStreamController<_i23.RoomKeyRequest>);
 
   @override
-  _i11.CachedStreamController<_i22.KeyVerification>
+  _i12.CachedStreamController<_i23.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_10<_i22.KeyVerification>(
+            returnValue: _FakeCachedStreamController_11<_i23.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_10<_i22.KeyVerification>(
+                _FakeCachedStreamController_11<_i23.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i11.CachedStreamController<_i22.KeyVerification>);
+          ) as _i12.CachedStreamController<_i23.KeyVerification>);
 
   @override
-  _i11.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i12.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_10<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_11<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_11<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i11.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i12.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i12.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_10<_i4.Event>(
+        returnValue: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<String> get onCancelSendEvent =>
+  _i12.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_10<String>(
+        returnValue: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i11.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i12.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_10<
+            returnValue: _FakeCachedStreamController_11<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_10<
+            returnValueForMissingStub: _FakeCachedStreamController_11<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i11.CachedStreamController<
+          ) as _i12.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -3758,11 +3810,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_11(
+        returnValue: _FakeDateTime_12(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_11(
+        returnValueForMissingStub: _FakeDateTime_12(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3835,7 +3887,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i22.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i23.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3890,7 +3942,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i13.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i14.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -3901,7 +3953,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i13.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i14.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -4012,7 +4064,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -4021,7 +4073,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -4030,7 +4082,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4057,20 +4109,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Client get httpClient => (super.noSuchMethod(
+  _i13.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_23(
+        returnValue: _FakeClient_24(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_23(
+        returnValueForMissingStub: _FakeClient_24(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i12.Client);
+      ) as _i13.Client);
 
   @override
-  set httpClient(_i12.Client? value) => super.noSuchMethod(
+  set httpClient(_i13.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4097,7 +4149,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<void> refreshAccessToken(
+  _i14.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4105,9 +4157,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4125,14 +4177,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4169,33 +4221,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i13.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i14.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i13.Future<_i4.DiscoveryInformation>);
+      ) as _i14.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i13.Future<
+  _i14.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -4217,7 +4269,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i13.Future<
+        returnValue: _i14.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4225,7 +4277,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_25(
+          _FakeGetVersionsResponse_26(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4240,7 +4292,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i13.Future<
+        returnValueForMissingStub: _i14.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4248,7 +4300,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_25(
+          _FakeGetVersionsResponse_26(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4263,7 +4315,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i13.Future<
+      ) as _i14.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -4272,7 +4324,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i13.Future<_i4.DiscoveryInformation> getWellknown({
+  _i14.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4285,8 +4337,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getWellknown,
@@ -4297,8 +4349,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getWellknown,
@@ -4309,10 +4361,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.DiscoveryInformation>);
+      ) as _i14.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i13.Future<_i4.RegisterResponse> register({
+  _i14.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -4340,7 +4392,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
+            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
           this,
           Invocation.method(
             #register,
@@ -4359,7 +4411,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
+            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
           this,
           Invocation.method(
             #register,
@@ -4377,10 +4429,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RegisterResponse>);
+      ) as _i14.Future<_i4.RegisterResponse>);
 
   @override
-  _i13.Future<_i4.LoginResponse> login(
+  _i14.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -4410,7 +4462,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
+        returnValue: _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
           this,
           Invocation.method(
             #login,
@@ -4430,7 +4482,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
+            _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
           this,
           Invocation.method(
             #login,
@@ -4449,10 +4501,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.LoginResponse>);
+      ) as _i14.Future<_i4.LoginResponse>);
 
   @override
-  _i13.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i14.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4465,8 +4517,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_28(
+        returnValue: _i14.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_29(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4478,8 +4530,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_28(
+            _i14.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_29(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4490,74 +4542,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i14.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> logoutAll() => (super.noSuchMethod(
+  _i14.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<T> uiaRequestBackground<T>(
-          _i13.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i14.Future<T> uiaRequestBackground<T>(
+          _i14.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i13.Future<T>.value(v),
+              (T v) => _i14.Future<T>.value(v),
             ) ??
-            _FakeFuture_29<T>(
+            _FakeFuture_30<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i13.Future<T>.value(v),
+              (T v) => _i14.Future<T>.value(v),
             ) ??
-            _FakeFuture_29<T>(
+            _FakeFuture_30<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i13.Future<T>);
+      ) as _i14.Future<T>);
 
   @override
-  _i13.Future<String> startDirectChat(
+  _i14.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -4579,7 +4631,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4595,7 +4647,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4610,10 +4662,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<String> createGroupChat({
+  _i14.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -4644,7 +4696,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4665,7 +4717,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4685,10 +4737,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i14.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4704,7 +4756,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4717,7 +4769,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4729,21 +4781,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i14.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<String> createSpace({
+  _i14.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -4768,7 +4820,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4786,7 +4838,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4803,10 +4855,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i14.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4814,7 +4866,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4823,7 +4875,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4831,10 +4883,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i13.Future<_i4.Profile> fetchOwnProfile({
+  _i14.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4847,7 +4899,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4859,7 +4911,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4870,10 +4922,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i13.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i14.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4887,8 +4939,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i13.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_30(
+        returnValue: _i14.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_31(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4900,8 +4952,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_30(
+            _i14.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_31(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4912,10 +4964,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.CachedProfileInformation>);
+      ) as _i14.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i13.Future<_i4.Profile> getProfileFromUserId(
+  _i14.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -4933,7 +4985,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4947,7 +4999,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4960,7 +5012,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -4982,31 +5034,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i13.Future<List<_i4.Room>>);
+            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i14.Future<List<_i4.Room>>);
 
   @override
-  _i13.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i14.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i13.Future<List<_i4.ArchivedRoom>>);
+            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i14.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i13.Future<_i4.GetVersionsResponse> getVersions({
+  _i14.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5019,8 +5071,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_25(
+        returnValue: _i14.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_26(
           this,
           Invocation.method(
             #getVersions,
@@ -5031,8 +5083,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_25(
+        returnValueForMissingStub: _i14.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_26(
           this,
           Invocation.method(
             #getVersions,
@@ -5043,20 +5095,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetVersionsResponse>);
+      ) as _i14.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i13.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i14.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<_i4.MediaConfig> getConfig({
+  _i14.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5069,7 +5121,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
+        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
           this,
           Invocation.method(
             #getConfig,
@@ -5081,7 +5133,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
+            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
           this,
           Invocation.method(
             #getConfig,
@@ -5092,10 +5144,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.MediaConfig>);
+      ) as _i14.Future<_i4.MediaConfig>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContent(
+  _i14.Future<_i15.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5115,7 +5167,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContent,
@@ -5131,7 +5183,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContent,
@@ -5146,10 +5198,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentOverrideName(
+  _i14.Future<_i15.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5171,7 +5223,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5188,7 +5240,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5204,10 +5256,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentThumbnail(
+  _i14.Future<_i15.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5235,7 +5287,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5255,7 +5307,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5274,10 +5326,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i14.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5287,7 +5339,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
+        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5296,7 +5348,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
+            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5304,11 +5356,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i13.Future<_i4.PreviewForUrl>);
+      ) as _i14.Future<_i4.PreviewForUrl>);
 
   @override
-  _i13.Future<Uri> uploadContent(
-    _i23.Uint8List? file, {
+  _i14.Future<Uri> uploadContent(
+    _i24.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5321,7 +5373,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i13.Future<Uri>.value(_FakeUri_16(
+        returnValue: _i14.Future<Uri>.value(_FakeUri_17(
           this,
           Invocation.method(
             #uploadContent,
@@ -5332,7 +5384,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_16(
+        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_17(
           this,
           Invocation.method(
             #uploadContent,
@@ -5343,10 +5395,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<Uri>);
+      ) as _i14.Future<Uri>);
 
   @override
-  _i13.Future<void> setTyping(
+  _i14.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5362,42 +5414,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> exportDump() => (super.noSuchMethod(
+  _i14.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i14.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i14.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Event?> getEventByPushNotification(
+  _i14.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -5413,12 +5465,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
-  _i13.Future<void> init({
+  _i14.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5453,9 +5505,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5467,40 +5519,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<void> clear() => (super.noSuchMethod(
+  _i14.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i14.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ensureNotSoftLoggedOut(
+  _i14.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleSync(
+  _i14.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -5510,9 +5562,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -5525,29 +5577,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i13.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i14.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i14.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDevice(
+  _i14.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5561,12 +5613,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDevicesOfUserIds(
+  _i14.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5582,12 +5634,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDeviceEncrypted(
+  _i14.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5607,12 +5659,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDeviceEncryptedChunked(
+  _i14.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -5626,23 +5678,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i14.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> joinRoom(
+  _i14.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -5660,7 +5712,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5674,7 +5726,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5687,10 +5739,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> changePassword(
+  _i14.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -5706,22 +5758,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> clearCache() => (super.noSuchMethod(
+  _i14.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ignoreUser(
+  _i14.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5731,22 +5783,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i14.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i14.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5757,7 +5809,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5766,7 +5818,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5774,32 +5826,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i13.Future<_i4.CachedPresence>);
+      ) as _i14.Future<_i4.CachedPresence>);
 
   @override
-  _i13.Future<void> abortSync() => (super.noSuchMethod(
+  _i14.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i14.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEventWithMetadata(
+  _i14.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5819,14 +5871,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i12.BaseResponse? response,
-    _i23.Uint8List? body,
+    _i13.BaseResponse? response,
+    _i24.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5858,7 +5910,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i13.Future<Map<String, Object?>> request(
+  _i14.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -5879,13 +5931,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> postPusher(
+  _i14.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -5895,57 +5947,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i14.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i14.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i14.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i13.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_35(
+        returnValue: _i14.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_36(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_35(
+        returnValueForMissingStub: _i14.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_36(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.TurnServerCredentials>);
+      ) as _i14.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5959,8 +6011,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5972,8 +6024,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -5984,10 +6036,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6003,8 +6055,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6017,8 +6069,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6030,10 +6082,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i14.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6047,7 +6099,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6059,7 +6111,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6070,17 +6122,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.KeyBackupData>);
+      ) as _i14.Future<_i4.KeyBackupData>);
 
   @override
-  _i13.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i14.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i13.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_38(
+        returnValue: _i14.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_39(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6088,18 +6140,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_38(
+            _i14.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_39(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i14.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i13.Future<int> pingAppservice(
+  _i14.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6109,12 +6161,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i13.Future<int>.value(0),
-        returnValueForMissingStub: _i13.Future<int>.value(0),
-      ) as _i13.Future<int>);
+        returnValue: _i14.Future<int>.value(0),
+        returnValueForMissingStub: _i14.Future<int>.value(0),
+      ) as _i14.Future<int>);
 
   @override
-  _i13.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i14.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6122,8 +6174,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_39(
+        returnValue: _i14.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_40(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6132,8 +6184,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_39(
+            _i14.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_40(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6141,15 +6193,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i13.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i14.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i13.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i14.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
+        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6157,17 +6209,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
+            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.MediaConfig>);
+      ) as _i14.Future<_i4.MediaConfig>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentAuthed(
+  _i14.Future<_i15.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6181,7 +6233,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6193,7 +6245,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6204,10 +6256,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentOverrideNameAuthed(
+  _i14.Future<_i15.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6223,7 +6275,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6236,7 +6288,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6248,10 +6300,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i14.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6261,7 +6313,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
+        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6270,7 +6322,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
+            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6278,10 +6330,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i13.Future<_i4.PreviewForUrl>);
+      ) as _i14.Future<_i4.PreviewForUrl>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentThumbnailAuthed(
+  _i14.Future<_i15.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -6305,7 +6357,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6323,7 +6375,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6340,21 +6392,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<bool> registrationTokenValidity(String? token) =>
+  _i14.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i14.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6364,8 +6416,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_40(
+        returnValue: _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_41(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6374,8 +6426,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_40(
+            _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_41(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6383,10 +6435,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i14.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i13.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i14.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6404,8 +6456,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_41(
+        returnValue: _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_42(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6419,8 +6471,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_41(
+            _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_42(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6433,10 +6485,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i14.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i14.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -6460,8 +6512,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i13.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_42(
+        returnValue: _i14.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_43(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6479,8 +6531,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_42(
+            _i14.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_43(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6497,10 +6549,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i14.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6528,8 +6580,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_43(
+                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6548,8 +6600,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_43(
+                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6567,10 +6619,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i14.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6599,9 +6651,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i13.Future<
+            returnValue: _i14.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6620,9 +6672,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i13.Future<
+            returnValueForMissingStub: _i14.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6641,11 +6693,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i13
+          ) as _i14
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i13.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i14.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -6661,8 +6713,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i13.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_45(
+        returnValue: _i14.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_46(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6675,8 +6727,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_45(
+            _i14.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_46(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6688,10 +6740,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetThreadRootsResponse>);
+      ) as _i14.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i13.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i14.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -6705,8 +6757,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i13.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_46(
+        returnValue: _i14.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_47(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6718,8 +6770,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_46(
+            _i14.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_47(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6730,33 +6782,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i14.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i14.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i13.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i14.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i13.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i14.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i13.Future<Uri?>.value(),
-        returnValueForMissingStub: _i13.Future<Uri?>.value(),
-      ) as _i13.Future<Uri?>);
+        returnValue: _i14.Future<Uri?>.value(),
+        returnValueForMissingStub: _i14.Future<Uri?>.value(),
+      ) as _i14.Future<Uri?>);
 
   @override
-  _i13.Future<void> add3PID(
+  _i14.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -6770,12 +6822,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> bind3PID(
+  _i14.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6791,12 +6843,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i14.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6810,14 +6862,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6839,8 +6891,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6856,8 +6908,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6873,10 +6925,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6900,8 +6952,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6918,8 +6970,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6936,10 +6988,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i14.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6953,14 +7005,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i14.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -6975,14 +7027,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7004,8 +7056,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7021,8 +7073,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7038,10 +7090,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7065,8 +7117,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7083,8 +7135,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7101,16 +7153,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i14.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
+            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7118,22 +7170,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
+            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.TokenOwnerInfo>);
+      ) as _i14.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i13.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i14.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
+        returnValue: _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7141,22 +7193,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
+            _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i13.Future<_i4.WhoIsInfo>);
+      ) as _i14.Future<_i4.WhoIsInfo>);
 
   @override
-  _i13.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i14.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
+        returnValue: _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7164,17 +7216,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
+            _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.Capabilities>);
+      ) as _i14.Future<_i4.Capabilities>);
 
   @override
-  _i13.Future<String> createRoom({
+  _i14.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -7207,7 +7259,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7229,7 +7281,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7250,10 +7302,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> deleteDevices(
+  _i14.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7263,22 +7315,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.Device>?>.value(),
-      ) as _i13.Future<List<_i4.Device>?>);
+        returnValue: _i14.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.Device>?>.value(),
+      ) as _i14.Future<List<_i4.Device>?>);
 
   @override
-  _i13.Future<void> deleteDevice(
+  _i14.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7288,34 +7340,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i14.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i13.Future<_i4.Device>.value(_FakeDevice_51(
+        returnValue: _i14.Future<_i4.Device>.value(_FakeDevice_52(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.Device>.value(_FakeDevice_51(
+        returnValueForMissingStub: _i14.Future<_i4.Device>.value(_FakeDevice_52(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i13.Future<_i4.Device>);
+      ) as _i14.Future<_i4.Device>);
 
   @override
-  _i13.Future<void> updateDevice(
+  _i14.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7325,12 +7377,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i14.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -7345,24 +7397,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i14.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i13.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Visibility?>.value(),
-      ) as _i13.Future<_i4.Visibility?>);
+        returnValue: _i14.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Visibility?>.value(),
+      ) as _i14.Future<_i4.Visibility?>);
 
   @override
-  _i13.Future<void> setRoomVisibilityOnDirectory(
+  _i14.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -7372,30 +7424,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i14.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i14.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_52(
+        returnValue: _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_53(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7403,18 +7455,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_52(
+            _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_53(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i14.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i13.Future<void> setRoomAlias(
+  _i14.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7426,12 +7478,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetEventsResponse> getEvents({
+  _i14.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7445,7 +7497,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
+            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
           this,
           Invocation.method(
             #getEvents,
@@ -7457,7 +7509,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
+            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
           this,
           Invocation.method(
             #getEvents,
@@ -7468,10 +7520,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetEventsResponse>);
+      ) as _i14.Future<_i4.GetEventsResponse>);
 
   @override
-  _i13.Future<_i4.PeekEventsResponse> peekEvents({
+  _i14.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7486,8 +7538,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i13.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_54(
+        returnValue: _i14.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_55(
           this,
           Invocation.method(
             #peekEvents,
@@ -7499,8 +7551,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_54(
+        returnValueForMissingStub: _i14.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_55(
           this,
           Invocation.method(
             #peekEvents,
@@ -7512,16 +7564,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.PeekEventsResponse>);
+      ) as _i14.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i13.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i14.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7529,27 +7581,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i13.Future<_i4.MatrixEvent>);
+      ) as _i14.Future<_i4.MatrixEvent>);
 
   @override
-  _i13.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i14.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i13.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
-      ) as _i13.Future<List<String>>);
+        returnValue: _i14.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
+      ) as _i14.Future<List<String>>);
 
   @override
-  _i13.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i14.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7561,8 +7613,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i13.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_56(
+        returnValue: _i14.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_57(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7573,8 +7625,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_56(
+            _i14.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_57(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7584,10 +7636,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.GetKeysChangesResponse>);
+      ) as _i14.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i13.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i14.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7598,7 +7650,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
+            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
           this,
           Invocation.method(
             #claimKeys,
@@ -7607,7 +7659,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
+            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
           this,
           Invocation.method(
             #claimKeys,
@@ -7615,10 +7667,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i13.Future<_i4.ClaimKeysResponse>);
+      ) as _i14.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i13.Future<void> uploadCrossSigningKeys({
+  _i14.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -7635,12 +7687,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.QueryKeysResponse> queryKeys(
+  _i14.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7651,7 +7703,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
+            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
           this,
           Invocation.method(
             #queryKeys,
@@ -7660,7 +7712,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
+            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
           this,
           Invocation.method(
             #queryKeys,
@@ -7668,10 +7720,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i13.Future<_i4.QueryKeysResponse>);
+      ) as _i14.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7679,14 +7731,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i13.Future<
+            returnValue: _i14.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i13.Future<
+            returnValueForMissingStub: _i14.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i13.Future<Map<String, int>> uploadKeys({
+  _i14.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -7701,13 +7753,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i13.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i14.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i13.Future<Map<String, int>>);
+            _i14.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i14.Future<Map<String, int>>);
 
   @override
-  _i13.Future<String> knockRoom(
+  _i14.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7721,7 +7773,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7733,7 +7785,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7744,20 +7796,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i14.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i13.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i14.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i14.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i13.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i14.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7772,8 +7824,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i13.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_59(
+        returnValue: _i14.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_60(
           this,
           Invocation.method(
             #getNotifications,
@@ -7786,8 +7838,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_59(
+            _i14.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_60(
           this,
           Invocation.method(
             #getNotifications,
@@ -7799,35 +7851,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetNotificationsResponse>);
+      ) as _i14.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i13.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i14.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i13.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_60(
+        returnValue: _i14.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_61(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_60(
+        returnValueForMissingStub: _i14.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_61(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i13.Future<_i4.GetPresenceResponse>);
+      ) as _i14.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i13.Future<void> setPresence(
+  _i14.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -7841,12 +7893,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, Object?>> deleteProfileField(
+  _i14.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7859,13 +7911,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getProfileField(
+  _i14.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7878,13 +7930,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<Map<String, Object?>> setProfileField(
+  _i14.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7899,13 +7951,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i14.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -7920,8 +7972,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i13.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_61(
+        returnValue: _i14.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_62(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7934,8 +7986,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_61(
+            _i14.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_62(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7947,10 +7999,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i14.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i13.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i14.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -7971,8 +8023,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i13.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_62(
+        returnValue: _i14.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_63(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -7988,8 +8040,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_62(
+            _i14.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_63(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8004,25 +8056,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i14.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i13.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.Pusher>?>.value(),
-      ) as _i13.Future<List<_i4.Pusher>?>);
+        returnValue: _i14.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.Pusher>?>.value(),
+      ) as _i14.Future<List<_i4.Pusher>?>);
 
   @override
-  _i13.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i14.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
+        returnValue: _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
           this,
           Invocation.method(
             #getPushRules,
@@ -8030,24 +8082,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
+            _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.PushRuleSet>);
+      ) as _i14.Future<_i4.PushRuleSet>);
 
   @override
-  _i13.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i14.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_64(
+        returnValue: _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_65(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8055,18 +8107,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_64(
+            _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_65(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i14.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i13.Future<void> deletePushRule(
+  _i14.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8078,12 +8130,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.PushRule> getPushRule(
+  _i14.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8095,7 +8147,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<_i4.PushRule>.value(_FakePushRule_65(
+        returnValue: _i14.Future<_i4.PushRule>.value(_FakePushRule_66(
           this,
           Invocation.method(
             #getPushRule,
@@ -8106,7 +8158,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PushRule>.value(_FakePushRule_65(
+            _i14.Future<_i4.PushRule>.value(_FakePushRule_66(
           this,
           Invocation.method(
             #getPushRule,
@@ -8116,10 +8168,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.PushRule>);
+      ) as _i14.Future<_i4.PushRule>);
 
   @override
-  _i13.Future<void> setPushRule(
+  _i14.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -8143,12 +8195,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<Object?>> getPushRuleActions(
+  _i14.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8160,13 +8212,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i14.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i13.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i13.Future<List<Object?>>);
+            _i14.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i14.Future<List<Object?>>);
 
   @override
-  _i13.Future<void> setPushRuleActions(
+  _i14.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -8180,12 +8232,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<bool> isPushRuleEnabled(
+  _i14.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8197,12 +8249,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> setPushRuleEnabled(
+  _i14.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -8216,19 +8268,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i14.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
+            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
           this,
           Invocation.method(
             #refresh,
@@ -8236,28 +8288,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
+            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i13.Future<_i4.RefreshResponse>);
+      ) as _i14.Future<_i4.RefreshResponse>);
 
   @override
-  _i13.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i14.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i13.Future<bool?>.value(),
-        returnValueForMissingStub: _i13.Future<bool?>.value(),
-      ) as _i13.Future<bool?>);
+        returnValue: _i14.Future<bool?>.value(),
+        returnValueForMissingStub: _i14.Future<bool?>.value(),
+      ) as _i14.Future<bool?>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8279,8 +8331,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8296,8 +8348,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8313,10 +8365,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8340,8 +8392,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8358,8 +8410,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8376,17 +8428,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8394,23 +8446,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i14.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
+        returnValue: _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8418,17 +8470,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
+            _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeys>);
+      ) as _i14.Future<_i4.RoomKeys>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -8440,8 +8492,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8452,8 +8504,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8463,10 +8515,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8478,8 +8530,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8490,8 +8542,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8501,10 +8553,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8516,7 +8568,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
+        returnValue: _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8527,7 +8579,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
+            _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8537,10 +8589,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeyBackup>);
+      ) as _i14.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -8554,8 +8606,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8567,8 +8619,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8579,10 +8631,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8596,8 +8648,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8609,8 +8661,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8621,10 +8673,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i14.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8638,7 +8690,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8650,7 +8702,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8661,10 +8713,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.KeyBackupData>);
+      ) as _i14.Future<_i4.KeyBackupData>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8680,8 +8732,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8694,8 +8746,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8707,18 +8759,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_69(
+                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_70(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8726,18 +8778,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_69(
+                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_70(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i13.Future<String> postRoomKeysVersion(
+  _i14.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -8749,7 +8801,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8760,7 +8812,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8770,29 +8822,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i14.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i14.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_70(
+        returnValue: _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_71(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8800,18 +8852,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_70(
+            _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_71(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i14.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i14.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -8826,24 +8878,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i14.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i13.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
-      ) as _i13.Future<List<String>>);
+        returnValue: _i14.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
+      ) as _i14.Future<List<String>>);
 
   @override
-  _i13.Future<void> ban(
+  _i14.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8857,12 +8909,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.EventContext> getEventContext(
+  _i14.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -8880,7 +8932,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<_i4.EventContext>.value(_FakeEventContext_71(
+        returnValue: _i14.Future<_i4.EventContext>.value(_FakeEventContext_72(
           this,
           Invocation.method(
             #getEventContext,
@@ -8895,7 +8947,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.EventContext>.value(_FakeEventContext_71(
+            _i14.Future<_i4.EventContext>.value(_FakeEventContext_72(
           this,
           Invocation.method(
             #getEventContext,
@@ -8909,10 +8961,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.EventContext>);
+      ) as _i14.Future<_i4.EventContext>);
 
   @override
-  _i13.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i14.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -8924,7 +8976,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8935,7 +8987,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8945,20 +8997,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.MatrixEvent>);
+      ) as _i14.Future<_i4.MatrixEvent>);
 
   @override
-  _i13.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i14.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> inviteBy3PID(
+  _i14.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -8970,12 +9022,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> inviteUser(
+  _i14.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8989,12 +9041,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> joinRoomById(
+  _i14.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -9008,7 +9060,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9020,7 +9072,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9031,23 +9083,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i14.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i13.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i14.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i13.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i13.Future<Map<String, _i4.RoomMember>?>);
+            _i14.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i14.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i13.Future<void> kick(
+  _i14.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9061,12 +9113,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> leaveRoom(
+  _i14.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9076,12 +9128,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i14.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -9097,12 +9149,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i13.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i13.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i14.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i14.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i13.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i14.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -9124,8 +9176,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_72(
+        returnValue: _i14.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_73(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9141,8 +9193,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_72(
+        returnValueForMissingStub: _i14.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_73(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9158,10 +9210,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomEventsResponse>);
+      ) as _i14.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i13.Future<void> setReadMarker(
+  _i14.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9177,12 +9229,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> postReceipt(
+  _i14.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -9198,12 +9250,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEvent(
+  _i14.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9219,12 +9271,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> reportRoom(
+  _i14.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9236,12 +9288,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> reportEvent(
+  _i14.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9259,12 +9311,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> sendMessage(
+  _i14.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9280,7 +9332,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9293,7 +9345,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9305,23 +9357,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i14.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i13.Future<List<_i4.MatrixEvent>>);
+            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i14.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i14.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -9338,13 +9390,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<String> setRoomStateWithKey(
+  _i14.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9360,7 +9412,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9373,7 +9425,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9385,10 +9437,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> unban(
+  _i14.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9402,12 +9454,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> upgradeRoom(
+  _i14.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9421,7 +9473,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9433,7 +9485,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9444,10 +9496,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.SearchResults> search(
+  _i14.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -9457,7 +9509,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
+        returnValue: _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
           this,
           Invocation.method(
             #search,
@@ -9466,7 +9518,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
+            _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
           this,
           Invocation.method(
             #search,
@@ -9474,10 +9526,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i13.Future<_i4.SearchResults>);
+      ) as _i14.Future<_i4.SearchResults>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> sync({
+  _i14.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -9498,7 +9550,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #sync,
@@ -9514,7 +9566,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #sync,
@@ -9529,22 +9581,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i14.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i13.Future<List<_i4.Location>>);
+            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i14.Future<List<_i4.Location>>);
 
   @override
-  _i13.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i14.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9554,21 +9606,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i13.Future<List<_i4.Location>>);
+            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i14.Future<List<_i4.Location>>);
 
   @override
-  _i13.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i14.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_74(
+        returnValue: _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_75(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9576,45 +9628,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_74(
+            _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_75(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i13.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i14.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i13.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i14.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9625,13 +9677,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getAccountData(
+  _i14.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9644,13 +9696,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> setAccountData(
+  _i14.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9664,12 +9716,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> defineFilter(
+  _i14.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -9681,7 +9733,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9692,7 +9744,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9702,10 +9754,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.Filter> getFilter(
+  _i14.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9717,7 +9769,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i13.Future<_i4.Filter>.value(_FakeFilter_18(
+        returnValue: _i14.Future<_i4.Filter>.value(_FakeFilter_19(
           this,
           Invocation.method(
             #getFilter,
@@ -9727,7 +9779,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.Filter>.value(_FakeFilter_18(
+        returnValueForMissingStub: _i14.Future<_i4.Filter>.value(_FakeFilter_19(
           this,
           Invocation.method(
             #getFilter,
@@ -9737,10 +9789,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.Filter>);
+      ) as _i14.Future<_i4.Filter>);
 
   @override
-  _i13.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i14.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9753,7 +9805,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
+            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9764,7 +9816,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
+            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9774,10 +9826,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.OpenIdCredentials>);
+      ) as _i14.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i13.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i14.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9792,13 +9844,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> setAccountDataPerRoom(
+  _i14.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9814,12 +9866,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i14.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9831,12 +9883,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i13.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i13.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i13.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i14.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i14.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i14.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i13.Future<void> deleteRoomTag(
+  _i14.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9850,12 +9902,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setRoomTag(
+  _i14.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9871,12 +9923,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i14.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9886,8 +9938,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i13.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_76(
+        returnValue: _i14.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_77(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9896,8 +9948,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_76(
+            _i14.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_77(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9905,10 +9957,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i13.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i14.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> reportUser(
+  _i14.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -9921,40 +9973,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i14.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i13.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_77(
+        returnValue: _i14.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_78(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_77(
+        returnValueForMissingStub: _i14.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_78(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.CreateContentResponse>);
+      ) as _i14.Future<_i4.CreateContentResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> uploadContentToMXC(
+  _i14.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i23.Uint8List? body, {
+    _i24.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -9972,8 +10024,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 }

--- a/test/widgets/invite_user_dialog_test.mocks.dart
+++ b/test/widgets/invite_user_dialog_test.mocks.dart
@@ -430,6 +430,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -936,6 +943,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/join_access_controller_test.mocks.dart
+++ b/test/widgets/join_access_controller_test.mocks.dart
@@ -8874,6 +8874,13 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i4.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -9380,6 +9387,16 @@ class MockRoom extends _i1.Mock implements _i4.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
+
+  @override
+  _i14.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i14.Future<void>.value(),
         returnValueForMissingStub: _i14.Future<void>.value(),

--- a/test/widgets/join_access_section_test.mocks.dart
+++ b/test/widgets/join_access_section_test.mocks.dart
@@ -430,6 +430,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -936,6 +943,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/login_controller_test.mocks.dart
+++ b/test/widgets/login_controller_test.mocks.dart
@@ -3,34 +3,36 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i14;
-import 'dart:typed_data' as _i23;
-import 'dart:ui' as _i18;
+import 'dart:async' as _i15;
+import 'dart:typed_data' as _i24;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
-import 'package:http/http.dart' as _i13;
-import 'package:kohera/core/models/server_auth_capabilities.dart' as _i16;
-import 'package:kohera/core/services/client_manager.dart' as _i21;
-import 'package:kohera/core/services/matrix_service.dart' as _i11;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
+import 'package:http/http.dart' as _i14;
+import 'package:kohera/core/models/server_auth_capabilities.dart' as _i17;
+import 'package:kohera/core/services/client_manager.dart' as _i22;
+import 'package:kohera/core/services/matrix_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i7;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i8;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i22;
+import 'package:matrix/encryption.dart' as _i23;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i15;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i12;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i16;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i13;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -111,8 +113,9 @@ class _FakeSelectionService_5 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
-  _FakeSyncService_6(
+class _FakeSpaceAccessService_6 extends _i1.SmartFake
+    implements _i8.SpaceAccessService {
+  _FakeSpaceAccessService_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -121,8 +124,8 @@ class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
         );
 }
 
-class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
-  _FakeAuthService_7(
+class _FakeSyncService_7 extends _i1.SmartFake implements _i9.SyncService {
+  _FakeSyncService_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -131,8 +134,8 @@ class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
         );
 }
 
-class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
-  _FakeOutboxService_8(
+class _FakeAuthService_8 extends _i1.SmartFake implements _i10.AuthService {
+  _FakeAuthService_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -141,8 +144,8 @@ class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
         );
 }
 
-class _FakeMatrixService_9 extends _i1.SmartFake implements _i11.MatrixService {
-  _FakeMatrixService_9(
+class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
+  _FakeOutboxService_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -151,8 +154,9 @@ class _FakeMatrixService_9 extends _i1.SmartFake implements _i11.MatrixService {
         );
 }
 
-class _FakeDatabaseApi_10 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_10(
+class _FakeMatrixService_10 extends _i1.SmartFake
+    implements _i12.MatrixService {
+  _FakeMatrixService_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -161,8 +165,8 @@ class _FakeDatabaseApi_10 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_11 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_11(
+class _FakeDatabaseApi_11 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -171,9 +175,19 @@ class _FakeFilter_11 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_12 extends _i1.SmartFake
+class _FakeFilter_12 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_12(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeNativeImplementations_13 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_12(
+  _FakeNativeImplementations_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -182,8 +196,8 @@ class _FakeNativeImplementations_12 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_13 extends _i1.SmartFake implements Duration {
-  _FakeDuration_13(
+class _FakeDuration_14 extends _i1.SmartFake implements Duration {
+  _FakeDuration_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -192,9 +206,9 @@ class _FakeDuration_13 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_14 extends _i1.SmartFake
+class _FakePushruleEvaluator_15 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_14(
+  _FakePushruleEvaluator_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -203,8 +217,8 @@ class _FakePushruleEvaluator_14 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_15 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_15(
+class _FakeProfile_16 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -213,9 +227,9 @@ class _FakeProfile_15 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeCachedStreamController_16<T> extends _i1.SmartFake
-    implements _i12.CachedStreamController<T> {
-  _FakeCachedStreamController_16(
+class _FakeCachedStreamController_17<T> extends _i1.SmartFake
+    implements _i13.CachedStreamController<T> {
+  _FakeCachedStreamController_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -224,8 +238,8 @@ class _FakeCachedStreamController_16<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_17 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_17(
+class _FakeDateTime_18 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -234,8 +248,8 @@ class _FakeDateTime_17 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_18 extends _i1.SmartFake implements _i13.Client {
-  _FakeClient_18(
+class _FakeClient_19 extends _i1.SmartFake implements _i14.Client {
+  _FakeClient_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -244,9 +258,9 @@ class _FakeClient_18 extends _i1.SmartFake implements _i13.Client {
         );
 }
 
-class _FakeDiscoveryInformation_19 extends _i1.SmartFake
+class _FakeDiscoveryInformation_20 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_19(
+  _FakeDiscoveryInformation_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -255,9 +269,9 @@ class _FakeDiscoveryInformation_19 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_20 extends _i1.SmartFake
+class _FakeGetVersionsResponse_21 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_20(
+  _FakeGetVersionsResponse_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -266,9 +280,9 @@ class _FakeGetVersionsResponse_20 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_21 extends _i1.SmartFake
+class _FakeRegisterResponse_22 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_21(
+  _FakeRegisterResponse_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -277,8 +291,8 @@ class _FakeRegisterResponse_21 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_22 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_22(
+class _FakeLoginResponse_23 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -287,9 +301,9 @@ class _FakeLoginResponse_22 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_23 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_24 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_23(
+  _FakeGetAuthMetadataResponse_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -298,8 +312,8 @@ class _FakeGetAuthMetadataResponse_23 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_24<T1> extends _i1.SmartFake implements _i14.Future<T1> {
-  _FakeFuture_24(
+class _FakeFuture_25<T1> extends _i1.SmartFake implements _i15.Future<T1> {
+  _FakeFuture_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -308,8 +322,8 @@ class _FakeFuture_24<T1> extends _i1.SmartFake implements _i14.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_25 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_25(
+class _FakeSyncUpdate_26 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -318,9 +332,9 @@ class _FakeSyncUpdate_25 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_26 extends _i1.SmartFake
+class _FakeCachedProfileInformation_27 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_26(
+  _FakeCachedProfileInformation_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -329,8 +343,8 @@ class _FakeCachedProfileInformation_26 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_27 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_27(
+class _FakeMediaConfig_28 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -339,8 +353,8 @@ class _FakeMediaConfig_27 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_28 extends _i1.SmartFake implements _i15.FileResponse {
-  _FakeFileResponse_28(
+class _FakeFileResponse_29 extends _i1.SmartFake implements _i16.FileResponse {
+  _FakeFileResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -349,8 +363,8 @@ class _FakeFileResponse_28 extends _i1.SmartFake implements _i15.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_29 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_29(
+class _FakePreviewForUrl_30 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -359,8 +373,8 @@ class _FakePreviewForUrl_29 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeUri_30 extends _i1.SmartFake implements Uri {
-  _FakeUri_30(
+class _FakeUri_31 extends _i1.SmartFake implements Uri {
+  _FakeUri_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -369,9 +383,9 @@ class _FakeUri_30 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_31 extends _i1.SmartFake
+class _FakeCachedPresence_32 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_31(
+  _FakeCachedPresence_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -380,9 +394,9 @@ class _FakeCachedPresence_31 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_32 extends _i1.SmartFake
+class _FakeTurnServerCredentials_33 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_32(
+  _FakeTurnServerCredentials_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -391,9 +405,9 @@ class _FakeTurnServerCredentials_32 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_33 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_34 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_33(
+  _FakeRoomKeysUpdateResponse_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -402,8 +416,8 @@ class _FakeRoomKeysUpdateResponse_33 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_34 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_34(
+class _FakeKeyBackupData_35 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -412,9 +426,9 @@ class _FakeKeyBackupData_34 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_35 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_36 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_35(
+  _FakeGetWellknownSupportResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -423,9 +437,9 @@ class _FakeGetWellknownSupportResponse_35 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_36 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_37 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_36(
+  _FakeGenerateLoginTokenResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -434,9 +448,9 @@ class _FakeGenerateLoginTokenResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_37 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_38 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_37(
+  _FakeGetRoomSummaryResponse$3_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -445,9 +459,9 @@ class _FakeGetRoomSummaryResponse$3_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_38 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_39 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_38(
+  _FakeGetSpaceHierarchyResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -456,9 +470,9 @@ class _FakeGetSpaceHierarchyResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_39 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_40 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_39(
+  _FakeGetRelatingEventsResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -467,9 +481,9 @@ class _FakeGetRelatingEventsResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_40 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_41 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_40(
+  _FakeGetRelatingEventsWithRelTypeResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -478,9 +492,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -489,9 +503,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_42 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_43 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_42(
+  _FakeGetThreadRootsResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -500,9 +514,9 @@ class _FakeGetThreadRootsResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_43 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_44 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_43(
+  _FakeGetEventByTimestampResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -511,9 +525,9 @@ class _FakeGetEventByTimestampResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_44 extends _i1.SmartFake
+class _FakeRequestTokenResponse_45 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_44(
+  _FakeRequestTokenResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -522,9 +536,9 @@ class _FakeRequestTokenResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_45 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_46 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_45(
+  _FakeTokenOwnerInfo_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -533,8 +547,8 @@ class _FakeTokenOwnerInfo_45 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_46 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_46(
+class _FakeWhoIsInfo_47 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -543,8 +557,8 @@ class _FakeWhoIsInfo_46 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_47 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_47(
+class _FakeCapabilities_48 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -553,8 +567,8 @@ class _FakeCapabilities_47 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_48 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_48(
+class _FakeDevice_49 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -563,9 +577,9 @@ class _FakeDevice_48 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_49 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_50 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_49(
+  _FakeGetRoomIdByAliasResponse_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -574,9 +588,9 @@ class _FakeGetRoomIdByAliasResponse_49 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_50 extends _i1.SmartFake
+class _FakeGetEventsResponse_51 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_50(
+  _FakeGetEventsResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -585,9 +599,9 @@ class _FakeGetEventsResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_51 extends _i1.SmartFake
+class _FakePeekEventsResponse_52 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_51(
+  _FakePeekEventsResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -596,8 +610,8 @@ class _FakePeekEventsResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_52 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_52(
+class _FakeMatrixEvent_53 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -606,9 +620,9 @@ class _FakeMatrixEvent_52 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_53 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_54 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_53(
+  _FakeGetKeysChangesResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -617,9 +631,9 @@ class _FakeGetKeysChangesResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_54 extends _i1.SmartFake
+class _FakeClaimKeysResponse_55 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_54(
+  _FakeClaimKeysResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -628,9 +642,9 @@ class _FakeClaimKeysResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_55 extends _i1.SmartFake
+class _FakeQueryKeysResponse_56 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_55(
+  _FakeQueryKeysResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -639,9 +653,9 @@ class _FakeQueryKeysResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_56 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_57 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_56(
+  _FakeGetNotificationsResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -650,9 +664,9 @@ class _FakeGetNotificationsResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_57 extends _i1.SmartFake
+class _FakeGetPresenceResponse_58 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_57(
+  _FakeGetPresenceResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -661,9 +675,9 @@ class _FakeGetPresenceResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_58 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_59 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_58(
+  _FakeGetPublicRoomsResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -672,9 +686,9 @@ class _FakeGetPublicRoomsResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_59 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_60 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_59(
+  _FakeQueryPublicRoomsResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -683,8 +697,8 @@ class _FakeQueryPublicRoomsResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_60 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_60(
+class _FakePushRuleSet_61 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -693,9 +707,9 @@ class _FakePushRuleSet_60 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_61 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_62 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_61(
+  _FakeGetPushRulesGlobalResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -704,8 +718,8 @@ class _FakeGetPushRulesGlobalResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_62 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_62(
+class _FakePushRule_63 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -714,9 +728,9 @@ class _FakePushRule_62 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_63 extends _i1.SmartFake
+class _FakeRefreshResponse_64 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_63(
+  _FakeRefreshResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -725,8 +739,8 @@ class _FakeRefreshResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_64 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_64(
+class _FakeRoomKeys_65 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -735,8 +749,8 @@ class _FakeRoomKeys_64 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_65 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_65(
+class _FakeRoomKeyBackup_66 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -745,9 +759,9 @@ class _FakeRoomKeyBackup_65 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_66 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_67 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_66(
+  _FakeGetRoomKeysVersionCurrentResponse_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,9 +770,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_66 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_67 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_68 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_67(
+  _FakeGetRoomKeysVersionResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -767,8 +781,8 @@ class _FakeGetRoomKeysVersionResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_68 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_68(
+class _FakeEventContext_69 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -777,9 +791,9 @@ class _FakeEventContext_68 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_69 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_70 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_69(
+  _FakeGetRoomEventsResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -788,8 +802,8 @@ class _FakeGetRoomEventsResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_70 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_70(
+class _FakeSearchResults_71 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -798,9 +812,9 @@ class _FakeSearchResults_70 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_71 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_72 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_71(
+  _FakeGetProtocolMetadataResponse$2_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -809,9 +823,9 @@ class _FakeGetProtocolMetadataResponse$2_71 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_72 extends _i1.SmartFake
+class _FakeOpenIdCredentials_73 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_72(
+  _FakeOpenIdCredentials_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -820,9 +834,9 @@ class _FakeOpenIdCredentials_72 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_73 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_74 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_73(
+  _FakeSearchUserDirectoryResponse_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -831,9 +845,9 @@ class _FakeSearchUserDirectoryResponse_73 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_74 extends _i1.SmartFake
+class _FakeCreateContentResponse_75 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_74(
+  _FakeCreateContentResponse_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,9 +856,9 @@ class _FakeCreateContentResponse_74 extends _i1.SmartFake
         );
 }
 
-class _FakeServerAuthCapabilities_75 extends _i1.SmartFake
-    implements _i16.ServerAuthCapabilities {
-  _FakeServerAuthCapabilities_75(
+class _FakeServerAuthCapabilities_76 extends _i1.SmartFake
+    implements _i17.ServerAuthCapabilities {
+  _FakeServerAuthCapabilities_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -856,7 +870,7 @@ class _FakeServerAuthCapabilities_75 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -886,11 +900,11 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -963,43 +977,56 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       ) as _i7.SelectionService);
 
   @override
-  _i8.SyncService get sync => (super.noSuchMethod(
+  _i8.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_6(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_6(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i8.SpaceAccessService);
+
+  @override
+  _i9.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_6(
+        returnValue: _FakeSyncService_7(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_6(
+        returnValueForMissingStub: _FakeSyncService_7(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i8.SyncService);
+      ) as _i9.SyncService);
 
   @override
-  _i9.AuthService get auth => (super.noSuchMethod(
+  _i10.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_7(
+        returnValue: _FakeAuthService_8(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_7(
+        returnValueForMissingStub: _FakeAuthService_8(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i9.AuthService);
+      ) as _i10.AuthService);
 
   @override
-  _i10.OutboxService get outbox => (super.noSuchMethod(
+  _i11.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_8(
+        returnValue: _FakeOutboxService_9(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_8(
+        returnValueForMissingStub: _FakeOutboxService_9(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i10.OutboxService);
+      ) as _i11.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1063,7 +1090,16 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       );
 
   @override
-  set sync(_i8.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i8.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i9.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -1072,7 +1108,7 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       );
 
   @override
-  set auth(_i9.AuthService? value) => super.noSuchMethod(
+  set auth(_i10.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -1081,7 +1117,7 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       );
 
   @override
-  set outbox(_i10.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i11.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -1097,14 +1133,14 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       ) as bool);
 
   @override
-  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i15.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1134,7 +1170,7 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1144,18 +1180,18 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       );
 
   @override
-  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i15.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> login({
+  _i15.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1170,12 +1206,12 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> completeSsoLogin({
+  _i15.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1188,12 +1224,12 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> completeRegistration(
+  _i15.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1203,32 +1239,32 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i15.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1237,7 +1273,7 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1246,17 +1282,17 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i15.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1267,7 +1303,7 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1304,26 +1340,26 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i15.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+  _i15.Future<bool> didPushRouteInformation(
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1353,7 +1389,7 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1362,7 +1398,7 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1371,16 +1407,16 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
       );
 
   @override
-  _i14.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i15.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i15.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i14.Future<_i18.AppExitResponse>);
+            _i15.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i15.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1404,13 +1440,13 @@ class MockMatrixService extends _i1.Mock implements _i11.MatrixService {
 /// A class which mocks [ClientManager].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockClientManager extends _i1.Mock implements _i21.ClientManager {
+class MockClientManager extends _i1.Mock implements _i22.ClientManager {
   @override
-  List<_i11.MatrixService> get services => (super.noSuchMethod(
+  List<_i12.MatrixService> get services => (super.noSuchMethod(
         Invocation.getter(#services),
-        returnValue: <_i11.MatrixService>[],
-        returnValueForMissingStub: <_i11.MatrixService>[],
-      ) as List<_i11.MatrixService>);
+        returnValue: <_i12.MatrixService>[],
+        returnValueForMissingStub: <_i12.MatrixService>[],
+      ) as List<_i12.MatrixService>);
 
   @override
   int get activeIndex => (super.noSuchMethod(
@@ -1420,17 +1456,17 @@ class MockClientManager extends _i1.Mock implements _i21.ClientManager {
       ) as int);
 
   @override
-  _i11.MatrixService get activeService => (super.noSuchMethod(
+  _i12.MatrixService get activeService => (super.noSuchMethod(
         Invocation.getter(#activeService),
-        returnValue: _FakeMatrixService_9(
+        returnValue: _FakeMatrixService_10(
           this,
           Invocation.getter(#activeService),
         ),
-        returnValueForMissingStub: _FakeMatrixService_9(
+        returnValueForMissingStub: _FakeMatrixService_10(
           this,
           Invocation.getter(#activeService),
         ),
-      ) as _i11.MatrixService);
+      ) as _i12.MatrixService);
 
   @override
   bool get hasMultipleAccounts => (super.noSuchMethod(
@@ -1447,14 +1483,14 @@ class MockClientManager extends _i1.Mock implements _i21.ClientManager {
       ) as bool);
 
   @override
-  _i14.Future<void> init() => (super.noSuchMethod(
+  _i15.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void setActiveAccount(int? index) => super.noSuchMethod(
@@ -1466,12 +1502,13 @@ class MockClientManager extends _i1.Mock implements _i21.ClientManager {
       );
 
   @override
-  _i14.Future<_i11.MatrixService> createLoginService() => (super.noSuchMethod(
+  _i15.Future<_i12.MatrixService> createLoginService() => (super.noSuchMethod(
         Invocation.method(
           #createLoginService,
           [],
         ),
-        returnValue: _i14.Future<_i11.MatrixService>.value(_FakeMatrixService_9(
+        returnValue:
+            _i15.Future<_i12.MatrixService>.value(_FakeMatrixService_10(
           this,
           Invocation.method(
             #createLoginService,
@@ -1479,14 +1516,14 @@ class MockClientManager extends _i1.Mock implements _i21.ClientManager {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i11.MatrixService>.value(_FakeMatrixService_9(
+            _i15.Future<_i12.MatrixService>.value(_FakeMatrixService_10(
           this,
           Invocation.method(
             #createLoginService,
             [],
           ),
         )),
-      ) as _i14.Future<_i11.MatrixService>);
+      ) as _i15.Future<_i12.MatrixService>);
 
   @override
   void commitPendingService() => super.noSuchMethod(
@@ -1507,36 +1544,36 @@ class MockClientManager extends _i1.Mock implements _i21.ClientManager {
       );
 
   @override
-  _i14.Future<void> addService(_i11.MatrixService? service) =>
+  _i15.Future<void> addService(_i12.MatrixService? service) =>
       (super.noSuchMethod(
         Invocation.method(
           #addService,
           [service],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> signOut(_i11.MatrixService? service) => (super.noSuchMethod(
+  _i15.Future<void> signOut(_i12.MatrixService? service) => (super.noSuchMethod(
         Invocation.method(
           #signOut,
           [service],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> removeService(_i11.MatrixService? service) =>
+  _i15.Future<void> removeService(_i12.MatrixService? service) =>
       (super.noSuchMethod(
         Invocation.method(
           #removeService,
           [service],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -1548,7 +1585,7 @@ class MockClientManager extends _i1.Mock implements _i21.ClientManager {
       );
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1557,7 +1594,7 @@ class MockClientManager extends _i1.Mock implements _i21.ClientManager {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1582,23 +1619,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_10(
+        returnValue: _FakeDatabaseApi_11(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_10(
+        returnValueForMissingStub: _FakeDatabaseApi_11(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i22.KeyVerificationMethod> get verificationMethods =>
+  Set<_i23.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i22.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i22.KeyVerificationMethod>{},
-      ) as Set<_i22.KeyVerificationMethod>);
+        returnValue: <_i23.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i23.KeyVerificationMethod>{},
+      ) as Set<_i23.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1659,11 +1696,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_11(
+        returnValue: _FakeFilter_12(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_11(
+        returnValueForMissingStub: _FakeFilter_12(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -1672,11 +1709,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_12(
+        returnValue: _FakeNativeImplementations_13(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_12(
+        returnValueForMissingStub: _FakeNativeImplementations_13(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -1692,11 +1729,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_13(
+        returnValue: _FakeDuration_14(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_13(
+        returnValueForMissingStub: _FakeDuration_14(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -1705,11 +1742,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_13(
+        returnValue: _FakeDuration_14(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_13(
+        returnValueForMissingStub: _FakeDuration_14(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -1718,11 +1755,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1759,11 +1796,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1793,11 +1830,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1806,11 +1843,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1833,11 +1870,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_14(
+        returnValue: _FakePushruleEvaluator_15(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_14(
+        returnValueForMissingStub: _FakePushruleEvaluator_15(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -1858,332 +1895,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i14.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i15.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i12.CachedStreamController<String> get onUserProfileUpdate =>
+  _i13.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_16<String>(
+        returnValue: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i14.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i15.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i14.Future<List<_i4.Room>>);
+            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i15.Future<List<_i4.Room>>);
 
   @override
-  _i12.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i13.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_16<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_17<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.EventUpdate>(
+            _FakeCachedStreamController_17<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.EventUpdate>);
+      ) as _i13.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i13.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_16<_i4.Event>(
+        returnValue: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i13.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_16<_i4.Event>(
+        returnValue: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onNotification =>
+  _i13.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_16<_i4.Event>(
+        returnValue: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i13.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_16<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_17<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_17<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i13.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i12.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i13.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_16<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_17<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_16<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_17<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i12.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i13.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i12.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i13.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_16<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_17<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.LoginState>(
+            _FakeCachedStreamController_17<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i12.CachedStreamController<_i4.LoginState>);
+      ) as _i13.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i12.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i13.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_16<bool>(
+        returnValue: _FakeCachedStreamController_17<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i12.CachedStreamController<bool>);
+      ) as _i13.CachedStreamController<bool>);
 
   @override
-  _i12.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i13.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_16<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_17<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i12.CachedStreamController<_i4.SdkError>);
+      ) as _i13.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i12.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i13.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_16<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_17<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.SyncUpdate>(
+            _FakeCachedStreamController_17<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i12.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i13.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i13.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_16<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_17<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_17<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i12.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i13.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.Presence> get onPresence =>
+  _i13.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_16<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_17<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i12.CachedStreamController<_i4.Presence>);
+      ) as _i13.CachedStreamController<_i4.Presence>);
 
   @override
-  _i12.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i13.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_16<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_17<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.CachedPresence>(
+            _FakeCachedStreamController_17<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i12.CachedStreamController<_i4.CachedPresence>);
+      ) as _i13.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i12.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i13.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_16<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_17<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.BasicEvent>(
+            _FakeCachedStreamController_17<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i12.CachedStreamController<_i4.BasicEvent>);
+      ) as _i13.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i12.CachedStreamController<_i22.RoomKeyRequest> get onRoomKeyRequest =>
+  _i13.CachedStreamController<_i23.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_16<_i22.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_17<_i23.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i22.RoomKeyRequest>(
+            _FakeCachedStreamController_17<_i23.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i12.CachedStreamController<_i22.RoomKeyRequest>);
+      ) as _i13.CachedStreamController<_i23.RoomKeyRequest>);
 
   @override
-  _i12.CachedStreamController<_i22.KeyVerification>
+  _i13.CachedStreamController<_i23.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_16<_i22.KeyVerification>(
+            returnValue: _FakeCachedStreamController_17<_i23.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_16<_i22.KeyVerification>(
+                _FakeCachedStreamController_17<_i23.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i12.CachedStreamController<_i22.KeyVerification>);
+          ) as _i13.CachedStreamController<_i23.KeyVerification>);
 
   @override
-  _i12.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i13.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_16<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_17<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_17<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i12.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i13.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i13.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_16<_i4.Event>(
+        returnValue: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<String> get onCancelSendEvent =>
+  _i13.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_16<String>(
+        returnValue: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i12.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i13.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_16<
+            returnValue: _FakeCachedStreamController_17<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_16<
+            returnValueForMissingStub: _FakeCachedStreamController_17<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i12.CachedStreamController<
+          ) as _i13.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -2203,11 +2240,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_17(
+        returnValue: _FakeDateTime_18(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_17(
+        returnValueForMissingStub: _FakeDateTime_18(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2280,7 +2317,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i22.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i23.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2335,7 +2372,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i14.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i15.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2346,7 +2383,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i14.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i15.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -2457,7 +2494,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -2466,7 +2503,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -2475,7 +2512,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -2502,20 +2539,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Client get httpClient => (super.noSuchMethod(
+  _i14.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_18(
+        returnValue: _FakeClient_19(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_18(
+        returnValueForMissingStub: _FakeClient_19(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i13.Client);
+      ) as _i14.Client);
 
   @override
-  set httpClient(_i13.Client? value) => super.noSuchMethod(
+  set httpClient(_i14.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -2542,7 +2579,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<void> refreshAccessToken(
+  _i15.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2550,9 +2587,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -2570,14 +2607,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2614,33 +2651,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i14.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i15.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_19(
+        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_20(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_19(
+        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_20(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i14.Future<_i4.DiscoveryInformation>);
+      ) as _i15.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i14.Future<
+  _i15.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -2662,7 +2699,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i14.Future<
+        returnValue: _i15.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2670,7 +2707,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_20(
+          _FakeGetVersionsResponse_21(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2685,7 +2722,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i14.Future<
+        returnValueForMissingStub: _i15.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2693,7 +2730,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_20(
+          _FakeGetVersionsResponse_21(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2708,7 +2745,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i14.Future<
+      ) as _i15.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -2717,7 +2754,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i14.Future<_i4.DiscoveryInformation> getWellknown({
+  _i15.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2730,8 +2767,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_19(
+        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_20(
           this,
           Invocation.method(
             #getWellknown,
@@ -2742,8 +2779,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_19(
+        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_20(
           this,
           Invocation.method(
             #getWellknown,
@@ -2754,10 +2791,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.DiscoveryInformation>);
+      ) as _i15.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i14.Future<_i4.RegisterResponse> register({
+  _i15.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -2785,7 +2822,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_21(
+            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_22(
           this,
           Invocation.method(
             #register,
@@ -2804,7 +2841,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_21(
+            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_22(
           this,
           Invocation.method(
             #register,
@@ -2822,10 +2859,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RegisterResponse>);
+      ) as _i15.Future<_i4.RegisterResponse>);
 
   @override
-  _i14.Future<_i4.LoginResponse> login(
+  _i15.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -2855,7 +2892,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_22(
+        returnValue: _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_23(
           this,
           Invocation.method(
             #login,
@@ -2875,7 +2912,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_22(
+            _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_23(
           this,
           Invocation.method(
             #login,
@@ -2894,10 +2931,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.LoginResponse>);
+      ) as _i15.Future<_i4.LoginResponse>);
 
   @override
-  _i14.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i15.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2910,8 +2947,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_23(
+        returnValue: _i15.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_24(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2923,8 +2960,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_23(
+            _i15.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_24(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2935,74 +2972,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i15.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logoutAll() => (super.noSuchMethod(
+  _i15.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<T> uiaRequestBackground<T>(
-          _i14.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i15.Future<T> uiaRequestBackground<T>(
+          _i15.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i14.Future<T>.value(v),
+              (T v) => _i15.Future<T>.value(v),
             ) ??
-            _FakeFuture_24<T>(
+            _FakeFuture_25<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i14.Future<T>.value(v),
+              (T v) => _i15.Future<T>.value(v),
             ) ??
-            _FakeFuture_24<T>(
+            _FakeFuture_25<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i14.Future<T>);
+      ) as _i15.Future<T>);
 
   @override
-  _i14.Future<String> startDirectChat(
+  _i15.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -3024,7 +3061,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3040,7 +3077,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3055,10 +3092,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> createGroupChat({
+  _i15.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -3089,7 +3126,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3110,7 +3147,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3130,10 +3167,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i15.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -3149,7 +3186,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3162,7 +3199,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3174,21 +3211,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i15.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<String> createSpace({
+  _i15.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -3213,7 +3250,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3231,7 +3268,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3248,10 +3285,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i15.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3259,7 +3296,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3268,7 +3305,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3276,10 +3313,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i14.Future<_i4.Profile> fetchOwnProfile({
+  _i15.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3292,7 +3329,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3304,7 +3341,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3315,10 +3352,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i14.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i15.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3332,8 +3369,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i14.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_26(
+        returnValue: _i15.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_27(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3345,8 +3382,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_26(
+            _i15.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_27(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3357,10 +3394,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.CachedProfileInformation>);
+      ) as _i15.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i14.Future<_i4.Profile> getProfileFromUserId(
+  _i15.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3378,7 +3415,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3392,7 +3429,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3405,7 +3442,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -3427,31 +3464,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i14.Future<List<_i4.Room>>);
+            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i15.Future<List<_i4.Room>>);
 
   @override
-  _i14.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i15.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i14.Future<List<_i4.ArchivedRoom>>);
+            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i15.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i14.Future<_i4.GetVersionsResponse> getVersions({
+  _i15.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3464,8 +3501,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_20(
+        returnValue: _i15.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_21(
           this,
           Invocation.method(
             #getVersions,
@@ -3476,8 +3513,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_20(
+        returnValueForMissingStub: _i15.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_21(
           this,
           Invocation.method(
             #getVersions,
@@ -3488,20 +3525,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetVersionsResponse>);
+      ) as _i15.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i14.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i15.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.MediaConfig> getConfig({
+  _i15.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3514,7 +3551,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
+        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
           this,
           Invocation.method(
             #getConfig,
@@ -3526,7 +3563,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
+            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
           this,
           Invocation.method(
             #getConfig,
@@ -3537,10 +3574,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.MediaConfig>);
+      ) as _i15.Future<_i4.MediaConfig>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContent(
+  _i15.Future<_i16.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -3560,7 +3597,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContent,
@@ -3576,7 +3613,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContent,
@@ -3591,10 +3628,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentOverrideName(
+  _i15.Future<_i16.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -3616,7 +3653,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3633,7 +3670,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3649,10 +3686,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentThumbnail(
+  _i15.Future<_i16.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -3680,7 +3717,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3700,7 +3737,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3719,10 +3756,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i15.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -3732,7 +3769,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
+        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3741,7 +3778,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
+            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3749,11 +3786,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i14.Future<_i4.PreviewForUrl>);
+      ) as _i15.Future<_i4.PreviewForUrl>);
 
   @override
-  _i14.Future<Uri> uploadContent(
-    _i23.Uint8List? file, {
+  _i15.Future<Uri> uploadContent(
+    _i24.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3766,7 +3803,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i14.Future<Uri>.value(_FakeUri_30(
+        returnValue: _i15.Future<Uri>.value(_FakeUri_31(
           this,
           Invocation.method(
             #uploadContent,
@@ -3777,7 +3814,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_30(
+        returnValueForMissingStub: _i15.Future<Uri>.value(_FakeUri_31(
           this,
           Invocation.method(
             #uploadContent,
@@ -3788,10 +3825,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<Uri>);
+      ) as _i15.Future<Uri>);
 
   @override
-  _i14.Future<void> setTyping(
+  _i15.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -3807,42 +3844,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> exportDump() => (super.noSuchMethod(
+  _i15.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i15.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i15.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Event?> getEventByPushNotification(
+  _i15.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -3858,12 +3895,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
-  _i14.Future<void> init({
+  _i15.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -3898,9 +3935,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -3912,40 +3949,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<void> clear() => (super.noSuchMethod(
+  _i15.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i15.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ensureNotSoftLoggedOut(
+  _i15.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSync(
+  _i15.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -3955,9 +3992,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -3970,29 +4007,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i14.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i15.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i15.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDevice(
+  _i15.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -4006,12 +4043,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDevicesOfUserIds(
+  _i15.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4027,12 +4064,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDeviceEncrypted(
+  _i15.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4052,12 +4089,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDeviceEncryptedChunked(
+  _i15.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -4071,23 +4108,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i15.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> joinRoom(
+  _i15.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -4105,7 +4142,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4119,7 +4156,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4132,10 +4169,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> changePassword(
+  _i15.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -4151,22 +4188,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> clearCache() => (super.noSuchMethod(
+  _i15.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ignoreUser(
+  _i15.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4176,22 +4213,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i15.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i15.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4202,7 +4239,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_31(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_32(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4211,7 +4248,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_31(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_32(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4219,32 +4256,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i14.Future<_i4.CachedPresence>);
+      ) as _i15.Future<_i4.CachedPresence>);
 
   @override
-  _i14.Future<void> abortSync() => (super.noSuchMethod(
+  _i15.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i15.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEventWithMetadata(
+  _i15.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4264,14 +4301,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i13.BaseResponse? response,
-    _i23.Uint8List? body,
+    _i14.BaseResponse? response,
+    _i24.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4303,7 +4340,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i14.Future<Map<String, Object?>> request(
+  _i15.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -4324,13 +4361,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> postPusher(
+  _i15.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -4340,57 +4377,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i15.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i15.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i15.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i14.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_32(
+        returnValue: _i15.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_33(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_32(
+        returnValueForMissingStub: _i15.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_33(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.TurnServerCredentials>);
+      ) as _i15.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4404,8 +4441,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4417,8 +4454,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4429,10 +4466,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4448,8 +4485,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4462,8 +4499,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4475,10 +4512,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i15.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4492,7 +4529,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
+        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4504,7 +4541,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
+            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4515,17 +4552,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.KeyBackupData>);
+      ) as _i15.Future<_i4.KeyBackupData>);
 
   @override
-  _i14.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i15.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i14.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_35(
+        returnValue: _i15.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_36(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -4533,18 +4570,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_35(
+            _i15.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_36(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i15.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i14.Future<int> pingAppservice(
+  _i15.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -4554,12 +4591,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i14.Future<int>.value(0),
-        returnValueForMissingStub: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+        returnValueForMissingStub: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
-  _i14.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i15.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4567,8 +4604,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_36(
+        returnValue: _i15.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_37(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4577,8 +4614,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_36(
+            _i15.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_37(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4586,15 +4623,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i14.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i15.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i14.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i15.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
+        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -4602,17 +4639,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
+            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.MediaConfig>);
+      ) as _i15.Future<_i4.MediaConfig>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentAuthed(
+  _i15.Future<_i16.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -4626,7 +4663,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4638,7 +4675,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4649,10 +4686,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentOverrideNameAuthed(
+  _i15.Future<_i16.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4668,7 +4705,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4681,7 +4718,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4693,10 +4730,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i15.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -4706,7 +4743,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
+        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4715,7 +4752,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
+            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4723,10 +4760,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i14.Future<_i4.PreviewForUrl>);
+      ) as _i15.Future<_i4.PreviewForUrl>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentThumbnailAuthed(
+  _i15.Future<_i16.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -4750,7 +4787,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4768,7 +4805,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4785,21 +4822,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<bool> registrationTokenValidity(String? token) =>
+  _i15.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i15.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -4809,8 +4846,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_37(
+        returnValue: _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_38(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4819,8 +4856,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_37(
+            _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_38(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4828,10 +4865,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i15.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i14.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i15.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -4849,8 +4886,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_38(
+        returnValue: _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_39(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4864,8 +4901,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_38(
+            _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_39(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4878,10 +4915,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i15.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i15.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -4905,8 +4942,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i14.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_39(
+        returnValue: _i15.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_40(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4924,8 +4961,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_39(
+            _i15.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_40(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4942,10 +4979,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i15.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -4973,8 +5010,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_40(
+                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_41(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4993,8 +5030,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_40(
+                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_41(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5012,10 +5049,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i15.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -5044,9 +5081,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i14.Future<
+            returnValue: _i15.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5065,9 +5102,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i14.Future<
+            returnValueForMissingStub: _i15.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5086,11 +5123,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i14
+          ) as _i15
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i14.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i15.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -5106,8 +5143,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i14.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_42(
+        returnValue: _i15.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_43(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5120,8 +5157,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_42(
+            _i15.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_43(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5133,10 +5170,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetThreadRootsResponse>);
+      ) as _i15.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i14.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i15.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -5150,8 +5187,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i14.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_43(
+        returnValue: _i15.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_44(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5163,8 +5200,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_43(
+            _i15.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_44(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5175,33 +5212,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i15.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i15.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i14.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i15.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i14.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i15.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i14.Future<Uri?>.value(),
-        returnValueForMissingStub: _i14.Future<Uri?>.value(),
-      ) as _i14.Future<Uri?>);
+        returnValue: _i15.Future<Uri?>.value(),
+        returnValueForMissingStub: _i15.Future<Uri?>.value(),
+      ) as _i15.Future<Uri?>);
 
   @override
-  _i14.Future<void> add3PID(
+  _i15.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -5215,12 +5252,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> bind3PID(
+  _i15.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5236,12 +5273,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i15.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5255,14 +5292,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5284,8 +5321,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5301,8 +5338,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5318,10 +5355,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5345,8 +5382,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5363,8 +5400,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5381,10 +5418,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i15.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5398,14 +5435,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i15.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -5420,14 +5457,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5449,8 +5486,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5466,8 +5503,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5483,10 +5520,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5510,8 +5547,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5528,8 +5565,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5546,16 +5583,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i15.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_45(
+            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -5563,22 +5600,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_45(
+            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.TokenOwnerInfo>);
+      ) as _i15.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i14.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i15.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_46(
+        returnValue: _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_47(
           this,
           Invocation.method(
             #getWhoIs,
@@ -5586,22 +5623,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_46(
+            _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_47(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i14.Future<_i4.WhoIsInfo>);
+      ) as _i15.Future<_i4.WhoIsInfo>);
 
   @override
-  _i14.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i15.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_47(
+        returnValue: _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_48(
           this,
           Invocation.method(
             #getCapabilities,
@@ -5609,17 +5646,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_47(
+            _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_48(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.Capabilities>);
+      ) as _i15.Future<_i4.Capabilities>);
 
   @override
-  _i14.Future<String> createRoom({
+  _i15.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -5652,7 +5689,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5674,7 +5711,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5695,10 +5732,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> deleteDevices(
+  _i15.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5708,22 +5745,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.Device>?>.value(),
-      ) as _i14.Future<List<_i4.Device>?>);
+        returnValue: _i15.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.Device>?>.value(),
+      ) as _i15.Future<List<_i4.Device>?>);
 
   @override
-  _i14.Future<void> deleteDevice(
+  _i15.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5733,34 +5770,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i15.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i14.Future<_i4.Device>.value(_FakeDevice_48(
+        returnValue: _i15.Future<_i4.Device>.value(_FakeDevice_49(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Device>.value(_FakeDevice_48(
+        returnValueForMissingStub: _i15.Future<_i4.Device>.value(_FakeDevice_49(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i14.Future<_i4.Device>);
+      ) as _i15.Future<_i4.Device>);
 
   @override
-  _i14.Future<void> updateDevice(
+  _i15.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -5770,12 +5807,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i15.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -5790,24 +5827,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i15.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i14.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Visibility?>.value(),
-      ) as _i14.Future<_i4.Visibility?>);
+        returnValue: _i15.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Visibility?>.value(),
+      ) as _i15.Future<_i4.Visibility?>);
 
   @override
-  _i14.Future<void> setRoomVisibilityOnDirectory(
+  _i15.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -5817,30 +5854,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i15.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i15.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_49(
+        returnValue: _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_50(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -5848,18 +5885,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_49(
+            _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_50(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i15.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i14.Future<void> setRoomAlias(
+  _i15.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -5871,12 +5908,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetEventsResponse> getEvents({
+  _i15.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -5890,7 +5927,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_50(
+            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_51(
           this,
           Invocation.method(
             #getEvents,
@@ -5902,7 +5939,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_50(
+            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_51(
           this,
           Invocation.method(
             #getEvents,
@@ -5913,10 +5950,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetEventsResponse>);
+      ) as _i15.Future<_i4.GetEventsResponse>);
 
   @override
-  _i14.Future<_i4.PeekEventsResponse> peekEvents({
+  _i15.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -5931,8 +5968,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i14.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_51(
+        returnValue: _i15.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_52(
           this,
           Invocation.method(
             #peekEvents,
@@ -5944,8 +5981,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_51(
+        returnValueForMissingStub: _i15.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_52(
           this,
           Invocation.method(
             #peekEvents,
@@ -5957,16 +5994,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.PeekEventsResponse>);
+      ) as _i15.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i14.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i15.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
+        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
           this,
           Invocation.method(
             #getOneEvent,
@@ -5974,27 +6011,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
+            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i14.Future<_i4.MatrixEvent>);
+      ) as _i15.Future<_i4.MatrixEvent>);
 
   @override
-  _i14.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i15.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 
   @override
-  _i14.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i15.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -6006,8 +6043,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i14.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_53(
+        returnValue: _i15.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_54(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6018,8 +6055,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_53(
+            _i15.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_54(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6029,10 +6066,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.GetKeysChangesResponse>);
+      ) as _i15.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i14.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i15.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -6043,7 +6080,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_54(
+            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
           this,
           Invocation.method(
             #claimKeys,
@@ -6052,7 +6089,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_54(
+            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
           this,
           Invocation.method(
             #claimKeys,
@@ -6060,10 +6097,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i14.Future<_i4.ClaimKeysResponse>);
+      ) as _i15.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i14.Future<void> uploadCrossSigningKeys({
+  _i15.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -6080,12 +6117,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.QueryKeysResponse> queryKeys(
+  _i15.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -6096,7 +6133,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_55(
+            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
           this,
           Invocation.method(
             #queryKeys,
@@ -6105,7 +6142,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_55(
+            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
           this,
           Invocation.method(
             #queryKeys,
@@ -6113,10 +6150,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i14.Future<_i4.QueryKeysResponse>);
+      ) as _i15.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -6124,14 +6161,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i14.Future<
+            returnValue: _i15.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i14.Future<
+            returnValueForMissingStub: _i15.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i14.Future<Map<String, int>> uploadKeys({
+  _i15.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -6146,13 +6183,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i14.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i15.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i14.Future<Map<String, int>>);
+            _i15.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i15.Future<Map<String, int>>);
 
   @override
-  _i14.Future<String> knockRoom(
+  _i15.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -6166,7 +6203,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6178,7 +6215,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6189,20 +6226,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i15.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i14.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i15.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i15.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i14.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i15.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6217,8 +6254,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i14.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_56(
+        returnValue: _i15.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_57(
           this,
           Invocation.method(
             #getNotifications,
@@ -6231,8 +6268,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_56(
+            _i15.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_57(
           this,
           Invocation.method(
             #getNotifications,
@@ -6244,35 +6281,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetNotificationsResponse>);
+      ) as _i15.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i14.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i15.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i14.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_57(
+        returnValue: _i15.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_58(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_57(
+        returnValueForMissingStub: _i15.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_58(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i14.Future<_i4.GetPresenceResponse>);
+      ) as _i15.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i14.Future<void> setPresence(
+  _i15.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -6286,12 +6323,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, Object?>> deleteProfileField(
+  _i15.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6304,13 +6341,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getProfileField(
+  _i15.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6323,13 +6360,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<Map<String, Object?>> setProfileField(
+  _i15.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6344,13 +6381,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i15.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6365,8 +6402,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i14.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_58(
+        returnValue: _i15.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_59(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6379,8 +6416,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_58(
+            _i15.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_59(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6392,10 +6429,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i15.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i14.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i15.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -6416,8 +6453,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i14.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_59(
+        returnValue: _i15.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_60(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6433,8 +6470,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_59(
+            _i15.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_60(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6449,25 +6486,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i15.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i14.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.Pusher>?>.value(),
-      ) as _i14.Future<List<_i4.Pusher>?>);
+        returnValue: _i15.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.Pusher>?>.value(),
+      ) as _i15.Future<List<_i4.Pusher>?>);
 
   @override
-  _i14.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i15.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_60(
+        returnValue: _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_61(
           this,
           Invocation.method(
             #getPushRules,
@@ -6475,24 +6512,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_60(
+            _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_61(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.PushRuleSet>);
+      ) as _i15.Future<_i4.PushRuleSet>);
 
   @override
-  _i14.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i15.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_61(
+        returnValue: _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_62(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -6500,18 +6537,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_61(
+            _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_62(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i15.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i14.Future<void> deletePushRule(
+  _i15.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6523,12 +6560,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.PushRule> getPushRule(
+  _i15.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6540,7 +6577,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<_i4.PushRule>.value(_FakePushRule_62(
+        returnValue: _i15.Future<_i4.PushRule>.value(_FakePushRule_63(
           this,
           Invocation.method(
             #getPushRule,
@@ -6551,7 +6588,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PushRule>.value(_FakePushRule_62(
+            _i15.Future<_i4.PushRule>.value(_FakePushRule_63(
           this,
           Invocation.method(
             #getPushRule,
@@ -6561,10 +6598,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.PushRule>);
+      ) as _i15.Future<_i4.PushRule>);
 
   @override
-  _i14.Future<void> setPushRule(
+  _i15.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -6588,12 +6625,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<Object?>> getPushRuleActions(
+  _i15.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6605,13 +6642,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i15.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i14.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i14.Future<List<Object?>>);
+            _i15.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i15.Future<List<Object?>>);
 
   @override
-  _i14.Future<void> setPushRuleActions(
+  _i15.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -6625,12 +6662,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> isPushRuleEnabled(
+  _i15.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6642,12 +6679,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> setPushRuleEnabled(
+  _i15.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -6661,19 +6698,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i15.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_63(
+            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_64(
           this,
           Invocation.method(
             #refresh,
@@ -6681,28 +6718,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_63(
+            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_64(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i14.Future<_i4.RefreshResponse>);
+      ) as _i15.Future<_i4.RefreshResponse>);
 
   @override
-  _i14.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i15.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i14.Future<bool?>.value(),
-        returnValueForMissingStub: _i14.Future<bool?>.value(),
-      ) as _i14.Future<bool?>);
+        returnValue: _i15.Future<bool?>.value(),
+        returnValueForMissingStub: _i15.Future<bool?>.value(),
+      ) as _i15.Future<bool?>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6724,8 +6761,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6741,8 +6778,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6758,10 +6795,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6785,8 +6822,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6803,8 +6840,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6821,17 +6858,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -6839,23 +6876,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i15.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_64(
+        returnValue: _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_65(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -6863,17 +6900,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_64(
+            _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_65(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeys>);
+      ) as _i15.Future<_i4.RoomKeys>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -6885,8 +6922,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6897,8 +6934,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6908,10 +6945,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6923,8 +6960,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6935,8 +6972,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6946,10 +6983,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6961,7 +6998,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_65(
+        returnValue: _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6972,7 +7009,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_65(
+            _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6982,10 +7019,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeyBackup>);
+      ) as _i15.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -6999,8 +7036,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7012,8 +7049,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7024,10 +7061,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7041,8 +7078,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7054,8 +7091,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7066,10 +7103,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i15.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7083,7 +7120,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
+        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7095,7 +7132,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
+            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7106,10 +7143,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.KeyBackupData>);
+      ) as _i15.Future<_i4.KeyBackupData>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7125,8 +7162,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7139,8 +7176,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7152,18 +7189,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_66(
+                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_67(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -7171,18 +7208,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_66(
+                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_67(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i14.Future<String> postRoomKeysVersion(
+  _i15.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -7194,7 +7231,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7205,7 +7242,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7215,29 +7252,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i15.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i15.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_67(
+        returnValue: _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_68(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7245,18 +7282,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_67(
+            _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_68(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i15.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i15.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -7271,24 +7308,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i15.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 
   @override
-  _i14.Future<void> ban(
+  _i15.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7302,12 +7339,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.EventContext> getEventContext(
+  _i15.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7325,7 +7362,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i4.EventContext>.value(_FakeEventContext_68(
+        returnValue: _i15.Future<_i4.EventContext>.value(_FakeEventContext_69(
           this,
           Invocation.method(
             #getEventContext,
@@ -7340,7 +7377,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.EventContext>.value(_FakeEventContext_68(
+            _i15.Future<_i4.EventContext>.value(_FakeEventContext_69(
           this,
           Invocation.method(
             #getEventContext,
@@ -7354,10 +7391,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.EventContext>);
+      ) as _i15.Future<_i4.EventContext>);
 
   @override
-  _i14.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i15.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7369,7 +7406,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
+        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7380,7 +7417,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
+            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7390,20 +7427,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.MatrixEvent>);
+      ) as _i15.Future<_i4.MatrixEvent>);
 
   @override
-  _i14.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> inviteBy3PID(
+  _i15.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -7415,12 +7452,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> inviteUser(
+  _i15.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7434,12 +7471,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> joinRoomById(
+  _i15.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -7453,7 +7490,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7465,7 +7502,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7476,23 +7513,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i15.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i15.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i14.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i14.Future<Map<String, _i4.RoomMember>?>);
+            _i15.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i15.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i14.Future<void> kick(
+  _i15.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7506,12 +7543,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> leaveRoom(
+  _i15.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -7521,12 +7558,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i15.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -7542,12 +7579,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i14.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i14.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i15.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i15.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i14.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i15.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -7569,8 +7606,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_69(
+        returnValue: _i15.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_70(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7586,8 +7623,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_69(
+        returnValueForMissingStub: _i15.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_70(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7603,10 +7640,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomEventsResponse>);
+      ) as _i15.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i14.Future<void> setReadMarker(
+  _i15.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -7622,12 +7659,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> postReceipt(
+  _i15.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -7643,12 +7680,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEvent(
+  _i15.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -7664,12 +7701,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> reportRoom(
+  _i15.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -7681,12 +7718,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> reportEvent(
+  _i15.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -7704,12 +7741,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> sendMessage(
+  _i15.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -7725,7 +7762,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7738,7 +7775,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7750,23 +7787,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i15.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i14.Future<List<_i4.MatrixEvent>>);
+            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i15.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i15.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -7783,13 +7820,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<String> setRoomStateWithKey(
+  _i15.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -7805,7 +7842,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7818,7 +7855,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7830,10 +7867,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> unban(
+  _i15.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7847,12 +7884,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> upgradeRoom(
+  _i15.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -7866,7 +7903,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7878,7 +7915,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7889,10 +7926,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.SearchResults> search(
+  _i15.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -7902,7 +7939,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_70(
+        returnValue: _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_71(
           this,
           Invocation.method(
             #search,
@@ -7911,7 +7948,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_70(
+            _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_71(
           this,
           Invocation.method(
             #search,
@@ -7919,10 +7956,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i14.Future<_i4.SearchResults>);
+      ) as _i15.Future<_i4.SearchResults>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> sync({
+  _i15.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -7943,7 +7980,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.method(
             #sync,
@@ -7959,7 +7996,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.method(
             #sync,
@@ -7974,22 +8011,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i15.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i14.Future<List<_i4.Location>>);
+            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i15.Future<List<_i4.Location>>);
 
   @override
-  _i14.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i15.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -7999,21 +8036,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i14.Future<List<_i4.Location>>);
+            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i15.Future<List<_i4.Location>>);
 
   @override
-  _i14.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i15.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_71(
+        returnValue: _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_72(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -8021,45 +8058,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_71(
+            _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_72(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i14.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i15.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i14.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i15.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8070,13 +8107,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getAccountData(
+  _i15.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -8089,13 +8126,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> setAccountData(
+  _i15.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -8109,12 +8146,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> defineFilter(
+  _i15.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -8126,7 +8163,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8137,7 +8174,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8147,10 +8184,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.Filter> getFilter(
+  _i15.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -8162,7 +8199,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i14.Future<_i4.Filter>.value(_FakeFilter_11(
+        returnValue: _i15.Future<_i4.Filter>.value(_FakeFilter_12(
           this,
           Invocation.method(
             #getFilter,
@@ -8172,7 +8209,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Filter>.value(_FakeFilter_11(
+        returnValueForMissingStub: _i15.Future<_i4.Filter>.value(_FakeFilter_12(
           this,
           Invocation.method(
             #getFilter,
@@ -8182,10 +8219,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.Filter>);
+      ) as _i15.Future<_i4.Filter>);
 
   @override
-  _i14.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i15.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8198,7 +8235,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_72(
+            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8209,7 +8246,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_72(
+            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8219,10 +8256,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.OpenIdCredentials>);
+      ) as _i15.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i14.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i15.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8237,13 +8274,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> setAccountDataPerRoom(
+  _i15.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8259,12 +8296,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i15.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8276,12 +8313,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i14.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i14.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i14.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i15.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i15.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i15.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i14.Future<void> deleteRoomTag(
+  _i15.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8295,12 +8332,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setRoomTag(
+  _i15.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8316,12 +8353,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i15.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8331,8 +8368,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i14.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_73(
+        returnValue: _i15.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_74(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8341,8 +8378,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_73(
+            _i15.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_74(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8350,10 +8387,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i14.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i15.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> reportUser(
+  _i15.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8366,40 +8403,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i15.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i14.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_74(
+        returnValue: _i15.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_75(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_74(
+        returnValueForMissingStub: _i15.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_75(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.CreateContentResponse>);
+      ) as _i15.Future<_i4.CreateContentResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> uploadContentToMXC(
+  _i15.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i23.Uint8List? body, {
+    _i24.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8417,16 +8454,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [AuthService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAuthService extends _i1.Mock implements _i9.AuthService {
+class MockAuthService extends _i1.Mock implements _i10.AuthService {
   @override
   bool get isLoggedIn => (super.noSuchMethod(
         Invocation.getter(#isLoggedIn),
@@ -8460,7 +8497,7 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
       ) as bool);
 
   @override
-  _i14.Future<bool> login({
+  _i15.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -8475,12 +8512,12 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
             #password: password,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> completeSsoLogin({
+  _i15.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -8493,12 +8530,12 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> completeRegistration(
+  _i15.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -8508,9 +8545,9 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
           [response],
           {#password: password},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void activateRestoredSession() => super.noSuchMethod(
@@ -8522,37 +8559,37 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
       );
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleServerLogout() => (super.noSuchMethod(
+  _i15.Future<void> handleServerLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleServerLogout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> saveSessionBackup() => (super.noSuchMethod(
+  _i15.Future<void> saveSessionBackup() => (super.noSuchMethod(
         Invocation.method(
           #saveSessionBackup,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i16.ServerAuthCapabilities> getServerAuthCapabilities(
+  _i15.Future<_i17.ServerAuthCapabilities> getServerAuthCapabilities(
     String? homeserver, {
     required bool? isLoggedIn,
   }) =>
@@ -8562,8 +8599,8 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
           [homeserver],
           {#isLoggedIn: isLoggedIn},
         ),
-        returnValue: _i14.Future<_i16.ServerAuthCapabilities>.value(
-            _FakeServerAuthCapabilities_75(
+        returnValue: _i15.Future<_i17.ServerAuthCapabilities>.value(
+            _FakeServerAuthCapabilities_76(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -8572,8 +8609,8 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i16.ServerAuthCapabilities>.value(
-                _FakeServerAuthCapabilities_75(
+            _i15.Future<_i17.ServerAuthCapabilities>.value(
+                _FakeServerAuthCapabilities_76(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -8581,7 +8618,7 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
             {#isLoggedIn: isLoggedIn},
           ),
         )),
-      ) as _i14.Future<_i16.ServerAuthCapabilities>);
+      ) as _i15.Future<_i17.ServerAuthCapabilities>);
 
   @override
   bool isPermanentAuthFailure(Object? error) => (super.noSuchMethod(
@@ -8594,37 +8631,37 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
       ) as bool);
 
   @override
-  _i14.Future<void> clearSessionKeys() => (super.noSuchMethod(
+  _i15.Future<void> clearSessionKeys() => (super.noSuchMethod(
         Invocation.method(
           #clearSessionKeys,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> migrateStorageKeys() => (super.noSuchMethod(
+  _i15.Future<void> migrateStorageKeys() => (super.noSuchMethod(
         Invocation.method(
           #migrateStorageKeys,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> persistCredentials() => (super.noSuchMethod(
+  _i15.Future<void> persistCredentials() => (super.noSuchMethod(
         Invocation.method(
           #persistCredentials,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8633,7 +8670,7 @@ class MockAuthService extends _i1.Mock implements _i9.AuthService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/test/widgets/media_viewer_shell_test.mocks.dart
+++ b/test/widgets/media_viewer_shell_test.mocks.dart
@@ -2026,6 +2026,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -2532,6 +2539,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/message_reply_test.mocks.dart
+++ b/test/widgets/message_reply_test.mocks.dart
@@ -4,33 +4,35 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i12;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i15;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i16;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i23;
+import 'package:matrix/src/utils/space_child.dart' as _i24;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -802,8 +804,9 @@ class _FakeSelectionService_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
-  _FakeSyncService_71(
+class _FakeSpaceAccessService_71 extends _i1.SmartFake
+    implements _i12.SpaceAccessService {
+  _FakeSpaceAccessService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -812,8 +815,8 @@ class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
         );
 }
 
-class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
-  _FakeAuthService_72(
+class _FakeSyncService_72 extends _i1.SmartFake implements _i13.SyncService {
+  _FakeSyncService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -822,9 +825,8 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeOutboxService_73 extends _i1.SmartFake
-    implements _i14.OutboxService {
-  _FakeOutboxService_73(
+class _FakeAuthService_73 extends _i1.SmartFake implements _i14.AuthService {
+  _FakeAuthService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -833,8 +835,9 @@ class _FakeOutboxService_73 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_74(
+class _FakeOutboxService_74 extends _i1.SmartFake
+    implements _i15.OutboxService {
+  _FakeOutboxService_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -843,9 +846,19 @@ class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_75 extends _i1.SmartFake
+class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_76 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_75(
+  _FakeLatestReceiptState_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -854,8 +867,8 @@ class _FakeLatestReceiptState_75 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_76(
+class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -864,8 +877,8 @@ class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_77(
+class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -874,8 +887,8 @@ class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_78 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_78(
+class _FakeRoom_79 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -884,9 +897,9 @@ class _FakeRoom_78 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeTimelineChunk_79 extends _i1.SmartFake
-    implements _i15.TimelineChunk {
-  _FakeTimelineChunk_79(
+class _FakeTimelineChunk_80 extends _i1.SmartFake
+    implements _i16.TimelineChunk {
+  _FakeTimelineChunk_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -895,8 +908,8 @@ class _FakeTimelineChunk_79 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixFile_80 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_80(
+class _FakeMatrixFile_81 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -905,8 +918,8 @@ class _FakeMatrixFile_80 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_81 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_81(
+class _FakeEvent_82 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -933,12 +946,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1058,11 +1071,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1099,11 +1112,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1133,11 +1146,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1146,11 +1159,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1436,34 +1449,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1619,7 +1632,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1908,14 +1921,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2303,8 +2316,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2320,8 +2333,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2362,7 +2375,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2378,7 +2391,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2427,7 +2440,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2448,7 +2461,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2551,7 +2564,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2569,7 +2582,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3088,7 +3101,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3440,7 +3453,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3454,7 +3467,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3605,7 +3618,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4983,7 +4996,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5005,7 +5018,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5499,7 +5512,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5511,7 +5524,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6519,7 +6532,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6530,7 +6543,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6778,7 +6791,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6790,7 +6803,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7050,7 +7063,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7063,7 +7076,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7130,7 +7143,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7143,7 +7156,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7191,7 +7204,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7203,7 +7216,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7451,7 +7464,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7462,7 +7475,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7724,7 +7737,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7751,7 +7764,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7781,11 +7794,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7858,43 +7871,56 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i11.SelectionService);
 
   @override
-  _i12.SyncService get sync => (super.noSuchMethod(
+  _i12.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i12.SpaceAccessService);
+
+  @override
+  _i13.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_71(
+        returnValue: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_71(
+        returnValueForMissingStub: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i12.SyncService);
+      ) as _i13.SyncService);
 
   @override
-  _i13.AuthService get auth => (super.noSuchMethod(
+  _i14.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_72(
+        returnValue: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_72(
+        returnValueForMissingStub: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i13.AuthService);
+      ) as _i14.AuthService);
 
   @override
-  _i14.OutboxService get outbox => (super.noSuchMethod(
+  _i15.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_73(
+        returnValue: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_73(
+        returnValueForMissingStub: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i14.OutboxService);
+      ) as _i15.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7958,7 +7984,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set sync(_i12.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i12.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i13.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7967,7 +8002,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set auth(_i13.AuthService? value) => super.noSuchMethod(
+  set auth(_i14.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7976,7 +8011,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i15.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -8029,7 +8064,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8123,7 +8158,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8132,7 +8167,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8151,7 +8186,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8162,7 +8197,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8210,7 +8245,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8248,7 +8283,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8257,7 +8292,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8266,16 +8301,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8303,11 +8338,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8337,11 +8372,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_74(
+        returnValue: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_74(
+        returnValueForMissingStub: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
@@ -8394,11 +8429,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8434,11 +8469,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8454,11 +8489,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8467,11 +8502,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8514,11 +8549,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8561,11 +8596,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_75(
+        returnValue: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_75(
+        returnValueForMissingStub: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8602,6 +8637,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   bool get isFavourite => (super.noSuchMethod(
         Invocation.getter(#isFavourite),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
@@ -8777,18 +8819,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i23.SpaceParent>[],
-        returnValueForMissingStub: <_i23.SpaceParent>[],
-      ) as List<_i23.SpaceParent>);
+        returnValue: <_i24.SpaceParent>[],
+        returnValueForMissingStub: <_i24.SpaceParent>[],
+      ) as List<_i24.SpaceParent>);
 
   @override
-  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i23.SpaceChild>[],
-        returnValueForMissingStub: <_i23.SpaceChild>[],
-      ) as List<_i23.SpaceChild>);
+        returnValue: <_i24.SpaceChild>[],
+        returnValueForMissingStub: <_i24.SpaceChild>[],
+      ) as List<_i24.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8955,14 +8997,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9010,7 +9052,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9018,7 +9060,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9033,7 +9075,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9041,7 +9083,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9119,13 +9161,23 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   _i5.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9133,7 +9185,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9375,7 +9427,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9386,7 +9438,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9475,15 +9527,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i15.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i16.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i15.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i15.TimelineChunk?>.value(),
-      ) as _i5.Future<_i15.TimelineChunk?>);
+        returnValue: _i5.Future<_i16.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i16.TimelineChunk?>.value(),
+      ) as _i5.Future<_i16.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9524,7 +9576,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -9541,7 +9593,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -9605,14 +9657,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9628,14 +9680,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9691,7 +9743,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9699,7 +9751,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10011,11 +10063,11 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_78(
+        returnValue: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_78(
+        returnValueForMissingStub: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
@@ -10065,17 +10117,17 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       ) as bool);
 
   @override
-  _i15.TimelineChunk get chunk => (super.noSuchMethod(
+  _i16.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_79(
+        returnValue: _FakeTimelineChunk_80(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_79(
+        returnValueForMissingStub: _FakeTimelineChunk_80(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i15.TimelineChunk);
+      ) as _i16.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10178,7 +10230,7 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       );
 
   @override
-  set chunk(_i15.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i16.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,
@@ -10377,11 +10429,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.getter(#sender),
         ),
@@ -10390,11 +10442,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10403,11 +10455,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_78(
+        returnValue: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_78(
+        returnValueForMissingStub: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
@@ -10430,11 +10482,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10443,11 +10495,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10456,11 +10508,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10469,11 +10521,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10482,11 +10534,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10495,11 +10547,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10564,11 +10616,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10577,11 +10629,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10634,11 +10686,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10723,11 +10775,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10745,11 +10797,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10960,7 +11012,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i18.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i19.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10975,7 +11027,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_80(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_81(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10989,7 +11041,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_80(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_81(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -11025,7 +11077,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11040,7 +11092,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11077,7 +11129,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11091,7 +11143,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11128,7 +11180,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11142,7 +11194,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11176,7 +11228,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11189,7 +11241,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11265,14 +11317,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_81(
+        returnValue: _FakeEvent_82(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_81(
+        returnValueForMissingStub: _FakeEvent_82(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -11289,11 +11341,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_78(
+        returnValue: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_78(
+        returnValueForMissingStub: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
@@ -11302,11 +11354,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -11372,11 +11424,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11401,11 +11453,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11423,11 +11475,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11474,7 +11526,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11486,7 +11538,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11556,7 +11608,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11569,7 +11621,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/widgets/new_dm_dialog_test.mocks.dart
+++ b/test/widgets/new_dm_dialog_test.mocks.dart
@@ -4,33 +4,35 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i17;
-import 'dart:ui' as _i19;
+import 'dart:typed_data' as _i18;
+import 'dart:ui' as _i20;
 
-import 'package:flutter/services.dart' as _i20;
-import 'package:flutter/widgets.dart' as _i21;
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i12;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i15;
+import 'package:matrix/encryption.dart' as _i16;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i23;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i22;
+import 'package:matrix/src/utils/space_child.dart' as _i23;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -802,8 +804,9 @@ class _FakeSelectionService_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
-  _FakeSyncService_71(
+class _FakeSpaceAccessService_71 extends _i1.SmartFake
+    implements _i12.SpaceAccessService {
+  _FakeSpaceAccessService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -812,8 +815,8 @@ class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
         );
 }
 
-class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
-  _FakeAuthService_72(
+class _FakeSyncService_72 extends _i1.SmartFake implements _i13.SyncService {
+  _FakeSyncService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -822,9 +825,8 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeOutboxService_73 extends _i1.SmartFake
-    implements _i14.OutboxService {
-  _FakeOutboxService_73(
+class _FakeAuthService_73 extends _i1.SmartFake implements _i14.AuthService {
+  _FakeAuthService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -833,8 +835,9 @@ class _FakeOutboxService_73 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_74(
+class _FakeOutboxService_74 extends _i1.SmartFake
+    implements _i15.OutboxService {
+  _FakeOutboxService_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -843,9 +846,19 @@ class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_75 extends _i1.SmartFake
+class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_76 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_75(
+  _FakeLatestReceiptState_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -854,8 +867,8 @@ class _FakeLatestReceiptState_75 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_76(
+class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -864,8 +877,8 @@ class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_77(
+class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,12 +905,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i15.KeyVerificationMethod> get verificationMethods =>
+  Set<_i16.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i15.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
-      ) as Set<_i15.KeyVerificationMethod>);
+        returnValue: <_i16.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
+      ) as Set<_i16.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1017,11 +1030,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1058,11 +1071,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1092,11 +1105,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1105,11 +1118,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1395,34 +1408,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i15.KeyVerification>
+  _i3.CachedStreamController<_i16.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i15.KeyVerification>(
+                _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i15.KeyVerification>);
+          ) as _i3.CachedStreamController<_i16.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1578,7 +1591,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1867,14 +1880,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2262,8 +2275,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2279,8 +2292,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2321,7 +2334,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2337,7 +2350,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2386,7 +2399,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2407,7 +2420,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2510,7 +2523,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2528,7 +2541,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3047,7 +3060,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i17.Uint8List? file, {
+    _i18.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3399,7 +3412,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3413,7 +3426,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3564,7 +3577,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i17.Uint8List? body,
+    _i18.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4942,7 +4955,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4964,7 +4977,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5458,7 +5471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5470,7 +5483,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6478,7 +6491,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6489,7 +6502,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6737,7 +6750,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6749,7 +6762,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7009,7 +7022,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7022,7 +7035,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7089,7 +7102,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7102,7 +7115,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7150,7 +7163,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7162,7 +7175,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7410,7 +7423,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7421,7 +7434,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7683,7 +7696,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i17.Uint8List? body, {
+    _i18.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7710,7 +7723,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7740,11 +7753,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7817,43 +7830,56 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i11.SelectionService);
 
   @override
-  _i12.SyncService get sync => (super.noSuchMethod(
+  _i12.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i12.SpaceAccessService);
+
+  @override
+  _i13.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_71(
+        returnValue: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_71(
+        returnValueForMissingStub: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i12.SyncService);
+      ) as _i13.SyncService);
 
   @override
-  _i13.AuthService get auth => (super.noSuchMethod(
+  _i14.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_72(
+        returnValue: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_72(
+        returnValueForMissingStub: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i13.AuthService);
+      ) as _i14.AuthService);
 
   @override
-  _i14.OutboxService get outbox => (super.noSuchMethod(
+  _i15.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_73(
+        returnValue: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_73(
+        returnValueForMissingStub: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i14.OutboxService);
+      ) as _i15.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7917,7 +7943,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set sync(_i12.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i12.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i13.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7926,7 +7961,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set auth(_i13.AuthService? value) => super.noSuchMethod(
+  set auth(_i14.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7935,7 +7970,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i15.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -7988,7 +8023,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8082,7 +8117,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8091,7 +8126,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8110,7 +8145,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8121,7 +8156,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8169,7 +8204,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i21.RouteInformation? routeInformation) =>
+          _i22.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8207,7 +8242,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8216,7 +8251,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8225,16 +8260,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
-      ) as _i5.Future<_i19.AppExitResponse>);
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i5.Future<_i20.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8262,11 +8297,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8296,11 +8331,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_74(
+        returnValue: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_74(
+        returnValueForMissingStub: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
@@ -8353,11 +8388,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8393,11 +8428,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8413,11 +8448,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8426,11 +8461,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8473,11 +8508,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8520,11 +8555,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_75(
+        returnValue: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_75(
+        returnValueForMissingStub: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8561,6 +8596,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   bool get isFavourite => (super.noSuchMethod(
         Invocation.getter(#isFavourite),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
@@ -8736,18 +8778,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i22.SpaceParent>[],
-        returnValueForMissingStub: <_i22.SpaceParent>[],
-      ) as List<_i22.SpaceParent>);
+        returnValue: <_i23.SpaceParent>[],
+        returnValueForMissingStub: <_i23.SpaceParent>[],
+      ) as List<_i23.SpaceParent>);
 
   @override
-  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i22.SpaceChild>[],
-        returnValueForMissingStub: <_i22.SpaceChild>[],
-      ) as List<_i22.SpaceChild>);
+        returnValue: <_i23.SpaceChild>[],
+        returnValueForMissingStub: <_i23.SpaceChild>[],
+      ) as List<_i23.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8914,14 +8956,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8969,7 +9011,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8977,7 +9019,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8992,7 +9034,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9000,7 +9042,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9078,13 +9120,23 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   _i5.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9092,7 +9144,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9334,7 +9386,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9345,7 +9397,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9434,15 +9486,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i23.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i23.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i23.TimelineChunk?>.value(),
-      ) as _i5.Future<_i23.TimelineChunk?>);
+        returnValue: _i5.Future<_i24.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i24.TimelineChunk?>.value(),
+      ) as _i5.Future<_i24.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9483,7 +9535,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -9500,7 +9552,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -9564,14 +9616,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9587,14 +9639,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9650,7 +9702,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9658,7 +9710,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/new_room_dialog_test.mocks.dart
+++ b/test/widgets/new_room_dialog_test.mocks.dart
@@ -8859,6 +8859,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -9365,6 +9372,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/recovery_key_handler_test.mocks.dart
+++ b/test/widgets/recovery_key_handler_test.mocks.dart
@@ -3,35 +3,37 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i14;
-import 'dart:typed_data' as _i24;
-import 'dart:ui' as _i21;
+import 'dart:async' as _i15;
+import 'dart:typed_data' as _i25;
+import 'dart:ui' as _i22;
 
-import 'package:flutter/services.dart' as _i22;
-import 'package:flutter/widgets.dart' as _i23;
-import 'package:http/http.dart' as _i13;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
+import 'package:flutter/services.dart' as _i23;
+import 'package:flutter/widgets.dart' as _i24;
+import 'package:http/http.dart' as _i14;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i7;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i8;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i11;
-import 'package:matrix/encryption/cross_signing.dart' as _i18;
-import 'package:matrix/encryption/key_verification_manager.dart' as _i17;
-import 'package:matrix/encryption/olm_manager.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i12;
+import 'package:matrix/encryption/cross_signing.dart' as _i19;
+import 'package:matrix/encryption/key_verification_manager.dart' as _i18;
+import 'package:matrix/encryption/olm_manager.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i15;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i12;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i16;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i13;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i20;
+import 'package:mockito/src/dummies.dart' as _i21;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -112,8 +114,9 @@ class _FakeSelectionService_5 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
-  _FakeSyncService_6(
+class _FakeSpaceAccessService_6 extends _i1.SmartFake
+    implements _i8.SpaceAccessService {
+  _FakeSpaceAccessService_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -122,8 +125,8 @@ class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
         );
 }
 
-class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
-  _FakeAuthService_7(
+class _FakeSyncService_7 extends _i1.SmartFake implements _i9.SyncService {
+  _FakeSyncService_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -132,8 +135,8 @@ class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
         );
 }
 
-class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
-  _FakeOutboxService_8(
+class _FakeAuthService_8 extends _i1.SmartFake implements _i10.AuthService {
+  _FakeAuthService_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -142,8 +145,8 @@ class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
         );
 }
 
-class _FakeEncryption_9 extends _i1.SmartFake implements _i11.Encryption {
-  _FakeEncryption_9(
+class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
+  _FakeOutboxService_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -152,8 +155,8 @@ class _FakeEncryption_9 extends _i1.SmartFake implements _i11.Encryption {
         );
 }
 
-class _FakeSSSS_10 extends _i1.SmartFake implements _i11.SSSS {
-  _FakeSSSS_10(
+class _FakeEncryption_10 extends _i1.SmartFake implements _i12.Encryption {
+  _FakeEncryption_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -162,9 +165,19 @@ class _FakeSSSS_10 extends _i1.SmartFake implements _i11.SSSS {
         );
 }
 
-class _FakeSecretStorageKeyContent_11 extends _i1.SmartFake
+class _FakeSSSS_11 extends _i1.SmartFake implements _i12.SSSS {
+  _FakeSSSS_11(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeSecretStorageKeyContent_12 extends _i1.SmartFake
     implements _i4.SecretStorageKeyContent {
-  _FakeSecretStorageKeyContent_11(
+  _FakeSecretStorageKeyContent_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -173,8 +186,8 @@ class _FakeSecretStorageKeyContent_11 extends _i1.SmartFake
         );
 }
 
-class _FakeDatabaseApi_12 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_12(
+class _FakeDatabaseApi_13 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -183,8 +196,8 @@ class _FakeDatabaseApi_12 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_13 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_13(
+class _FakeFilter_14 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -193,9 +206,9 @@ class _FakeFilter_13 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_14 extends _i1.SmartFake
+class _FakeNativeImplementations_15 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_14(
+  _FakeNativeImplementations_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -204,8 +217,8 @@ class _FakeNativeImplementations_14 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_15 extends _i1.SmartFake implements Duration {
-  _FakeDuration_15(
+class _FakeDuration_16 extends _i1.SmartFake implements Duration {
+  _FakeDuration_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -214,9 +227,9 @@ class _FakeDuration_15 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_16 extends _i1.SmartFake
+class _FakePushruleEvaluator_17 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_16(
+  _FakePushruleEvaluator_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -225,8 +238,8 @@ class _FakePushruleEvaluator_16 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_17 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_17(
+class _FakeProfile_18 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -235,9 +248,9 @@ class _FakeProfile_17 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeCachedStreamController_18<T> extends _i1.SmartFake
-    implements _i12.CachedStreamController<T> {
-  _FakeCachedStreamController_18(
+class _FakeCachedStreamController_19<T> extends _i1.SmartFake
+    implements _i13.CachedStreamController<T> {
+  _FakeCachedStreamController_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -246,8 +259,8 @@ class _FakeCachedStreamController_18<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_19 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_19(
+class _FakeDateTime_20 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -256,8 +269,8 @@ class _FakeDateTime_19 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_20 extends _i1.SmartFake implements _i13.Client {
-  _FakeClient_20(
+class _FakeClient_21 extends _i1.SmartFake implements _i14.Client {
+  _FakeClient_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -266,9 +279,9 @@ class _FakeClient_20 extends _i1.SmartFake implements _i13.Client {
         );
 }
 
-class _FakeDiscoveryInformation_21 extends _i1.SmartFake
+class _FakeDiscoveryInformation_22 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_21(
+  _FakeDiscoveryInformation_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -277,9 +290,9 @@ class _FakeDiscoveryInformation_21 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_22 extends _i1.SmartFake
+class _FakeGetVersionsResponse_23 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_22(
+  _FakeGetVersionsResponse_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -288,9 +301,9 @@ class _FakeGetVersionsResponse_22 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_23 extends _i1.SmartFake
+class _FakeRegisterResponse_24 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_23(
+  _FakeRegisterResponse_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -299,8 +312,8 @@ class _FakeRegisterResponse_23 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_24 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_24(
+class _FakeLoginResponse_25 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -309,9 +322,9 @@ class _FakeLoginResponse_24 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_25 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_26 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_25(
+  _FakeGetAuthMetadataResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -320,8 +333,8 @@ class _FakeGetAuthMetadataResponse_25 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_26<T1> extends _i1.SmartFake implements _i14.Future<T1> {
-  _FakeFuture_26(
+class _FakeFuture_27<T1> extends _i1.SmartFake implements _i15.Future<T1> {
+  _FakeFuture_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -330,8 +343,8 @@ class _FakeFuture_26<T1> extends _i1.SmartFake implements _i14.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_27 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_27(
+class _FakeSyncUpdate_28 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -340,9 +353,9 @@ class _FakeSyncUpdate_27 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_28 extends _i1.SmartFake
+class _FakeCachedProfileInformation_29 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_28(
+  _FakeCachedProfileInformation_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -351,8 +364,8 @@ class _FakeCachedProfileInformation_28 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_29 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_29(
+class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -361,8 +374,8 @@ class _FakeMediaConfig_29 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_30 extends _i1.SmartFake implements _i15.FileResponse {
-  _FakeFileResponse_30(
+class _FakeFileResponse_31 extends _i1.SmartFake implements _i16.FileResponse {
+  _FakeFileResponse_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -371,8 +384,8 @@ class _FakeFileResponse_30 extends _i1.SmartFake implements _i15.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_31 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_31(
+class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -381,8 +394,8 @@ class _FakePreviewForUrl_31 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeUri_32 extends _i1.SmartFake implements Uri {
-  _FakeUri_32(
+class _FakeUri_33 extends _i1.SmartFake implements Uri {
+  _FakeUri_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -391,9 +404,9 @@ class _FakeUri_32 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_33 extends _i1.SmartFake
+class _FakeCachedPresence_34 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_33(
+  _FakeCachedPresence_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -402,9 +415,9 @@ class _FakeCachedPresence_33 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_34 extends _i1.SmartFake
+class _FakeTurnServerCredentials_35 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_34(
+  _FakeTurnServerCredentials_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -413,9 +426,9 @@ class _FakeTurnServerCredentials_34 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_35(
+  _FakeRoomKeysUpdateResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -424,8 +437,8 @@ class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_36(
+class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -434,9 +447,9 @@ class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_37(
+  _FakeGetWellknownSupportResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -445,9 +458,9 @@ class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_38(
+  _FakeGenerateLoginTokenResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -456,9 +469,9 @@ class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_39(
+  _FakeGetRoomSummaryResponse$3_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -467,9 +480,9 @@ class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_40(
+  _FakeGetSpaceHierarchyResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -478,9 +491,9 @@ class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_41(
+  _FakeGetRelatingEventsResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -489,9 +502,9 @@ class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_42(
+  _FakeGetRelatingEventsWithRelTypeResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -500,9 +513,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -511,9 +524,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_44(
+  _FakeGetThreadRootsResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -522,9 +535,9 @@ class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_45(
+  _FakeGetEventByTimestampResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -533,9 +546,9 @@ class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_46 extends _i1.SmartFake
+class _FakeRequestTokenResponse_47 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_46(
+  _FakeRequestTokenResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -544,9 +557,9 @@ class _FakeRequestTokenResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_47(
+  _FakeTokenOwnerInfo_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -555,8 +568,8 @@ class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_48(
+class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -565,8 +578,8 @@ class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_49(
+class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -575,8 +588,8 @@ class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_50(
+class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -585,9 +598,9 @@ class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_51(
+  _FakeGetRoomIdByAliasResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -596,9 +609,9 @@ class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_52 extends _i1.SmartFake
+class _FakeGetEventsResponse_53 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_52(
+  _FakeGetEventsResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -607,9 +620,9 @@ class _FakeGetEventsResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_53 extends _i1.SmartFake
+class _FakePeekEventsResponse_54 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_53(
+  _FakePeekEventsResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -618,8 +631,8 @@ class _FakePeekEventsResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_54(
+class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -628,9 +641,9 @@ class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_55(
+  _FakeGetKeysChangesResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -639,9 +652,9 @@ class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_56 extends _i1.SmartFake
+class _FakeClaimKeysResponse_57 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_56(
+  _FakeClaimKeysResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -650,9 +663,9 @@ class _FakeClaimKeysResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_57 extends _i1.SmartFake
+class _FakeQueryKeysResponse_58 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_57(
+  _FakeQueryKeysResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -661,9 +674,9 @@ class _FakeQueryKeysResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_58(
+  _FakeGetNotificationsResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -672,9 +685,9 @@ class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_59 extends _i1.SmartFake
+class _FakeGetPresenceResponse_60 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_59(
+  _FakeGetPresenceResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -683,9 +696,9 @@ class _FakeGetPresenceResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_60(
+  _FakeGetPublicRoomsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -694,9 +707,9 @@ class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_61(
+  _FakeQueryPublicRoomsResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -705,8 +718,8 @@ class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_62(
+class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -715,9 +728,9 @@ class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_63(
+  _FakeGetPushRulesGlobalResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -726,8 +739,8 @@ class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_64(
+class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -736,9 +749,9 @@ class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_65 extends _i1.SmartFake
+class _FakeRefreshResponse_66 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_65(
+  _FakeRefreshResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -747,8 +760,8 @@ class _FakeRefreshResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_66(
+class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -757,8 +770,8 @@ class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_67(
+class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -767,9 +780,9 @@ class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_68(
+  _FakeGetRoomKeysVersionCurrentResponse_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -778,9 +791,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_69(
+  _FakeGetRoomKeysVersionResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -789,8 +802,8 @@ class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_70(
+class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -799,9 +812,9 @@ class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_71(
+  _FakeGetRoomEventsResponse_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -810,8 +823,8 @@ class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_72(
+class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -820,9 +833,9 @@ class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_73(
+  _FakeGetProtocolMetadataResponse$2_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -831,9 +844,9 @@ class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_74 extends _i1.SmartFake
+class _FakeOpenIdCredentials_75 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_74(
+  _FakeOpenIdCredentials_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,9 +855,9 @@ class _FakeOpenIdCredentials_74 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_75(
+  _FakeSearchUserDirectoryResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -853,9 +866,9 @@ class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_76 extends _i1.SmartFake
+class _FakeCreateContentResponse_77 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_76(
+  _FakeCreateContentResponse_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -864,8 +877,8 @@ class _FakeCreateContentResponse_76 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyManager_77 extends _i1.SmartFake implements _i11.KeyManager {
-  _FakeKeyManager_77(
+class _FakeKeyManager_78 extends _i1.SmartFake implements _i12.KeyManager {
+  _FakeKeyManager_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -874,8 +887,8 @@ class _FakeKeyManager_77 extends _i1.SmartFake implements _i11.KeyManager {
         );
 }
 
-class _FakeOlmManager_78 extends _i1.SmartFake implements _i16.OlmManager {
-  _FakeOlmManager_78(
+class _FakeOlmManager_79 extends _i1.SmartFake implements _i17.OlmManager {
+  _FakeOlmManager_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -884,9 +897,9 @@ class _FakeOlmManager_78 extends _i1.SmartFake implements _i16.OlmManager {
         );
 }
 
-class _FakeKeyVerificationManager_79 extends _i1.SmartFake
-    implements _i17.KeyVerificationManager {
-  _FakeKeyVerificationManager_79(
+class _FakeKeyVerificationManager_80 extends _i1.SmartFake
+    implements _i18.KeyVerificationManager {
+  _FakeKeyVerificationManager_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -895,8 +908,8 @@ class _FakeKeyVerificationManager_79 extends _i1.SmartFake
         );
 }
 
-class _FakeCrossSigning_80 extends _i1.SmartFake implements _i18.CrossSigning {
-  _FakeCrossSigning_80(
+class _FakeCrossSigning_81 extends _i1.SmartFake implements _i19.CrossSigning {
+  _FakeCrossSigning_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -905,8 +918,8 @@ class _FakeCrossSigning_80 extends _i1.SmartFake implements _i18.CrossSigning {
         );
 }
 
-class _FakeBootstrap_81 extends _i1.SmartFake implements _i11.Bootstrap {
-  _FakeBootstrap_81(
+class _FakeBootstrap_82 extends _i1.SmartFake implements _i12.Bootstrap {
+  _FakeBootstrap_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -915,8 +928,8 @@ class _FakeBootstrap_81 extends _i1.SmartFake implements _i11.Bootstrap {
         );
 }
 
-class _FakeToDeviceEvent_82 extends _i1.SmartFake implements _i4.ToDeviceEvent {
-  _FakeToDeviceEvent_82(
+class _FakeToDeviceEvent_83 extends _i1.SmartFake implements _i4.ToDeviceEvent {
+  _FakeToDeviceEvent_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -925,8 +938,8 @@ class _FakeToDeviceEvent_82 extends _i1.SmartFake implements _i4.ToDeviceEvent {
         );
 }
 
-class _FakeEvent_83 extends _i1.SmartFake implements _i4.Event {
-  _FakeEvent_83(
+class _FakeEvent_84 extends _i1.SmartFake implements _i4.Event {
+  _FakeEvent_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -938,7 +951,7 @@ class _FakeEvent_83 extends _i1.SmartFake implements _i4.Event {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -968,11 +981,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1045,43 +1058,56 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i7.SelectionService);
 
   @override
-  _i8.SyncService get sync => (super.noSuchMethod(
+  _i8.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_6(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_6(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i8.SpaceAccessService);
+
+  @override
+  _i9.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_6(
+        returnValue: _FakeSyncService_7(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_6(
+        returnValueForMissingStub: _FakeSyncService_7(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i8.SyncService);
+      ) as _i9.SyncService);
 
   @override
-  _i9.AuthService get auth => (super.noSuchMethod(
+  _i10.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_7(
+        returnValue: _FakeAuthService_8(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_7(
+        returnValueForMissingStub: _FakeAuthService_8(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i9.AuthService);
+      ) as _i10.AuthService);
 
   @override
-  _i10.OutboxService get outbox => (super.noSuchMethod(
+  _i11.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_8(
+        returnValue: _FakeOutboxService_9(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_8(
+        returnValueForMissingStub: _FakeOutboxService_9(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i10.OutboxService);
+      ) as _i11.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1145,7 +1171,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set sync(_i8.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i8.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i9.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -1154,7 +1189,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set auth(_i9.AuthService? value) => super.noSuchMethod(
+  set auth(_i10.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -1163,7 +1198,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set outbox(_i10.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i11.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -1179,14 +1214,14 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i15.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1216,7 +1251,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1226,18 +1261,18 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i15.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> login({
+  _i15.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1252,12 +1287,12 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> completeSsoLogin({
+  _i15.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1270,12 +1305,12 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> completeRegistration(
+  _i15.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1285,32 +1320,32 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i15.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1319,7 +1354,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1328,17 +1363,17 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i15.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1349,7 +1384,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1386,26 +1421,26 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i15.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> didPushRouteInformation(
-          _i23.RouteInformation? routeInformation) =>
+  _i15.Future<bool> didPushRouteInformation(
+          _i24.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1435,7 +1470,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1444,7 +1479,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1453,16 +1488,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i14.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i15.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i14.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+            _i15.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i14.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
-      ) as _i14.Future<_i21.AppExitResponse>);
+            _i15.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+      ) as _i15.Future<_i22.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1509,24 +1544,24 @@ class MockChatBackupService extends _i1.Mock implements _i6.ChatBackupService {
       ) as bool);
 
   @override
-  _i14.Future<void> checkChatBackupStatus() => (super.noSuchMethod(
+  _i15.Future<void> checkChatBackupStatus() => (super.noSuchMethod(
         Invocation.method(
           #checkChatBackupStatus,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> disableChatBackup() => (super.noSuchMethod(
+  _i15.Future<void> disableChatBackup() => (super.noSuchMethod(
         Invocation.method(
           #disableChatBackup,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void resetChatBackupState() => super.noSuchMethod(
@@ -1538,71 +1573,71 @@ class MockChatBackupService extends _i1.Mock implements _i6.ChatBackupService {
       );
 
   @override
-  _i14.Future<void> tryAutoUnlockBackup() => (super.noSuchMethod(
+  _i15.Future<void> tryAutoUnlockBackup() => (super.noSuchMethod(
         Invocation.method(
           #tryAutoUnlockBackup,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> runKeyRecovery({_i11.OpenSSSS? ssssKey}) =>
+  _i15.Future<void> runKeyRecovery({_i12.OpenSSSS? ssssKey}) =>
       (super.noSuchMethod(
         Invocation.method(
           #runKeyRecovery,
           [],
           {#ssssKey: ssssKey},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> requestMissingRoomKeys({bool? force = false}) =>
+  _i15.Future<void> requestMissingRoomKeys({bool? force = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #requestMissingRoomKeys,
           [],
           {#force: force},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> getStoredRecoveryKey() => (super.noSuchMethod(
+  _i15.Future<String?> getStoredRecoveryKey() => (super.noSuchMethod(
         Invocation.method(
           #getStoredRecoveryKey,
           [],
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> storeRecoveryKey(String? key) => (super.noSuchMethod(
+  _i15.Future<void> storeRecoveryKey(String? key) => (super.noSuchMethod(
         Invocation.method(
           #storeRecoveryKey,
           [key],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteStoredRecoveryKey() => (super.noSuchMethod(
+  _i15.Future<void> deleteStoredRecoveryKey() => (super.noSuchMethod(
         Invocation.method(
           #deleteStoredRecoveryKey,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1611,7 +1646,7 @@ class MockChatBackupService extends _i1.Mock implements _i6.ChatBackupService {
       );
 
   @override
-  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1641,19 +1676,19 @@ class MockChatBackupService extends _i1.Mock implements _i6.ChatBackupService {
 /// A class which mocks [Bootstrap].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBootstrap extends _i1.Mock implements _i11.Bootstrap {
+class MockBootstrap extends _i1.Mock implements _i12.Bootstrap {
   @override
-  _i11.Encryption get encryption => (super.noSuchMethod(
+  _i12.Encryption get encryption => (super.noSuchMethod(
         Invocation.getter(#encryption),
-        returnValue: _FakeEncryption_9(
+        returnValue: _FakeEncryption_10(
           this,
           Invocation.getter(#encryption),
         ),
-        returnValueForMissingStub: _FakeEncryption_9(
+        returnValueForMissingStub: _FakeEncryption_10(
           this,
           Invocation.getter(#encryption),
         ),
-      ) as _i11.Encryption);
+      ) as _i12.Encryption);
 
   @override
   _i4.Client get client => (super.noSuchMethod(
@@ -1669,14 +1704,14 @@ class MockBootstrap extends _i1.Mock implements _i11.Bootstrap {
       ) as _i4.Client);
 
   @override
-  _i11.BootstrapState get state => (super.noSuchMethod(
+  _i12.BootstrapState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i11.BootstrapState.loading,
-        returnValueForMissingStub: _i11.BootstrapState.loading,
-      ) as _i11.BootstrapState);
+        returnValue: _i12.BootstrapState.loading,
+        returnValueForMissingStub: _i12.BootstrapState.loading,
+      ) as _i12.BootstrapState);
 
   @override
-  set onUpdate(void Function(_i11.Bootstrap)? value) => super.noSuchMethod(
+  set onUpdate(void Function(_i12.Bootstrap)? value) => super.noSuchMethod(
         Invocation.setter(
           #onUpdate,
           value,
@@ -1685,7 +1720,7 @@ class MockBootstrap extends _i1.Mock implements _i11.Bootstrap {
       );
 
   @override
-  set oldSsssKeys(Map<String, _i11.OpenSSSS>? value) => super.noSuchMethod(
+  set oldSsssKeys(Map<String, _i12.OpenSSSS>? value) => super.noSuchMethod(
         Invocation.setter(
           #oldSsssKeys,
           value,
@@ -1694,7 +1729,7 @@ class MockBootstrap extends _i1.Mock implements _i11.Bootstrap {
       );
 
   @override
-  set newSsssKey(_i11.OpenSSSS? value) => super.noSuchMethod(
+  set newSsssKey(_i12.OpenSSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #newSsssKey,
           value,
@@ -1712,7 +1747,7 @@ class MockBootstrap extends _i1.Mock implements _i11.Bootstrap {
       );
 
   @override
-  set state(_i11.BootstrapState? newState) => super.noSuchMethod(
+  set state(_i12.BootstrapState? newState) => super.noSuchMethod(
         Invocation.setter(
           #state,
           newState,
@@ -1746,14 +1781,14 @@ class MockBootstrap extends _i1.Mock implements _i11.Bootstrap {
           #mostUsedKey,
           [secrets],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
             [secrets],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
@@ -1823,7 +1858,7 @@ class MockBootstrap extends _i1.Mock implements _i11.Bootstrap {
       );
 
   @override
-  _i14.Future<void> newSsss([
+  _i15.Future<void> newSsss([
     String? passphrase,
     String? name,
   ]) =>
@@ -1835,19 +1870,19 @@ class MockBootstrap extends _i1.Mock implements _i11.Bootstrap {
             name,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> openExistingSsss() => (super.noSuchMethod(
+  _i15.Future<void> openExistingSsss() => (super.noSuchMethod(
         Invocation.method(
           #openExistingSsss,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void checkCrossSigning() => super.noSuchMethod(
@@ -1859,17 +1894,17 @@ class MockBootstrap extends _i1.Mock implements _i11.Bootstrap {
       );
 
   @override
-  _i14.Future<void> wipeCrossSigning(bool? wipe) => (super.noSuchMethod(
+  _i15.Future<void> wipeCrossSigning(bool? wipe) => (super.noSuchMethod(
         Invocation.method(
           #wipeCrossSigning,
           [wipe],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> askSetupCrossSigning({
+  _i15.Future<void> askSetupCrossSigning({
     bool? setupMasterKey = false,
     bool? setupSelfSigningKey = false,
     bool? setupUserSigningKey = false,
@@ -1884,9 +1919,9 @@ class MockBootstrap extends _i1.Mock implements _i11.Bootstrap {
             #setupUserSigningKey: setupUserSigningKey,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void checkOnlineKeyBackup() => super.noSuchMethod(
@@ -1907,41 +1942,41 @@ class MockBootstrap extends _i1.Mock implements _i11.Bootstrap {
       );
 
   @override
-  _i14.Future<void> askSetupOnlineKeyBackup(bool? setup) => (super.noSuchMethod(
+  _i15.Future<void> askSetupOnlineKeyBackup(bool? setup) => (super.noSuchMethod(
         Invocation.method(
           #askSetupOnlineKeyBackup,
           [setup],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 }
 
 /// A class which mocks [OpenSSSS].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockOpenSSSS extends _i1.Mock implements _i11.OpenSSSS {
+class MockOpenSSSS extends _i1.Mock implements _i12.OpenSSSS {
   @override
-  _i11.SSSS get ssss => (super.noSuchMethod(
+  _i12.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_10(
+        returnValue: _FakeSSSS_11(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_10(
+        returnValueForMissingStub: _FakeSSSS_11(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i11.SSSS);
+      ) as _i12.SSSS);
 
   @override
   String get keyId => (super.noSuchMethod(
         Invocation.getter(#keyId),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#keyId),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#keyId),
         ),
@@ -1950,11 +1985,11 @@ class MockOpenSSSS extends _i1.Mock implements _i11.OpenSSSS {
   @override
   _i4.SecretStorageKeyContent get keyData => (super.noSuchMethod(
         Invocation.getter(#keyData),
-        returnValue: _FakeSecretStorageKeyContent_11(
+        returnValue: _FakeSecretStorageKeyContent_12(
           this,
           Invocation.getter(#keyData),
         ),
-        returnValueForMissingStub: _FakeSecretStorageKeyContent_11(
+        returnValueForMissingStub: _FakeSecretStorageKeyContent_12(
           this,
           Invocation.getter(#keyData),
         ),
@@ -1975,7 +2010,7 @@ class MockOpenSSSS extends _i1.Mock implements _i11.OpenSSSS {
       ) as bool);
 
   @override
-  set privateKey(_i24.Uint8List? value) => super.noSuchMethod(
+  set privateKey(_i25.Uint8List? value) => super.noSuchMethod(
         Invocation.setter(
           #privateKey,
           value,
@@ -1984,7 +2019,7 @@ class MockOpenSSSS extends _i1.Mock implements _i11.OpenSSSS {
       );
 
   @override
-  _i14.Future<void> unlock({
+  _i15.Future<void> unlock({
     String? passphrase,
     String? recoveryKey,
     String? keyOrPassphrase,
@@ -2001,27 +2036,27 @@ class MockOpenSSSS extends _i1.Mock implements _i11.OpenSSSS {
             #postUnlock: postUnlock,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setPrivateKey(_i24.Uint8List? key) => (super.noSuchMethod(
+  _i15.Future<void> setPrivateKey(_i25.Uint8List? key) => (super.noSuchMethod(
         Invocation.method(
           #setPrivateKey,
           [key],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> getStored(String? type) => (super.noSuchMethod(
+  _i15.Future<String> getStored(String? type) => (super.noSuchMethod(
         Invocation.method(
           #getStored,
           [type],
         ),
-        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #getStored,
@@ -2029,17 +2064,17 @@ class MockOpenSSSS extends _i1.Mock implements _i11.OpenSSSS {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i20.dummyValue<String>(
+            _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #getStored,
             [type],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> store(
+  _i15.Future<void> store(
     String? type,
     String? secret, {
     bool? add = false,
@@ -2053,12 +2088,12 @@ class MockOpenSSSS extends _i1.Mock implements _i11.OpenSSSS {
           ],
           {#add: add},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> validateAndStripOtherKeys(
+  _i15.Future<void> validateAndStripOtherKeys(
     String? type,
     String? secret,
   ) =>
@@ -2070,19 +2105,19 @@ class MockOpenSSSS extends _i1.Mock implements _i11.OpenSSSS {
             secret,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> maybeCacheAll() => (super.noSuchMethod(
+  _i15.Future<void> maybeCacheAll() => (super.noSuchMethod(
         Invocation.method(
           #maybeCacheAll,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 }
 
 /// A class which mocks [Client].
@@ -2092,23 +2127,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_12(
+        returnValue: _FakeDatabaseApi_13(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_12(
+        returnValueForMissingStub: _FakeDatabaseApi_13(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i11.KeyVerificationMethod> get verificationMethods =>
+  Set<_i12.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i11.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i11.KeyVerificationMethod>{},
-      ) as Set<_i11.KeyVerificationMethod>);
+        returnValue: <_i12.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i12.KeyVerificationMethod>{},
+      ) as Set<_i12.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -2169,11 +2204,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_13(
+        returnValue: _FakeFilter_14(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_13(
+        returnValueForMissingStub: _FakeFilter_14(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -2182,11 +2217,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_14(
+        returnValue: _FakeNativeImplementations_15(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_14(
+        returnValueForMissingStub: _FakeNativeImplementations_15(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -2202,11 +2237,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_15(
+        returnValue: _FakeDuration_16(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_15(
+        returnValueForMissingStub: _FakeDuration_16(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -2215,11 +2250,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_15(
+        returnValue: _FakeDuration_16(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_15(
+        returnValueForMissingStub: _FakeDuration_16(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -2228,11 +2263,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -2269,11 +2304,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -2303,11 +2338,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -2316,11 +2351,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -2343,11 +2378,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_16(
+        returnValue: _FakePushruleEvaluator_17(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_16(
+        returnValueForMissingStub: _FakePushruleEvaluator_17(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -2368,332 +2403,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i14.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i15.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_17(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_17(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i12.CachedStreamController<String> get onUserProfileUpdate =>
+  _i13.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_18<String>(
+        returnValue: _FakeCachedStreamController_19<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i14.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i15.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i14.Future<List<_i4.Room>>);
+            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i15.Future<List<_i4.Room>>);
 
   @override
-  _i12.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i13.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_18<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_19<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.EventUpdate>(
+            _FakeCachedStreamController_19<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.EventUpdate>);
+      ) as _i13.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i13.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_18<_i4.Event>(
+        returnValue: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i13.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_18<_i4.Event>(
+        returnValue: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onNotification =>
+  _i13.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_18<_i4.Event>(
+        returnValue: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i13.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_18<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_19<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_19<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i13.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i12.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i13.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_18<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_19<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_18<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_19<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i12.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i13.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i12.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i13.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_18<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_19<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.LoginState>(
+            _FakeCachedStreamController_19<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i12.CachedStreamController<_i4.LoginState>);
+      ) as _i13.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i12.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i13.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_18<bool>(
+        returnValue: _FakeCachedStreamController_19<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i12.CachedStreamController<bool>);
+      ) as _i13.CachedStreamController<bool>);
 
   @override
-  _i12.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i13.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_18<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_19<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i12.CachedStreamController<_i4.SdkError>);
+      ) as _i13.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i12.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i13.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_18<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_19<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.SyncUpdate>(
+            _FakeCachedStreamController_19<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i12.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i13.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i13.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_18<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_19<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_19<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i12.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i13.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.Presence> get onPresence =>
+  _i13.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_18<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_19<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i12.CachedStreamController<_i4.Presence>);
+      ) as _i13.CachedStreamController<_i4.Presence>);
 
   @override
-  _i12.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i13.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_18<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_19<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.CachedPresence>(
+            _FakeCachedStreamController_19<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i12.CachedStreamController<_i4.CachedPresence>);
+      ) as _i13.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i12.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i13.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_18<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_19<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.BasicEvent>(
+            _FakeCachedStreamController_19<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i12.CachedStreamController<_i4.BasicEvent>);
+      ) as _i13.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i12.CachedStreamController<_i11.RoomKeyRequest> get onRoomKeyRequest =>
+  _i13.CachedStreamController<_i12.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_18<_i11.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_19<_i12.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i11.RoomKeyRequest>(
+            _FakeCachedStreamController_19<_i12.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i12.CachedStreamController<_i11.RoomKeyRequest>);
+      ) as _i13.CachedStreamController<_i12.RoomKeyRequest>);
 
   @override
-  _i12.CachedStreamController<_i11.KeyVerification>
+  _i13.CachedStreamController<_i12.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_18<_i11.KeyVerification>(
+            returnValue: _FakeCachedStreamController_19<_i12.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_18<_i11.KeyVerification>(
+                _FakeCachedStreamController_19<_i12.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i12.CachedStreamController<_i11.KeyVerification>);
+          ) as _i13.CachedStreamController<_i12.KeyVerification>);
 
   @override
-  _i12.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i13.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_18<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_19<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_18<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_19<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i12.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i13.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i13.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_18<_i4.Event>(
+        returnValue: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<String> get onCancelSendEvent =>
+  _i13.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_18<String>(
+        returnValue: _FakeCachedStreamController_19<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_18<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_19<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i12.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i13.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_18<
+            returnValue: _FakeCachedStreamController_19<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_18<
+            returnValueForMissingStub: _FakeCachedStreamController_19<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i12.CachedStreamController<
+          ) as _i13.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -2713,11 +2748,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_19(
+        returnValue: _FakeDateTime_20(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_19(
+        returnValueForMissingStub: _FakeDateTime_20(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2790,7 +2825,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i11.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i12.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2845,7 +2880,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i14.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i15.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2856,7 +2891,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i14.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i15.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -2967,7 +3002,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -2976,7 +3011,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -2985,7 +3020,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -3012,20 +3047,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Client get httpClient => (super.noSuchMethod(
+  _i14.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_20(
+        returnValue: _FakeClient_21(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_20(
+        returnValueForMissingStub: _FakeClient_21(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i13.Client);
+      ) as _i14.Client);
 
   @override
-  set httpClient(_i13.Client? value) => super.noSuchMethod(
+  set httpClient(_i14.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -3052,7 +3087,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<void> refreshAccessToken(
+  _i15.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3060,9 +3095,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -3080,14 +3115,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -3124,33 +3159,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i14.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i15.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_21(
+        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_22(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_21(
+        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_22(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i14.Future<_i4.DiscoveryInformation>);
+      ) as _i15.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i14.Future<
+  _i15.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -3172,7 +3207,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i14.Future<
+        returnValue: _i15.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -3180,7 +3215,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_22(
+          _FakeGetVersionsResponse_23(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -3195,7 +3230,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i14.Future<
+        returnValueForMissingStub: _i15.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -3203,7 +3238,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_22(
+          _FakeGetVersionsResponse_23(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -3218,7 +3253,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i14.Future<
+      ) as _i15.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -3227,7 +3262,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i14.Future<_i4.DiscoveryInformation> getWellknown({
+  _i15.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3240,8 +3275,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_21(
+        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_22(
           this,
           Invocation.method(
             #getWellknown,
@@ -3252,8 +3287,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_21(
+        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_22(
           this,
           Invocation.method(
             #getWellknown,
@@ -3264,10 +3299,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.DiscoveryInformation>);
+      ) as _i15.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i14.Future<_i4.RegisterResponse> register({
+  _i15.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -3295,7 +3330,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_23(
+            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_24(
           this,
           Invocation.method(
             #register,
@@ -3314,7 +3349,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_23(
+            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_24(
           this,
           Invocation.method(
             #register,
@@ -3332,10 +3367,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RegisterResponse>);
+      ) as _i15.Future<_i4.RegisterResponse>);
 
   @override
-  _i14.Future<_i4.LoginResponse> login(
+  _i15.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -3365,7 +3400,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_24(
+        returnValue: _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_25(
           this,
           Invocation.method(
             #login,
@@ -3385,7 +3420,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_24(
+            _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_25(
           this,
           Invocation.method(
             #login,
@@ -3404,10 +3439,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.LoginResponse>);
+      ) as _i15.Future<_i4.LoginResponse>);
 
   @override
-  _i14.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i15.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3420,8 +3455,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_25(
+        returnValue: _i15.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_26(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -3433,8 +3468,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_25(
+            _i15.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_26(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -3445,74 +3480,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i15.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logoutAll() => (super.noSuchMethod(
+  _i15.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<T> uiaRequestBackground<T>(
-          _i14.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i15.Future<T> uiaRequestBackground<T>(
+          _i15.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValue: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i14.Future<T>.value(v),
+              (T v) => _i15.Future<T>.value(v),
             ) ??
-            _FakeFuture_26<T>(
+            _FakeFuture_27<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i14.Future<T>.value(v),
+              (T v) => _i15.Future<T>.value(v),
             ) ??
-            _FakeFuture_26<T>(
+            _FakeFuture_27<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i14.Future<T>);
+      ) as _i15.Future<T>);
 
   @override
-  _i14.Future<String> startDirectChat(
+  _i15.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -3534,7 +3569,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3550,7 +3585,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i20.dummyValue<String>(
+            _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3565,10 +3600,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> createGroupChat({
+  _i15.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -3599,7 +3634,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3620,7 +3655,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i20.dummyValue<String>(
+            _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3640,10 +3675,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i15.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -3659,7 +3694,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3672,7 +3707,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3684,21 +3719,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i15.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<String> createSpace({
+  _i15.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -3723,7 +3758,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3741,7 +3776,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i20.dummyValue<String>(
+            _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3758,10 +3793,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i15.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3769,7 +3804,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_17(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3778,7 +3813,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_17(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3786,10 +3821,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i14.Future<_i4.Profile> fetchOwnProfile({
+  _i15.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3802,7 +3837,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_17(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3814,7 +3849,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_17(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3825,10 +3860,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i14.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i15.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3842,8 +3877,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i14.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_28(
+        returnValue: _i15.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_29(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3855,8 +3890,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_28(
+            _i15.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_29(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3867,10 +3902,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.CachedProfileInformation>);
+      ) as _i15.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i14.Future<_i4.Profile> getProfileFromUserId(
+  _i15.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3888,7 +3923,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_17(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3902,7 +3937,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_17(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_18(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3915,7 +3950,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -3937,31 +3972,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i14.Future<List<_i4.Room>>);
+            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i15.Future<List<_i4.Room>>);
 
   @override
-  _i14.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i15.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i14.Future<List<_i4.ArchivedRoom>>);
+            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i15.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i14.Future<_i4.GetVersionsResponse> getVersions({
+  _i15.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3974,8 +4009,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_22(
+        returnValue: _i15.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_23(
           this,
           Invocation.method(
             #getVersions,
@@ -3986,8 +4021,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_22(
+        returnValueForMissingStub: _i15.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_23(
           this,
           Invocation.method(
             #getVersions,
@@ -3998,20 +4033,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetVersionsResponse>);
+      ) as _i15.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i14.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i15.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.MediaConfig> getConfig({
+  _i15.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4024,7 +4059,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
+        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfig,
@@ -4036,7 +4071,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
+            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfig,
@@ -4047,10 +4082,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.MediaConfig>);
+      ) as _i15.Future<_i4.MediaConfig>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContent(
+  _i15.Future<_i16.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -4070,7 +4105,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContent,
@@ -4086,7 +4121,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContent,
@@ -4101,10 +4136,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentOverrideName(
+  _i15.Future<_i16.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4126,7 +4161,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -4143,7 +4178,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -4159,10 +4194,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentThumbnail(
+  _i15.Future<_i16.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -4190,7 +4225,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -4210,7 +4245,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -4229,10 +4264,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i15.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -4242,7 +4277,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
+        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -4251,7 +4286,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
+            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -4259,11 +4294,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i14.Future<_i4.PreviewForUrl>);
+      ) as _i15.Future<_i4.PreviewForUrl>);
 
   @override
-  _i14.Future<Uri> uploadContent(
-    _i24.Uint8List? file, {
+  _i15.Future<Uri> uploadContent(
+    _i25.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -4276,7 +4311,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i14.Future<Uri>.value(_FakeUri_32(
+        returnValue: _i15.Future<Uri>.value(_FakeUri_33(
           this,
           Invocation.method(
             #uploadContent,
@@ -4287,7 +4322,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_32(
+        returnValueForMissingStub: _i15.Future<Uri>.value(_FakeUri_33(
           this,
           Invocation.method(
             #uploadContent,
@@ -4298,10 +4333,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<Uri>);
+      ) as _i15.Future<Uri>);
 
   @override
-  _i14.Future<void> setTyping(
+  _i15.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -4317,42 +4352,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> exportDump() => (super.noSuchMethod(
+  _i15.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i15.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i15.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Event?> getEventByPushNotification(
+  _i15.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -4368,12 +4403,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
-  _i14.Future<void> init({
+  _i15.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -4408,9 +4443,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -4422,40 +4457,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<void> clear() => (super.noSuchMethod(
+  _i15.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i15.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ensureNotSoftLoggedOut(
+  _i15.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSync(
+  _i15.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -4465,9 +4500,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -4480,29 +4515,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i14.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i15.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i15.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDevice(
+  _i15.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -4516,12 +4551,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDevicesOfUserIds(
+  _i15.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4537,12 +4572,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDeviceEncrypted(
+  _i15.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4562,12 +4597,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDeviceEncryptedChunked(
+  _i15.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -4581,23 +4616,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i15.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> joinRoom(
+  _i15.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -4615,7 +4650,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4629,7 +4664,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i20.dummyValue<String>(
+            _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4642,10 +4677,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> changePassword(
+  _i15.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -4661,22 +4696,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> clearCache() => (super.noSuchMethod(
+  _i15.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ignoreUser(
+  _i15.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4686,22 +4721,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i15.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i15.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4712,7 +4747,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4721,7 +4756,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4729,32 +4764,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i14.Future<_i4.CachedPresence>);
+      ) as _i15.Future<_i4.CachedPresence>);
 
   @override
-  _i14.Future<void> abortSync() => (super.noSuchMethod(
+  _i15.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i15.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEventWithMetadata(
+  _i15.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4774,14 +4809,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i13.BaseResponse? response,
-    _i24.Uint8List? body,
+    _i14.BaseResponse? response,
+    _i25.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4813,7 +4848,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i14.Future<Map<String, Object?>> request(
+  _i15.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -4834,13 +4869,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> postPusher(
+  _i15.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -4850,57 +4885,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i15.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i15.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i15.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i14.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_34(
+        returnValue: _i15.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_35(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_34(
+        returnValueForMissingStub: _i15.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_35(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.TurnServerCredentials>);
+      ) as _i15.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4914,8 +4949,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4927,8 +4962,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4939,10 +4974,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4958,8 +4993,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4972,8 +5007,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4985,10 +5020,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i15.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5002,7 +5037,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -5014,7 +5049,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -5025,17 +5060,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.KeyBackupData>);
+      ) as _i15.Future<_i4.KeyBackupData>);
 
   @override
-  _i14.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i15.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i14.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_37(
+        returnValue: _i15.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_38(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -5043,18 +5078,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_37(
+            _i15.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_38(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i15.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i14.Future<int> pingAppservice(
+  _i15.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -5064,12 +5099,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i14.Future<int>.value(0),
-        returnValueForMissingStub: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+        returnValueForMissingStub: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
-  _i14.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i15.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5077,8 +5112,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_38(
+        returnValue: _i15.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_39(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -5087,8 +5122,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_38(
+            _i15.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_39(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -5096,15 +5131,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i14.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i15.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i14.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i15.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
+        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -5112,17 +5147,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
+            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.MediaConfig>);
+      ) as _i15.Future<_i4.MediaConfig>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentAuthed(
+  _i15.Future<_i16.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -5136,7 +5171,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -5148,7 +5183,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -5159,10 +5194,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentOverrideNameAuthed(
+  _i15.Future<_i16.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5178,7 +5213,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -5191,7 +5226,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -5203,10 +5238,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i15.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -5216,7 +5251,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
+        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -5225,7 +5260,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
+            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -5233,10 +5268,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i14.Future<_i4.PreviewForUrl>);
+      ) as _i15.Future<_i4.PreviewForUrl>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentThumbnailAuthed(
+  _i15.Future<_i16.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5260,7 +5295,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -5278,7 +5313,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_30(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -5295,21 +5330,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<bool> registrationTokenValidity(String? token) =>
+  _i15.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i15.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -5319,8 +5354,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_39(
+        returnValue: _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_40(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -5329,8 +5364,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_39(
+            _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_40(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -5338,10 +5373,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i15.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i14.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i15.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -5359,8 +5394,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_40(
+        returnValue: _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_41(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -5374,8 +5409,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_40(
+            _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_41(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -5388,10 +5423,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i15.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i15.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -5415,8 +5450,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i14.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_41(
+        returnValue: _i15.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_42(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -5434,8 +5469,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_41(
+            _i15.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_42(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -5452,10 +5487,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i15.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -5483,8 +5518,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_42(
+                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5503,8 +5538,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_42(
+                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5522,10 +5557,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i15.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -5554,9 +5589,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i14.Future<
+            returnValue: _i15.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5575,9 +5610,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i14.Future<
+            returnValueForMissingStub: _i15.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5596,11 +5631,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i14
+          ) as _i15
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i14.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i15.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -5616,8 +5651,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i14.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_44(
+        returnValue: _i15.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_45(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5630,8 +5665,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_44(
+            _i15.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_45(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5643,10 +5678,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetThreadRootsResponse>);
+      ) as _i15.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i14.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i15.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -5660,8 +5695,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i14.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_45(
+        returnValue: _i15.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_46(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5673,8 +5708,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_45(
+            _i15.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_46(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5685,33 +5720,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i15.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i15.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i14.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i15.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i14.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i15.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i14.Future<Uri?>.value(),
-        returnValueForMissingStub: _i14.Future<Uri?>.value(),
-      ) as _i14.Future<Uri?>);
+        returnValue: _i15.Future<Uri?>.value(),
+        returnValueForMissingStub: _i15.Future<Uri?>.value(),
+      ) as _i15.Future<Uri?>);
 
   @override
-  _i14.Future<void> add3PID(
+  _i15.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -5725,12 +5760,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> bind3PID(
+  _i15.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5746,12 +5781,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i15.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5765,14 +5800,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5794,8 +5829,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5811,8 +5846,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5828,10 +5863,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5855,8 +5890,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5873,8 +5908,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5891,10 +5926,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i15.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5908,14 +5943,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i15.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -5930,14 +5965,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5959,8 +5994,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5976,8 +6011,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5993,10 +6028,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6020,8 +6055,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -6038,8 +6073,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -6056,16 +6091,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i15.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
+            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -6073,22 +6108,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
+            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.TokenOwnerInfo>);
+      ) as _i15.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i14.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i15.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
+        returnValue: _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
           this,
           Invocation.method(
             #getWhoIs,
@@ -6096,22 +6131,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
+            _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i14.Future<_i4.WhoIsInfo>);
+      ) as _i15.Future<_i4.WhoIsInfo>);
 
   @override
-  _i14.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i15.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
+        returnValue: _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
           this,
           Invocation.method(
             #getCapabilities,
@@ -6119,17 +6154,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
+            _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.Capabilities>);
+      ) as _i15.Future<_i4.Capabilities>);
 
   @override
-  _i14.Future<String> createRoom({
+  _i15.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -6162,7 +6197,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -6184,7 +6219,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i20.dummyValue<String>(
+            _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -6205,10 +6240,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> deleteDevices(
+  _i15.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -6218,22 +6253,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.Device>?>.value(),
-      ) as _i14.Future<List<_i4.Device>?>);
+        returnValue: _i15.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.Device>?>.value(),
+      ) as _i15.Future<List<_i4.Device>?>);
 
   @override
-  _i14.Future<void> deleteDevice(
+  _i15.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -6243,34 +6278,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i15.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i14.Future<_i4.Device>.value(_FakeDevice_50(
+        returnValue: _i15.Future<_i4.Device>.value(_FakeDevice_51(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Device>.value(_FakeDevice_50(
+        returnValueForMissingStub: _i15.Future<_i4.Device>.value(_FakeDevice_51(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i14.Future<_i4.Device>);
+      ) as _i15.Future<_i4.Device>);
 
   @override
-  _i14.Future<void> updateDevice(
+  _i15.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -6280,12 +6315,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i15.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -6300,24 +6335,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i15.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i14.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Visibility?>.value(),
-      ) as _i14.Future<_i4.Visibility?>);
+        returnValue: _i15.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Visibility?>.value(),
+      ) as _i15.Future<_i4.Visibility?>);
 
   @override
-  _i14.Future<void> setRoomVisibilityOnDirectory(
+  _i15.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -6327,30 +6362,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i15.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i15.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_51(
+        returnValue: _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_52(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -6358,18 +6393,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_51(
+            _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_52(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i15.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i14.Future<void> setRoomAlias(
+  _i15.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -6381,12 +6416,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetEventsResponse> getEvents({
+  _i15.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -6400,7 +6435,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
+            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
           this,
           Invocation.method(
             #getEvents,
@@ -6412,7 +6447,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
+            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
           this,
           Invocation.method(
             #getEvents,
@@ -6423,10 +6458,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetEventsResponse>);
+      ) as _i15.Future<_i4.GetEventsResponse>);
 
   @override
-  _i14.Future<_i4.PeekEventsResponse> peekEvents({
+  _i15.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -6441,8 +6476,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i14.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_53(
+        returnValue: _i15.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_54(
           this,
           Invocation.method(
             #peekEvents,
@@ -6454,8 +6489,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_53(
+        returnValueForMissingStub: _i15.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_54(
           this,
           Invocation.method(
             #peekEvents,
@@ -6467,16 +6502,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.PeekEventsResponse>);
+      ) as _i15.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i14.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i15.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneEvent,
@@ -6484,27 +6519,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i14.Future<_i4.MatrixEvent>);
+      ) as _i15.Future<_i4.MatrixEvent>);
 
   @override
-  _i14.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i15.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 
   @override
-  _i14.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i15.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -6516,8 +6551,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i14.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_55(
+        returnValue: _i15.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_56(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6528,8 +6563,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_55(
+            _i15.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_56(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6539,10 +6574,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.GetKeysChangesResponse>);
+      ) as _i15.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i14.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i15.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -6553,7 +6588,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
+            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
           this,
           Invocation.method(
             #claimKeys,
@@ -6562,7 +6597,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
+            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
           this,
           Invocation.method(
             #claimKeys,
@@ -6570,10 +6605,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i14.Future<_i4.ClaimKeysResponse>);
+      ) as _i15.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i14.Future<void> uploadCrossSigningKeys({
+  _i15.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -6590,12 +6625,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.QueryKeysResponse> queryKeys(
+  _i15.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -6606,7 +6641,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
+            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
           this,
           Invocation.method(
             #queryKeys,
@@ -6615,7 +6650,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
+            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
           this,
           Invocation.method(
             #queryKeys,
@@ -6623,10 +6658,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i14.Future<_i4.QueryKeysResponse>);
+      ) as _i15.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -6634,14 +6669,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i14.Future<
+            returnValue: _i15.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i14.Future<
+            returnValueForMissingStub: _i15.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i14.Future<Map<String, int>> uploadKeys({
+  _i15.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -6656,13 +6691,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i14.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i15.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i14.Future<Map<String, int>>);
+            _i15.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i15.Future<Map<String, int>>);
 
   @override
-  _i14.Future<String> knockRoom(
+  _i15.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -6676,7 +6711,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6688,7 +6723,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i20.dummyValue<String>(
+            _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6699,20 +6734,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i15.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i14.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i15.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i15.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i14.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i15.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6727,8 +6762,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i14.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_58(
+        returnValue: _i15.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_59(
           this,
           Invocation.method(
             #getNotifications,
@@ -6741,8 +6776,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_58(
+            _i15.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_59(
           this,
           Invocation.method(
             #getNotifications,
@@ -6754,35 +6789,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetNotificationsResponse>);
+      ) as _i15.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i14.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i15.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i14.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_59(
+        returnValue: _i15.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_60(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_59(
+        returnValueForMissingStub: _i15.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_60(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i14.Future<_i4.GetPresenceResponse>);
+      ) as _i15.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i14.Future<void> setPresence(
+  _i15.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -6796,12 +6831,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, Object?>> deleteProfileField(
+  _i15.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6814,13 +6849,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getProfileField(
+  _i15.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6833,13 +6868,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<Map<String, Object?>> setProfileField(
+  _i15.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6854,13 +6889,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i15.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6875,8 +6910,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i14.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_60(
+        returnValue: _i15.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_61(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6889,8 +6924,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_60(
+            _i15.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_61(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6902,10 +6937,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i15.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i14.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i15.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -6926,8 +6961,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i14.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_61(
+        returnValue: _i15.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_62(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6943,8 +6978,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_61(
+            _i15.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_62(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6959,25 +6994,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i15.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i14.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.Pusher>?>.value(),
-      ) as _i14.Future<List<_i4.Pusher>?>);
+        returnValue: _i15.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.Pusher>?>.value(),
+      ) as _i15.Future<List<_i4.Pusher>?>);
 
   @override
-  _i14.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i15.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
+        returnValue: _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
           this,
           Invocation.method(
             #getPushRules,
@@ -6985,24 +7020,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
+            _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.PushRuleSet>);
+      ) as _i15.Future<_i4.PushRuleSet>);
 
   @override
-  _i14.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i15.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_63(
+        returnValue: _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_64(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -7010,18 +7045,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_63(
+            _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_64(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i15.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i14.Future<void> deletePushRule(
+  _i15.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -7033,12 +7068,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.PushRule> getPushRule(
+  _i15.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -7050,7 +7085,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<_i4.PushRule>.value(_FakePushRule_64(
+        returnValue: _i15.Future<_i4.PushRule>.value(_FakePushRule_65(
           this,
           Invocation.method(
             #getPushRule,
@@ -7061,7 +7096,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PushRule>.value(_FakePushRule_64(
+            _i15.Future<_i4.PushRule>.value(_FakePushRule_65(
           this,
           Invocation.method(
             #getPushRule,
@@ -7071,10 +7106,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.PushRule>);
+      ) as _i15.Future<_i4.PushRule>);
 
   @override
-  _i14.Future<void> setPushRule(
+  _i15.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -7098,12 +7133,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<Object?>> getPushRuleActions(
+  _i15.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -7115,13 +7150,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i15.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i14.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i14.Future<List<Object?>>);
+            _i15.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i15.Future<List<Object?>>);
 
   @override
-  _i14.Future<void> setPushRuleActions(
+  _i15.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -7135,12 +7170,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> isPushRuleEnabled(
+  _i15.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -7152,12 +7187,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> setPushRuleEnabled(
+  _i15.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -7171,19 +7206,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i15.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
+            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
           this,
           Invocation.method(
             #refresh,
@@ -7191,28 +7226,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
+            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i14.Future<_i4.RefreshResponse>);
+      ) as _i15.Future<_i4.RefreshResponse>);
 
   @override
-  _i14.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i15.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i14.Future<bool?>.value(),
-        returnValueForMissingStub: _i14.Future<bool?>.value(),
-      ) as _i14.Future<bool?>);
+        returnValue: _i15.Future<bool?>.value(),
+        returnValueForMissingStub: _i15.Future<bool?>.value(),
+      ) as _i15.Future<bool?>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7234,8 +7269,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -7251,8 +7286,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -7268,10 +7303,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7295,8 +7330,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -7313,8 +7348,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_46(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_47(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -7331,17 +7366,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -7349,23 +7384,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i15.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
+        returnValue: _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -7373,17 +7408,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
+            _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeys>);
+      ) as _i15.Future<_i4.RoomKeys>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -7395,8 +7430,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -7407,8 +7442,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -7418,10 +7453,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -7433,8 +7468,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -7445,8 +7480,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -7456,10 +7491,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -7471,7 +7506,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
+        returnValue: _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -7482,7 +7517,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
+            _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -7492,10 +7527,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeyBackup>);
+      ) as _i15.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -7509,8 +7544,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7522,8 +7557,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7534,10 +7569,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7551,8 +7586,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7564,8 +7599,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7576,10 +7611,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i15.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7593,7 +7628,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7605,7 +7640,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
+            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7616,10 +7651,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.KeyBackupData>);
+      ) as _i15.Future<_i4.KeyBackupData>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7635,8 +7670,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_35(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7649,8 +7684,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_35(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_36(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7662,18 +7697,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_68(
+                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_69(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -7681,18 +7716,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_68(
+                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_69(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i14.Future<String> postRoomKeysVersion(
+  _i15.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -7704,7 +7739,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7715,7 +7750,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i20.dummyValue<String>(
+            _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7725,29 +7760,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i15.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i15.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_69(
+        returnValue: _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_70(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7755,18 +7790,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_69(
+            _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_70(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i15.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i15.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -7781,24 +7816,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i15.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 
   @override
-  _i14.Future<void> ban(
+  _i15.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7812,12 +7847,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.EventContext> getEventContext(
+  _i15.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7835,7 +7870,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i4.EventContext>.value(_FakeEventContext_70(
+        returnValue: _i15.Future<_i4.EventContext>.value(_FakeEventContext_71(
           this,
           Invocation.method(
             #getEventContext,
@@ -7850,7 +7885,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.EventContext>.value(_FakeEventContext_70(
+            _i15.Future<_i4.EventContext>.value(_FakeEventContext_71(
           this,
           Invocation.method(
             #getEventContext,
@@ -7864,10 +7899,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.EventContext>);
+      ) as _i15.Future<_i4.EventContext>);
 
   @override
-  _i14.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i15.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7879,7 +7914,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7890,7 +7925,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
+            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7900,20 +7935,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.MatrixEvent>);
+      ) as _i15.Future<_i4.MatrixEvent>);
 
   @override
-  _i14.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> inviteBy3PID(
+  _i15.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -7925,12 +7960,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> inviteUser(
+  _i15.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7944,12 +7979,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> joinRoomById(
+  _i15.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -7963,7 +7998,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7975,7 +8010,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i20.dummyValue<String>(
+            _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7986,23 +8021,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i15.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i15.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i14.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i14.Future<Map<String, _i4.RoomMember>?>);
+            _i15.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i15.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i14.Future<void> kick(
+  _i15.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8016,12 +8051,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> leaveRoom(
+  _i15.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -8031,12 +8066,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i15.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -8052,12 +8087,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i14.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i14.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i15.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i15.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i14.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i15.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -8079,8 +8114,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_71(
+        returnValue: _i15.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_72(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -8096,8 +8131,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_71(
+        returnValueForMissingStub: _i15.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_72(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -8113,10 +8148,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomEventsResponse>);
+      ) as _i15.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i14.Future<void> setReadMarker(
+  _i15.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -8132,12 +8167,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> postReceipt(
+  _i15.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -8153,12 +8188,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEvent(
+  _i15.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -8174,12 +8209,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> reportRoom(
+  _i15.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -8191,12 +8226,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> reportEvent(
+  _i15.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -8214,12 +8249,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> sendMessage(
+  _i15.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -8235,7 +8270,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -8248,7 +8283,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i20.dummyValue<String>(
+            _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -8260,23 +8295,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i15.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i14.Future<List<_i4.MatrixEvent>>);
+            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i15.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i15.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -8293,13 +8328,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<String> setRoomStateWithKey(
+  _i15.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -8315,7 +8350,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -8328,7 +8363,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i20.dummyValue<String>(
+            _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -8340,10 +8375,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> unban(
+  _i15.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8357,12 +8392,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> upgradeRoom(
+  _i15.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -8376,7 +8411,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -8388,7 +8423,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i20.dummyValue<String>(
+            _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -8399,10 +8434,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.SearchResults> search(
+  _i15.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -8412,7 +8447,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
+        returnValue: _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
           this,
           Invocation.method(
             #search,
@@ -8421,7 +8456,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
+            _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
           this,
           Invocation.method(
             #search,
@@ -8429,10 +8464,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i14.Future<_i4.SearchResults>);
+      ) as _i15.Future<_i4.SearchResults>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> sync({
+  _i15.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -8453,7 +8488,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
           this,
           Invocation.method(
             #sync,
@@ -8469,7 +8504,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
           this,
           Invocation.method(
             #sync,
@@ -8484,22 +8519,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i15.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i14.Future<List<_i4.Location>>);
+            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i15.Future<List<_i4.Location>>);
 
   @override
-  _i14.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i15.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8509,21 +8544,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i14.Future<List<_i4.Location>>);
+            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i15.Future<List<_i4.Location>>);
 
   @override
-  _i14.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i15.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_73(
+        returnValue: _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_74(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -8531,45 +8566,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_73(
+            _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_74(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i14.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i15.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i14.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i15.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8580,13 +8615,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getAccountData(
+  _i15.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -8599,13 +8634,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> setAccountData(
+  _i15.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -8619,12 +8654,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> defineFilter(
+  _i15.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -8636,7 +8671,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8647,7 +8682,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i20.dummyValue<String>(
+            _i15.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8657,10 +8692,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.Filter> getFilter(
+  _i15.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -8672,7 +8707,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i14.Future<_i4.Filter>.value(_FakeFilter_13(
+        returnValue: _i15.Future<_i4.Filter>.value(_FakeFilter_14(
           this,
           Invocation.method(
             #getFilter,
@@ -8682,7 +8717,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Filter>.value(_FakeFilter_13(
+        returnValueForMissingStub: _i15.Future<_i4.Filter>.value(_FakeFilter_14(
           this,
           Invocation.method(
             #getFilter,
@@ -8692,10 +8727,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.Filter>);
+      ) as _i15.Future<_i4.Filter>);
 
   @override
-  _i14.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i15.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8708,7 +8743,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
+            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8719,7 +8754,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
+            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8729,10 +8764,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.OpenIdCredentials>);
+      ) as _i15.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i14.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i15.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8747,13 +8782,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> setAccountDataPerRoom(
+  _i15.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8769,12 +8804,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i15.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8786,12 +8821,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i14.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i14.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i14.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i15.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i15.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i15.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i14.Future<void> deleteRoomTag(
+  _i15.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8805,12 +8840,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setRoomTag(
+  _i15.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8826,12 +8861,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i15.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8841,8 +8876,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i14.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_75(
+        returnValue: _i15.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_76(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8851,8 +8886,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_75(
+            _i15.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_76(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8860,10 +8895,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i14.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i15.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> reportUser(
+  _i15.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8876,40 +8911,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i15.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i14.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_76(
+        returnValue: _i15.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_77(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_76(
+        returnValueForMissingStub: _i15.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_77(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.CreateContentResponse>);
+      ) as _i15.Future<_i4.CreateContentResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> uploadContentToMXC(
+  _i15.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i24.Uint8List? body, {
+    _i25.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8927,16 +8962,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [Encryption].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEncryption extends _i1.Mock implements _i11.Encryption {
+class MockEncryption extends _i1.Mock implements _i12.Encryption {
   @override
   _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -8965,85 +9000,85 @@ class MockEncryption extends _i1.Mock implements _i11.Encryption {
       ) as bool);
 
   @override
-  _i11.KeyManager get keyManager => (super.noSuchMethod(
+  _i12.KeyManager get keyManager => (super.noSuchMethod(
         Invocation.getter(#keyManager),
-        returnValue: _FakeKeyManager_77(
+        returnValue: _FakeKeyManager_78(
           this,
           Invocation.getter(#keyManager),
         ),
-        returnValueForMissingStub: _FakeKeyManager_77(
+        returnValueForMissingStub: _FakeKeyManager_78(
           this,
           Invocation.getter(#keyManager),
         ),
-      ) as _i11.KeyManager);
+      ) as _i12.KeyManager);
 
   @override
-  _i16.OlmManager get olmManager => (super.noSuchMethod(
+  _i17.OlmManager get olmManager => (super.noSuchMethod(
         Invocation.getter(#olmManager),
-        returnValue: _FakeOlmManager_78(
+        returnValue: _FakeOlmManager_79(
           this,
           Invocation.getter(#olmManager),
         ),
-        returnValueForMissingStub: _FakeOlmManager_78(
+        returnValueForMissingStub: _FakeOlmManager_79(
           this,
           Invocation.getter(#olmManager),
         ),
-      ) as _i16.OlmManager);
+      ) as _i17.OlmManager);
 
   @override
-  _i17.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
+  _i18.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
         Invocation.getter(#keyVerificationManager),
-        returnValue: _FakeKeyVerificationManager_79(
+        returnValue: _FakeKeyVerificationManager_80(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-        returnValueForMissingStub: _FakeKeyVerificationManager_79(
+        returnValueForMissingStub: _FakeKeyVerificationManager_80(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-      ) as _i17.KeyVerificationManager);
+      ) as _i18.KeyVerificationManager);
 
   @override
-  _i18.CrossSigning get crossSigning => (super.noSuchMethod(
+  _i19.CrossSigning get crossSigning => (super.noSuchMethod(
         Invocation.getter(#crossSigning),
-        returnValue: _FakeCrossSigning_80(
+        returnValue: _FakeCrossSigning_81(
           this,
           Invocation.getter(#crossSigning),
         ),
-        returnValueForMissingStub: _FakeCrossSigning_80(
+        returnValueForMissingStub: _FakeCrossSigning_81(
           this,
           Invocation.getter(#crossSigning),
         ),
-      ) as _i18.CrossSigning);
+      ) as _i19.CrossSigning);
 
   @override
-  _i11.SSSS get ssss => (super.noSuchMethod(
+  _i12.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_10(
+        returnValue: _FakeSSSS_11(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_10(
+        returnValueForMissingStub: _FakeSSSS_11(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i11.SSSS);
+      ) as _i12.SSSS);
 
   @override
   String get ourDeviceId => (super.noSuchMethod(
         Invocation.getter(#ourDeviceId),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
       ) as String);
 
   @override
-  set keyManager(_i11.KeyManager? value) => super.noSuchMethod(
+  set keyManager(_i12.KeyManager? value) => super.noSuchMethod(
         Invocation.setter(
           #keyManager,
           value,
@@ -9052,7 +9087,7 @@ class MockEncryption extends _i1.Mock implements _i11.Encryption {
       );
 
   @override
-  set olmManager(_i16.OlmManager? value) => super.noSuchMethod(
+  set olmManager(_i17.OlmManager? value) => super.noSuchMethod(
         Invocation.setter(
           #olmManager,
           value,
@@ -9061,7 +9096,7 @@ class MockEncryption extends _i1.Mock implements _i11.Encryption {
       );
 
   @override
-  set keyVerificationManager(_i17.KeyVerificationManager? value) =>
+  set keyVerificationManager(_i18.KeyVerificationManager? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #keyVerificationManager,
@@ -9071,7 +9106,7 @@ class MockEncryption extends _i1.Mock implements _i11.Encryption {
       );
 
   @override
-  set crossSigning(_i18.CrossSigning? value) => super.noSuchMethod(
+  set crossSigning(_i19.CrossSigning? value) => super.noSuchMethod(
         Invocation.setter(
           #crossSigning,
           value,
@@ -9080,7 +9115,7 @@ class MockEncryption extends _i1.Mock implements _i11.Encryption {
       );
 
   @override
-  set ssss(_i11.SSSS? value) => super.noSuchMethod(
+  set ssss(_i12.SSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #ssss,
           value,
@@ -9098,7 +9133,7 @@ class MockEncryption extends _i1.Mock implements _i11.Encryption {
       );
 
   @override
-  _i14.Future<void> init(
+  _i15.Future<void> init(
     String? olmAccount, {
     String? deviceId,
     String? pickleKey,
@@ -9114,19 +9149,19 @@ class MockEncryption extends _i1.Mock implements _i11.Encryption {
             #dehydratedDeviceAlgorithm: dehydratedDeviceAlgorithm,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i11.Bootstrap bootstrap({void Function(_i11.Bootstrap)? onUpdate}) =>
+  _i12.Bootstrap bootstrap({void Function(_i12.Bootstrap)? onUpdate}) =>
       (super.noSuchMethod(
         Invocation.method(
           #bootstrap,
           [],
           {#onUpdate: onUpdate},
         ),
-        returnValue: _FakeBootstrap_81(
+        returnValue: _FakeBootstrap_82(
           this,
           Invocation.method(
             #bootstrap,
@@ -9134,7 +9169,7 @@ class MockEncryption extends _i1.Mock implements _i11.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-        returnValueForMissingStub: _FakeBootstrap_81(
+        returnValueForMissingStub: _FakeBootstrap_82(
           this,
           Invocation.method(
             #bootstrap,
@@ -9142,7 +9177,7 @@ class MockEncryption extends _i1.Mock implements _i11.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-      ) as _i11.Bootstrap);
+      ) as _i12.Bootstrap);
 
   @override
   void handleDeviceOneTimeKeysCount(
@@ -9170,18 +9205,18 @@ class MockEncryption extends _i1.Mock implements _i11.Encryption {
       );
 
   @override
-  _i14.Future<void> handleToDeviceEvent(_i4.ToDeviceEvent? event) =>
+  _i15.Future<void> handleToDeviceEvent(_i4.ToDeviceEvent? event) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleToDeviceEvent,
           [event],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleEventUpdate(
+  _i15.Future<void> handleEventUpdate(
     _i4.Event? event,
     _i4.EventUpdateType? type,
   ) =>
@@ -9193,19 +9228,19 @@ class MockEncryption extends _i1.Mock implements _i11.Encryption {
             type,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.ToDeviceEvent> decryptToDeviceEvent(
+  _i15.Future<_i4.ToDeviceEvent> decryptToDeviceEvent(
           _i4.ToDeviceEvent? event) =>
       (super.noSuchMethod(
         Invocation.method(
           #decryptToDeviceEvent,
           [event],
         ),
-        returnValue: _i14.Future<_i4.ToDeviceEvent>.value(_FakeToDeviceEvent_82(
+        returnValue: _i15.Future<_i4.ToDeviceEvent>.value(_FakeToDeviceEvent_83(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -9213,14 +9248,14 @@ class MockEncryption extends _i1.Mock implements _i11.Encryption {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.ToDeviceEvent>.value(_FakeToDeviceEvent_82(
+            _i15.Future<_i4.ToDeviceEvent>.value(_FakeToDeviceEvent_83(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
             [event],
           ),
         )),
-      ) as _i14.Future<_i4.ToDeviceEvent>);
+      ) as _i15.Future<_i4.ToDeviceEvent>);
 
   @override
   _i4.Event decryptRoomEventSync(_i4.Event? event) => (super.noSuchMethod(
@@ -9228,14 +9263,14 @@ class MockEncryption extends _i1.Mock implements _i11.Encryption {
           #decryptRoomEventSync,
           [event],
         ),
-        returnValue: _FakeEvent_83(
+        returnValue: _FakeEvent_84(
           this,
           Invocation.method(
             #decryptRoomEventSync,
             [event],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_83(
+        returnValueForMissingStub: _FakeEvent_84(
           this,
           Invocation.method(
             #decryptRoomEventSync,
@@ -9245,7 +9280,7 @@ class MockEncryption extends _i1.Mock implements _i11.Encryption {
       ) as _i4.Event);
 
   @override
-  _i14.Future<_i4.Event> decryptRoomEvent(
+  _i15.Future<_i4.Event> decryptRoomEvent(
     _i4.Event? event, {
     bool? store = false,
     _i4.EventUpdateType? updateType = _i4.EventUpdateType.timeline,
@@ -9259,7 +9294,7 @@ class MockEncryption extends _i1.Mock implements _i11.Encryption {
             #updateType: updateType,
           },
         ),
-        returnValue: _i14.Future<_i4.Event>.value(_FakeEvent_83(
+        returnValue: _i15.Future<_i4.Event>.value(_FakeEvent_84(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -9270,7 +9305,7 @@ class MockEncryption extends _i1.Mock implements _i11.Encryption {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Event>.value(_FakeEvent_83(
+        returnValueForMissingStub: _i15.Future<_i4.Event>.value(_FakeEvent_84(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -9281,10 +9316,10 @@ class MockEncryption extends _i1.Mock implements _i11.Encryption {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Event>);
+      ) as _i15.Future<_i4.Event>);
 
   @override
-  _i14.Future<Map<String, dynamic>> encryptGroupMessagePayload(
+  _i15.Future<Map<String, dynamic>> encryptGroupMessagePayload(
     String? roomId,
     Map<String, dynamic>? payload, {
     String? type = 'm.room.message',
@@ -9299,13 +9334,13 @@ class MockEncryption extends _i1.Mock implements _i11.Encryption {
           {#type: type},
         ),
         returnValue:
-            _i14.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
+            _i15.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
-      ) as _i14.Future<Map<String, dynamic>>);
+            _i15.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
+      ) as _i15.Future<Map<String, dynamic>>);
 
   @override
-  _i14.Future<
+  _i15.Future<
       Map<String, Map<String, Map<String, dynamic>>>> encryptToDeviceMessage(
     List<_i4.DeviceKeys>? deviceKeys,
     String? type,
@@ -9321,50 +9356,50 @@ class MockEncryption extends _i1.Mock implements _i11.Encryption {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Map<String, Map<String, dynamic>>>>.value(
+            _i15.Future<Map<String, Map<String, Map<String, dynamic>>>>.value(
                 <String, Map<String, Map<String, dynamic>>>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Map<String, Map<String, dynamic>>>>.value(
+            _i15.Future<Map<String, Map<String, Map<String, dynamic>>>>.value(
                 <String, Map<String, Map<String, dynamic>>>{}),
-      ) as _i14.Future<Map<String, Map<String, Map<String, dynamic>>>>);
+      ) as _i15.Future<Map<String, Map<String, Map<String, dynamic>>>>);
 
   @override
-  _i14.Future<void> autovalidateMasterOwnKey() => (super.noSuchMethod(
+  _i15.Future<void> autovalidateMasterOwnKey() => (super.noSuchMethod(
         Invocation.method(
           #autovalidateMasterOwnKey,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> dispose() => (super.noSuchMethod(
+  _i15.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 }
 
 /// A class which mocks [CrossSigning].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCrossSigning extends _i1.Mock implements _i18.CrossSigning {
+class MockCrossSigning extends _i1.Mock implements _i19.CrossSigning {
   @override
-  _i11.Encryption get encryption => (super.noSuchMethod(
+  _i12.Encryption get encryption => (super.noSuchMethod(
         Invocation.getter(#encryption),
-        returnValue: _FakeEncryption_9(
+        returnValue: _FakeEncryption_10(
           this,
           Invocation.getter(#encryption),
         ),
-        returnValueForMissingStub: _FakeEncryption_9(
+        returnValueForMissingStub: _FakeEncryption_10(
           this,
           Invocation.getter(#encryption),
         ),
-      ) as _i11.Encryption);
+      ) as _i12.Encryption);
 
   @override
   _i4.Client get client => (super.noSuchMethod(
@@ -9387,21 +9422,21 @@ class MockCrossSigning extends _i1.Mock implements _i18.CrossSigning {
       ) as bool);
 
   @override
-  _i14.Future<bool> isCached() => (super.noSuchMethod(
+  _i15.Future<bool> isCached() => (super.noSuchMethod(
         Invocation.method(
           #isCached,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> selfSign({
+  _i15.Future<void> selfSign({
     String? passphrase,
     String? recoveryKey,
     String? keyOrPassphrase,
-    _i11.OpenSSSS? openSsss,
+    _i12.OpenSSSS? openSsss,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9414,9 +9449,9 @@ class MockCrossSigning extends _i1.Mock implements _i18.CrossSigning {
             #openSsss: openSsss,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   bool signable(List<_i4.SignableKey>? keys) => (super.noSuchMethod(
@@ -9429,12 +9464,12 @@ class MockCrossSigning extends _i1.Mock implements _i18.CrossSigning {
       ) as bool);
 
   @override
-  _i14.Future<void> sign(List<_i4.SignableKey>? keys) => (super.noSuchMethod(
+  _i15.Future<void> sign(List<_i4.SignableKey>? keys) => (super.noSuchMethod(
         Invocation.method(
           #sign,
           [keys],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 }

--- a/test/widgets/registration_controller_test.mocks.dart
+++ b/test/widgets/registration_controller_test.mocks.dart
@@ -4,32 +4,34 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/models/server_auth_capabilities.dart' as _i15;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
+import 'package:kohera/core/models/server_auth_capabilities.dart' as _i16;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i12;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -801,8 +803,9 @@ class _FakeSelectionService_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
-  _FakeSyncService_71(
+class _FakeSpaceAccessService_71 extends _i1.SmartFake
+    implements _i12.SpaceAccessService {
+  _FakeSpaceAccessService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -811,8 +814,8 @@ class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
         );
 }
 
-class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
-  _FakeAuthService_72(
+class _FakeSyncService_72 extends _i1.SmartFake implements _i13.SyncService {
+  _FakeSyncService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -821,9 +824,8 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeOutboxService_73 extends _i1.SmartFake
-    implements _i14.OutboxService {
-  _FakeOutboxService_73(
+class _FakeAuthService_73 extends _i1.SmartFake implements _i14.AuthService {
+  _FakeAuthService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -832,9 +834,20 @@ class _FakeOutboxService_73 extends _i1.SmartFake
         );
 }
 
-class _FakeServerAuthCapabilities_74 extends _i1.SmartFake
-    implements _i15.ServerAuthCapabilities {
-  _FakeServerAuthCapabilities_74(
+class _FakeOutboxService_74 extends _i1.SmartFake
+    implements _i15.OutboxService {
+  _FakeOutboxService_74(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeServerAuthCapabilities_75 extends _i1.SmartFake
+    implements _i16.ServerAuthCapabilities {
+  _FakeServerAuthCapabilities_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -861,12 +874,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -986,11 +999,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1027,11 +1040,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1061,11 +1074,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1074,11 +1087,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1364,34 +1377,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1547,7 +1560,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1836,14 +1849,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2231,8 +2244,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2248,8 +2261,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2290,7 +2303,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2306,7 +2319,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2355,7 +2368,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2376,7 +2389,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2479,7 +2492,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2497,7 +2510,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3016,7 +3029,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3368,7 +3381,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3382,7 +3395,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3533,7 +3546,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4911,7 +4924,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4933,7 +4946,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5427,7 +5440,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5439,7 +5452,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6447,7 +6460,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6458,7 +6471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6706,7 +6719,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6718,7 +6731,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6978,7 +6991,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6991,7 +7004,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7058,7 +7071,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7071,7 +7084,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7119,7 +7132,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7131,7 +7144,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7379,7 +7392,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7390,7 +7403,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7652,7 +7665,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7679,7 +7692,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7709,11 +7722,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7786,43 +7799,56 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i11.SelectionService);
 
   @override
-  _i12.SyncService get sync => (super.noSuchMethod(
+  _i12.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i12.SpaceAccessService);
+
+  @override
+  _i13.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_71(
+        returnValue: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_71(
+        returnValueForMissingStub: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i12.SyncService);
+      ) as _i13.SyncService);
 
   @override
-  _i13.AuthService get auth => (super.noSuchMethod(
+  _i14.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_72(
+        returnValue: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_72(
+        returnValueForMissingStub: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i13.AuthService);
+      ) as _i14.AuthService);
 
   @override
-  _i14.OutboxService get outbox => (super.noSuchMethod(
+  _i15.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_73(
+        returnValue: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_73(
+        returnValueForMissingStub: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i14.OutboxService);
+      ) as _i15.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7886,7 +7912,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set sync(_i12.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i12.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i13.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7895,7 +7930,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set auth(_i13.AuthService? value) => super.noSuchMethod(
+  set auth(_i14.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7904,7 +7939,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i15.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -7957,7 +7992,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8051,7 +8086,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8060,7 +8095,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8079,7 +8114,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8090,7 +8125,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8138,7 +8173,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8176,7 +8211,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8185,7 +8220,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8194,16 +8229,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8227,7 +8262,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 /// A class which mocks [AuthService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAuthService extends _i1.Mock implements _i13.AuthService {
+class MockAuthService extends _i1.Mock implements _i14.AuthService {
   @override
   bool get isLoggedIn => (super.noSuchMethod(
         Invocation.getter(#isLoggedIn),
@@ -8353,7 +8388,7 @@ class MockAuthService extends _i1.Mock implements _i13.AuthService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i15.ServerAuthCapabilities> getServerAuthCapabilities(
+  _i5.Future<_i16.ServerAuthCapabilities> getServerAuthCapabilities(
     String? homeserver, {
     required bool? isLoggedIn,
   }) =>
@@ -8363,8 +8398,8 @@ class MockAuthService extends _i1.Mock implements _i13.AuthService {
           [homeserver],
           {#isLoggedIn: isLoggedIn},
         ),
-        returnValue: _i5.Future<_i15.ServerAuthCapabilities>.value(
-            _FakeServerAuthCapabilities_74(
+        returnValue: _i5.Future<_i16.ServerAuthCapabilities>.value(
+            _FakeServerAuthCapabilities_75(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -8373,8 +8408,8 @@ class MockAuthService extends _i1.Mock implements _i13.AuthService {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i15.ServerAuthCapabilities>.value(
-                _FakeServerAuthCapabilities_74(
+            _i5.Future<_i16.ServerAuthCapabilities>.value(
+                _FakeServerAuthCapabilities_75(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -8382,7 +8417,7 @@ class MockAuthService extends _i1.Mock implements _i13.AuthService {
             {#isLoggedIn: isLoggedIn},
           ),
         )),
-      ) as _i5.Future<_i15.ServerAuthCapabilities>);
+      ) as _i5.Future<_i16.ServerAuthCapabilities>);
 
   @override
   bool isPermanentAuthFailure(Object? error) => (super.noSuchMethod(
@@ -8425,7 +8460,7 @@ class MockAuthService extends _i1.Mock implements _i13.AuthService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8434,7 +8469,7 @@ class MockAuthService extends _i1.Mock implements _i13.AuthService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/test/widgets/room_avatar_test.mocks.dart
+++ b/test/widgets/room_avatar_test.mocks.dart
@@ -1084,6 +1084,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -1590,6 +1597,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/room_context_menu_test.mocks.dart
+++ b/test/widgets/room_context_menu_test.mocks.dart
@@ -4,33 +4,35 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i17;
-import 'dart:ui' as _i19;
+import 'dart:typed_data' as _i18;
+import 'dart:ui' as _i20;
 
-import 'package:flutter/services.dart' as _i20;
-import 'package:flutter/widgets.dart' as _i21;
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i12;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i15;
+import 'package:matrix/encryption.dart' as _i16;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i23;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i22;
+import 'package:matrix/src/utils/space_child.dart' as _i23;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -802,8 +804,9 @@ class _FakeSelectionService_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
-  _FakeSyncService_71(
+class _FakeSpaceAccessService_71 extends _i1.SmartFake
+    implements _i12.SpaceAccessService {
+  _FakeSpaceAccessService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -812,8 +815,8 @@ class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
         );
 }
 
-class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
-  _FakeAuthService_72(
+class _FakeSyncService_72 extends _i1.SmartFake implements _i13.SyncService {
+  _FakeSyncService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -822,9 +825,8 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeOutboxService_73 extends _i1.SmartFake
-    implements _i14.OutboxService {
-  _FakeOutboxService_73(
+class _FakeAuthService_73 extends _i1.SmartFake implements _i14.AuthService {
+  _FakeAuthService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -833,8 +835,9 @@ class _FakeOutboxService_73 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_74(
+class _FakeOutboxService_74 extends _i1.SmartFake
+    implements _i15.OutboxService {
+  _FakeOutboxService_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -843,9 +846,19 @@ class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_75 extends _i1.SmartFake
+class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_76 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_75(
+  _FakeLatestReceiptState_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -854,8 +867,8 @@ class _FakeLatestReceiptState_75 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_76(
+class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -864,8 +877,8 @@ class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_77(
+class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,12 +905,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i15.KeyVerificationMethod> get verificationMethods =>
+  Set<_i16.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i15.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
-      ) as Set<_i15.KeyVerificationMethod>);
+        returnValue: <_i16.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
+      ) as Set<_i16.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1017,11 +1030,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1058,11 +1071,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1092,11 +1105,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1105,11 +1118,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1395,34 +1408,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i15.KeyVerification>
+  _i3.CachedStreamController<_i16.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i15.KeyVerification>(
+                _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i15.KeyVerification>);
+          ) as _i3.CachedStreamController<_i16.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1578,7 +1591,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1867,14 +1880,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2262,8 +2275,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2279,8 +2292,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2321,7 +2334,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2337,7 +2350,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2386,7 +2399,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2407,7 +2420,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2510,7 +2523,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2528,7 +2541,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3047,7 +3060,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i17.Uint8List? file, {
+    _i18.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3399,7 +3412,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3413,7 +3426,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3564,7 +3577,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i17.Uint8List? body,
+    _i18.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4942,7 +4955,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4964,7 +4977,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5458,7 +5471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5470,7 +5483,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6478,7 +6491,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6489,7 +6502,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6737,7 +6750,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6749,7 +6762,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7009,7 +7022,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7022,7 +7035,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7089,7 +7102,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7102,7 +7115,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7150,7 +7163,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7162,7 +7175,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7410,7 +7423,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7421,7 +7434,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7683,7 +7696,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i17.Uint8List? body, {
+    _i18.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7710,7 +7723,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7740,11 +7753,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7817,43 +7830,56 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i11.SelectionService);
 
   @override
-  _i12.SyncService get sync => (super.noSuchMethod(
+  _i12.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i12.SpaceAccessService);
+
+  @override
+  _i13.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_71(
+        returnValue: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_71(
+        returnValueForMissingStub: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i12.SyncService);
+      ) as _i13.SyncService);
 
   @override
-  _i13.AuthService get auth => (super.noSuchMethod(
+  _i14.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_72(
+        returnValue: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_72(
+        returnValueForMissingStub: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i13.AuthService);
+      ) as _i14.AuthService);
 
   @override
-  _i14.OutboxService get outbox => (super.noSuchMethod(
+  _i15.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_73(
+        returnValue: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_73(
+        returnValueForMissingStub: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i14.OutboxService);
+      ) as _i15.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7917,7 +7943,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set sync(_i12.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i12.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i13.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7926,7 +7961,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set auth(_i13.AuthService? value) => super.noSuchMethod(
+  set auth(_i14.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7935,7 +7970,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i15.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -7988,7 +8023,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8082,7 +8117,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8091,7 +8126,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8110,7 +8145,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8121,7 +8156,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8169,7 +8204,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i21.RouteInformation? routeInformation) =>
+          _i22.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8207,7 +8242,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8216,7 +8251,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8225,16 +8260,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
-      ) as _i5.Future<_i19.AppExitResponse>);
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i5.Future<_i20.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8262,11 +8297,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8296,11 +8331,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_74(
+        returnValue: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_74(
+        returnValueForMissingStub: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
@@ -8353,11 +8388,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8393,11 +8428,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8413,11 +8448,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8426,11 +8461,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8473,11 +8508,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8520,11 +8555,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_75(
+        returnValue: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_75(
+        returnValueForMissingStub: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8561,6 +8596,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   bool get isFavourite => (super.noSuchMethod(
         Invocation.getter(#isFavourite),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
@@ -8736,18 +8778,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i22.SpaceParent>[],
-        returnValueForMissingStub: <_i22.SpaceParent>[],
-      ) as List<_i22.SpaceParent>);
+        returnValue: <_i23.SpaceParent>[],
+        returnValueForMissingStub: <_i23.SpaceParent>[],
+      ) as List<_i23.SpaceParent>);
 
   @override
-  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i22.SpaceChild>[],
-        returnValueForMissingStub: <_i22.SpaceChild>[],
-      ) as List<_i22.SpaceChild>);
+        returnValue: <_i23.SpaceChild>[],
+        returnValueForMissingStub: <_i23.SpaceChild>[],
+      ) as List<_i23.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8914,14 +8956,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8969,7 +9011,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8977,7 +9019,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8992,7 +9034,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9000,7 +9042,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9078,13 +9120,23 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   _i5.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9092,7 +9144,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9334,7 +9386,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9345,7 +9397,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9434,15 +9486,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i23.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i23.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i23.TimelineChunk?>.value(),
-      ) as _i5.Future<_i23.TimelineChunk?>);
+        returnValue: _i5.Future<_i24.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i24.TimelineChunk?>.value(),
+      ) as _i5.Future<_i24.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9483,7 +9535,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -9500,7 +9552,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -9564,14 +9616,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9587,14 +9639,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9650,7 +9702,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9658,7 +9710,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/room_details_panel_test.mocks.dart
+++ b/test/widgets/room_details_panel_test.mocks.dart
@@ -8612,6 +8612,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -9118,6 +9125,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/room_members_section_test.mocks.dart
+++ b/test/widgets/room_members_section_test.mocks.dart
@@ -4,33 +4,35 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i17;
-import 'dart:ui' as _i19;
+import 'dart:typed_data' as _i18;
+import 'dart:ui' as _i20;
 
-import 'package:flutter/services.dart' as _i20;
-import 'package:flutter/widgets.dart' as _i21;
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i12;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i15;
+import 'package:matrix/encryption.dart' as _i16;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i23;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i22;
+import 'package:matrix/src/utils/space_child.dart' as _i23;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -802,8 +804,9 @@ class _FakeSelectionService_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
-  _FakeSyncService_71(
+class _FakeSpaceAccessService_71 extends _i1.SmartFake
+    implements _i12.SpaceAccessService {
+  _FakeSpaceAccessService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -812,8 +815,8 @@ class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
         );
 }
 
-class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
-  _FakeAuthService_72(
+class _FakeSyncService_72 extends _i1.SmartFake implements _i13.SyncService {
+  _FakeSyncService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -822,9 +825,8 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeOutboxService_73 extends _i1.SmartFake
-    implements _i14.OutboxService {
-  _FakeOutboxService_73(
+class _FakeAuthService_73 extends _i1.SmartFake implements _i14.AuthService {
+  _FakeAuthService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -833,8 +835,9 @@ class _FakeOutboxService_73 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_74(
+class _FakeOutboxService_74 extends _i1.SmartFake
+    implements _i15.OutboxService {
+  _FakeOutboxService_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -843,9 +846,19 @@ class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_75 extends _i1.SmartFake
+class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_76 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_75(
+  _FakeLatestReceiptState_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -854,8 +867,8 @@ class _FakeLatestReceiptState_75 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_76(
+class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -864,8 +877,8 @@ class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_77(
+class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -874,8 +887,8 @@ class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_78 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_78(
+class _FakeRoom_79 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -902,12 +915,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i15.KeyVerificationMethod> get verificationMethods =>
+  Set<_i16.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i15.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
-      ) as Set<_i15.KeyVerificationMethod>);
+        returnValue: <_i16.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
+      ) as Set<_i16.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1027,11 +1040,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1068,11 +1081,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1102,11 +1115,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1115,11 +1128,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1405,34 +1418,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i15.KeyVerification>
+  _i3.CachedStreamController<_i16.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i15.KeyVerification>(
+                _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i15.KeyVerification>);
+          ) as _i3.CachedStreamController<_i16.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1588,7 +1601,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1877,14 +1890,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2272,8 +2285,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2289,8 +2302,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2331,7 +2344,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2347,7 +2360,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2396,7 +2409,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2417,7 +2430,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2520,7 +2533,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2538,7 +2551,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3057,7 +3070,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i17.Uint8List? file, {
+    _i18.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3409,7 +3422,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3423,7 +3436,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3574,7 +3587,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i17.Uint8List? body,
+    _i18.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4952,7 +4965,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4974,7 +4987,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5468,7 +5481,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5480,7 +5493,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6488,7 +6501,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6499,7 +6512,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6747,7 +6760,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6759,7 +6772,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7019,7 +7032,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7032,7 +7045,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7099,7 +7112,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7112,7 +7125,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7160,7 +7173,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7172,7 +7185,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7420,7 +7433,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7431,7 +7444,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7693,7 +7706,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i17.Uint8List? body, {
+    _i18.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7720,7 +7733,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7750,11 +7763,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7827,43 +7840,56 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i11.SelectionService);
 
   @override
-  _i12.SyncService get sync => (super.noSuchMethod(
+  _i12.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i12.SpaceAccessService);
+
+  @override
+  _i13.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_71(
+        returnValue: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_71(
+        returnValueForMissingStub: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i12.SyncService);
+      ) as _i13.SyncService);
 
   @override
-  _i13.AuthService get auth => (super.noSuchMethod(
+  _i14.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_72(
+        returnValue: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_72(
+        returnValueForMissingStub: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i13.AuthService);
+      ) as _i14.AuthService);
 
   @override
-  _i14.OutboxService get outbox => (super.noSuchMethod(
+  _i15.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_73(
+        returnValue: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_73(
+        returnValueForMissingStub: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i14.OutboxService);
+      ) as _i15.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7927,7 +7953,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set sync(_i12.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i12.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i13.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7936,7 +7971,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set auth(_i13.AuthService? value) => super.noSuchMethod(
+  set auth(_i14.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7945,7 +7980,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i15.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -7998,7 +8033,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8092,7 +8127,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8101,7 +8136,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8120,7 +8155,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8131,7 +8166,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8179,7 +8214,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i21.RouteInformation? routeInformation) =>
+          _i22.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8217,7 +8252,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8226,7 +8261,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8235,16 +8270,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
-      ) as _i5.Future<_i19.AppExitResponse>);
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i5.Future<_i20.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8272,11 +8307,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8306,11 +8341,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_74(
+        returnValue: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_74(
+        returnValueForMissingStub: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
@@ -8363,11 +8398,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8403,11 +8438,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8423,11 +8458,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8436,11 +8471,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8483,11 +8518,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8530,11 +8565,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_75(
+        returnValue: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_75(
+        returnValueForMissingStub: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8571,6 +8606,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   bool get isFavourite => (super.noSuchMethod(
         Invocation.getter(#isFavourite),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
@@ -8746,18 +8788,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i22.SpaceParent>[],
-        returnValueForMissingStub: <_i22.SpaceParent>[],
-      ) as List<_i22.SpaceParent>);
+        returnValue: <_i23.SpaceParent>[],
+        returnValueForMissingStub: <_i23.SpaceParent>[],
+      ) as List<_i23.SpaceParent>);
 
   @override
-  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i22.SpaceChild>[],
-        returnValueForMissingStub: <_i22.SpaceChild>[],
-      ) as List<_i22.SpaceChild>);
+        returnValue: <_i23.SpaceChild>[],
+        returnValueForMissingStub: <_i23.SpaceChild>[],
+      ) as List<_i23.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8924,14 +8966,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8979,7 +9021,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8987,7 +9029,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9002,7 +9044,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9010,7 +9052,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9088,13 +9130,23 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   _i5.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9102,7 +9154,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9344,7 +9396,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9355,7 +9407,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9444,15 +9496,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i23.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i23.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i23.TimelineChunk?>.value(),
-      ) as _i5.Future<_i23.TimelineChunk?>);
+        returnValue: _i5.Future<_i24.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i24.TimelineChunk?>.value(),
+      ) as _i5.Future<_i24.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9493,7 +9545,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -9510,7 +9562,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -9574,14 +9626,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9597,14 +9649,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9660,7 +9712,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9668,7 +9720,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9980,11 +10032,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_78(
+        returnValue: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_78(
+        returnValueForMissingStub: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
@@ -9993,11 +10045,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -10063,11 +10115,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -10092,11 +10144,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10114,11 +10166,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10165,7 +10217,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -10177,7 +10229,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -10247,7 +10299,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -10260,7 +10312,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/widgets/room_section_header_test.mocks.dart
+++ b/test/widgets/room_section_header_test.mocks.dart
@@ -4,36 +4,38 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/material.dart' as _i24;
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/material.dart' as _i25;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
-import 'package:kohera/core/services/preferences_service.dart' as _i23;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/preferences_service.dart' as _i24;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i12;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
-import 'package:kohera/core/theme/custom_theme.dart' as _i15;
+import 'package:kohera/core/theme/custom_theme.dart' as _i16;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i26;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i27;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i25;
+import 'package:matrix/src/utils/space_child.dart' as _i26;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -805,8 +807,9 @@ class _FakeSelectionService_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
-  _FakeSyncService_71(
+class _FakeSpaceAccessService_71 extends _i1.SmartFake
+    implements _i12.SpaceAccessService {
+  _FakeSpaceAccessService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -815,8 +818,8 @@ class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
         );
 }
 
-class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
-  _FakeAuthService_72(
+class _FakeSyncService_72 extends _i1.SmartFake implements _i13.SyncService {
+  _FakeSyncService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -825,9 +828,8 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeOutboxService_73 extends _i1.SmartFake
-    implements _i14.OutboxService {
-  _FakeOutboxService_73(
+class _FakeAuthService_73 extends _i1.SmartFake implements _i14.AuthService {
+  _FakeAuthService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -836,8 +838,9 @@ class _FakeOutboxService_73 extends _i1.SmartFake
         );
 }
 
-class _FakeCustomTheme_74 extends _i1.SmartFake implements _i15.CustomTheme {
-  _FakeCustomTheme_74(
+class _FakeOutboxService_74 extends _i1.SmartFake
+    implements _i15.OutboxService {
+  _FakeOutboxService_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -846,8 +849,8 @@ class _FakeCustomTheme_74 extends _i1.SmartFake implements _i15.CustomTheme {
         );
 }
 
-class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_75(
+class _FakeCustomTheme_75 extends _i1.SmartFake implements _i16.CustomTheme {
+  _FakeCustomTheme_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -856,9 +859,19 @@ class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_76 extends _i1.SmartFake
+class _FakeRoomSummary_76 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_76(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_77 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_76(
+  _FakeLatestReceiptState_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,8 +880,8 @@ class _FakeLatestReceiptState_76 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_77(
+class _FakeTimeline_78 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -877,8 +890,8 @@ class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_78(
+class _FakeUser_79 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -905,12 +918,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1030,11 +1043,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1071,11 +1084,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1105,11 +1118,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1118,11 +1131,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1408,34 +1421,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1591,7 +1604,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1880,14 +1893,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2275,8 +2288,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2292,8 +2305,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2334,7 +2347,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2350,7 +2363,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2399,7 +2412,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2420,7 +2433,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2523,7 +2536,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2541,7 +2554,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3060,7 +3073,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3412,7 +3425,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3426,7 +3439,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3577,7 +3590,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4955,7 +4968,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4977,7 +4990,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5471,7 +5484,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5483,7 +5496,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6491,7 +6504,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6502,7 +6515,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6750,7 +6763,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6762,7 +6775,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7022,7 +7035,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7035,7 +7048,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7102,7 +7115,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7115,7 +7128,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7163,7 +7176,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7175,7 +7188,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7423,7 +7436,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7434,7 +7447,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7696,7 +7709,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7723,7 +7736,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7753,11 +7766,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7830,43 +7843,56 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i11.SelectionService);
 
   @override
-  _i12.SyncService get sync => (super.noSuchMethod(
+  _i12.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i12.SpaceAccessService);
+
+  @override
+  _i13.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_71(
+        returnValue: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_71(
+        returnValueForMissingStub: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i12.SyncService);
+      ) as _i13.SyncService);
 
   @override
-  _i13.AuthService get auth => (super.noSuchMethod(
+  _i14.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_72(
+        returnValue: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_72(
+        returnValueForMissingStub: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i13.AuthService);
+      ) as _i14.AuthService);
 
   @override
-  _i14.OutboxService get outbox => (super.noSuchMethod(
+  _i15.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_73(
+        returnValue: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_73(
+        returnValueForMissingStub: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i14.OutboxService);
+      ) as _i15.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7930,7 +7956,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set sync(_i12.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i12.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i13.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7939,7 +7974,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set auth(_i13.AuthService? value) => super.noSuchMethod(
+  set auth(_i14.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7948,7 +7983,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i15.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -8001,7 +8036,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8095,7 +8130,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8104,7 +8139,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8123,7 +8158,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8134,7 +8169,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8182,7 +8217,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8220,7 +8255,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8229,7 +8264,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8238,16 +8273,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8272,60 +8307,60 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockPreferencesService extends _i1.Mock
-    implements _i23.PreferencesService {
+    implements _i24.PreferencesService {
   @override
-  _i23.MessageDensity get messageDensity => (super.noSuchMethod(
+  _i24.MessageDensity get messageDensity => (super.noSuchMethod(
         Invocation.getter(#messageDensity),
-        returnValue: _i23.MessageDensity.compact,
-        returnValueForMissingStub: _i23.MessageDensity.compact,
-      ) as _i23.MessageDensity);
+        returnValue: _i24.MessageDensity.compact,
+        returnValueForMissingStub: _i24.MessageDensity.compact,
+      ) as _i24.MessageDensity);
 
   @override
-  _i23.MobileTab get lastMobileTab => (super.noSuchMethod(
+  _i24.MobileTab get lastMobileTab => (super.noSuchMethod(
         Invocation.getter(#lastMobileTab),
-        returnValue: _i23.MobileTab.inbox,
-        returnValueForMissingStub: _i23.MobileTab.inbox,
-      ) as _i23.MobileTab);
+        returnValue: _i24.MobileTab.inbox,
+        returnValueForMissingStub: _i24.MobileTab.inbox,
+      ) as _i24.MobileTab);
 
   @override
-  _i24.ThemeMode get themeMode => (super.noSuchMethod(
+  _i25.ThemeMode get themeMode => (super.noSuchMethod(
         Invocation.getter(#themeMode),
-        returnValue: _i24.ThemeMode.system,
-        returnValueForMissingStub: _i24.ThemeMode.system,
-      ) as _i24.ThemeMode);
+        returnValue: _i25.ThemeMode.system,
+        returnValueForMissingStub: _i25.ThemeMode.system,
+      ) as _i25.ThemeMode);
 
   @override
   String get themeModeLabel => (super.noSuchMethod(
         Invocation.getter(#themeModeLabel),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#themeModeLabel),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#themeModeLabel),
         ),
       ) as String);
 
   @override
-  _i15.CustomTheme get customTheme => (super.noSuchMethod(
+  _i16.CustomTheme get customTheme => (super.noSuchMethod(
         Invocation.getter(#customTheme),
-        returnValue: _FakeCustomTheme_74(
+        returnValue: _FakeCustomTheme_75(
           this,
           Invocation.getter(#customTheme),
         ),
-        returnValueForMissingStub: _FakeCustomTheme_74(
+        returnValueForMissingStub: _FakeCustomTheme_75(
           this,
           Invocation.getter(#customTheme),
         ),
-      ) as _i15.CustomTheme);
+      ) as _i16.CustomTheme);
 
   @override
-  _i24.ThemeMode get customThemeMode => (super.noSuchMethod(
+  _i25.ThemeMode get customThemeMode => (super.noSuchMethod(
         Invocation.getter(#customThemeMode),
-        returnValue: _i24.ThemeMode.system,
-        returnValueForMissingStub: _i24.ThemeMode.system,
-      ) as _i24.ThemeMode);
+        returnValue: _i25.ThemeMode.system,
+        returnValueForMissingStub: _i25.ThemeMode.system,
+      ) as _i25.ThemeMode);
 
   @override
   Set<String> get collapsedSpaceSections => (super.noSuchMethod(
@@ -8356,20 +8391,20 @@ class MockPreferencesService extends _i1.Mock
       ) as double);
 
   @override
-  _i23.NotificationLevel get notificationLevel => (super.noSuchMethod(
+  _i24.NotificationLevel get notificationLevel => (super.noSuchMethod(
         Invocation.getter(#notificationLevel),
-        returnValue: _i23.NotificationLevel.all,
-        returnValueForMissingStub: _i23.NotificationLevel.all,
-      ) as _i23.NotificationLevel);
+        returnValue: _i24.NotificationLevel.all,
+        returnValueForMissingStub: _i24.NotificationLevel.all,
+      ) as _i24.NotificationLevel);
 
   @override
   String get notificationLevelLabel => (super.noSuchMethod(
         Invocation.getter(#notificationLevelLabel),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#notificationLevelLabel),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#notificationLevelLabel),
         ),
@@ -8523,11 +8558,11 @@ class MockPreferencesService extends _i1.Mock
       ) as bool);
 
   @override
-  _i23.AudioQuality get audioQuality => (super.noSuchMethod(
+  _i24.AudioQuality get audioQuality => (super.noSuchMethod(
         Invocation.getter(#audioQuality),
-        returnValue: _i23.AudioQuality.speech,
-        returnValueForMissingStub: _i23.AudioQuality.speech,
-      ) as _i23.AudioQuality);
+        returnValue: _i24.AudioQuality.speech,
+        returnValueForMissingStub: _i24.AudioQuality.speech,
+      ) as _i24.AudioQuality);
 
   @override
   bool get highPassFilter => (super.noSuchMethod(
@@ -8578,7 +8613,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setMessageDensity(_i23.MessageDensity? density) =>
+  _i5.Future<void> setMessageDensity(_i24.MessageDensity? density) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMessageDensity,
@@ -8589,7 +8624,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setLastMobileTab(_i23.MobileTab? tab) => (super.noSuchMethod(
+  _i5.Future<void> setLastMobileTab(_i24.MobileTab? tab) => (super.noSuchMethod(
         Invocation.method(
           #setLastMobileTab,
           [tab],
@@ -8599,7 +8634,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setThemeMode(_i24.ThemeMode? mode) => (super.noSuchMethod(
+  _i5.Future<void> setThemeMode(_i25.ThemeMode? mode) => (super.noSuchMethod(
         Invocation.method(
           #setThemeMode,
           [mode],
@@ -8619,7 +8654,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setCustomTheme(_i15.CustomTheme? theme) =>
+  _i5.Future<void> setCustomTheme(_i16.CustomTheme? theme) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCustomTheme,
@@ -8630,7 +8665,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setCustomThemeMode(_i24.ThemeMode? mode) =>
+  _i5.Future<void> setCustomThemeMode(_i25.ThemeMode? mode) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCustomThemeMode,
@@ -8682,7 +8717,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setNotificationLevel(_i23.NotificationLevel? level) =>
+  _i5.Future<void> setNotificationLevel(_i24.NotificationLevel? level) =>
       (super.noSuchMethod(
         Invocation.method(
           #setNotificationLevel,
@@ -8961,7 +8996,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setAudioQuality(_i23.AudioQuality? quality) =>
+  _i5.Future<void> setAudioQuality(_i24.AudioQuality? quality) =>
       (super.noSuchMethod(
         Invocation.method(
           #setAudioQuality,
@@ -9022,7 +9057,7 @@ class MockPreferencesService extends _i1.Mock
       ) as bool);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -9031,7 +9066,7 @@ class MockPreferencesService extends _i1.Mock
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -9065,11 +9100,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -9099,11 +9134,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_75(
+        returnValue: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_75(
+        returnValueForMissingStub: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
@@ -9156,11 +9191,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -9196,11 +9231,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -9216,11 +9251,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -9229,11 +9264,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -9276,11 +9311,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -9323,11 +9358,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_76(
+        returnValue: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_76(
+        returnValueForMissingStub: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -9364,6 +9399,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   bool get isFavourite => (super.noSuchMethod(
         Invocation.getter(#isFavourite),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
@@ -9539,18 +9581,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i26.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i25.SpaceParent>[],
-        returnValueForMissingStub: <_i25.SpaceParent>[],
-      ) as List<_i25.SpaceParent>);
+        returnValue: <_i26.SpaceParent>[],
+        returnValueForMissingStub: <_i26.SpaceParent>[],
+      ) as List<_i26.SpaceParent>);
 
   @override
-  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i26.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i25.SpaceChild>[],
-        returnValueForMissingStub: <_i25.SpaceChild>[],
-      ) as List<_i25.SpaceChild>);
+        returnValue: <_i26.SpaceChild>[],
+        returnValueForMissingStub: <_i26.SpaceChild>[],
+      ) as List<_i26.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9717,14 +9759,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9772,7 +9814,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9780,7 +9822,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9795,7 +9837,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9803,7 +9845,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9881,13 +9923,23 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   _i5.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9895,7 +9947,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -10137,7 +10189,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -10148,7 +10200,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -10237,15 +10289,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i26.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i27.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i26.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i26.TimelineChunk?>.value(),
-      ) as _i5.Future<_i26.TimelineChunk?>);
+        returnValue: _i5.Future<_i27.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i27.TimelineChunk?>.value(),
+      ) as _i5.Future<_i27.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -10286,7 +10338,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -10303,7 +10355,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -10367,14 +10419,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -10390,14 +10442,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -10453,7 +10505,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10461,7 +10513,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/room_tile_test.mocks.dart
+++ b/test/widgets/room_tile_test.mocks.dart
@@ -3,42 +3,44 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i13;
-import 'dart:typed_data' as _i23;
-import 'dart:ui' as _i17;
+import 'dart:async' as _i14;
+import 'dart:typed_data' as _i24;
+import 'dart:ui' as _i18;
 
-import 'package:flutter/services.dart' as _i18;
-import 'package:flutter/widgets.dart' as _i19;
-import 'package:http/http.dart' as _i12;
-import 'package:kohera/core/services/call_service.dart' as _i24;
-import 'package:kohera/core/services/matrix_service.dart' as _i15;
-import 'package:kohera/core/services/preferences_service.dart' as _i30;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i9;
+import 'package:flutter/services.dart' as _i19;
+import 'package:flutter/widgets.dart' as _i20;
+import 'package:http/http.dart' as _i13;
+import 'package:kohera/core/services/call_service.dart' as _i25;
+import 'package:kohera/core/services/matrix_service.dart' as _i16;
+import 'package:kohera/core/services/preferences_service.dart' as _i31;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i10;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i11;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i7;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i8;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i8;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
-import 'package:kohera/features/calling/models/call_participant.dart' as _i27;
-import 'package:kohera/features/calling/models/call_state.dart' as _i29;
-import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i28;
-import 'package:kohera/features/calling/services/livekit_service.dart' as _i25;
-import 'package:kohera/features/calling/services/ringtone_service.dart' as _i31;
+import 'package:kohera/features/calling/models/call_participant.dart' as _i28;
+import 'package:kohera/features/calling/models/call_state.dart' as _i30;
+import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i29;
+import 'package:kohera/features/calling/services/livekit_service.dart' as _i26;
+import 'package:kohera/features/calling/services/ringtone_service.dart' as _i32;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:livekit_client/livekit_client.dart' as _i26;
-import 'package:matrix/encryption.dart' as _i22;
+import 'package:livekit_client/livekit_client.dart' as _i27;
+import 'package:matrix/encryption.dart' as _i23;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i14;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i21;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i11;
-import 'package:matrix/src/utils/space_child.dart' as _i20;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i15;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i12;
+import 'package:matrix/src/utils/space_child.dart' as _i21;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -119,8 +121,9 @@ class _FakeSelectionService_5 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
-  _FakeSyncService_6(
+class _FakeSpaceAccessService_6 extends _i1.SmartFake
+    implements _i8.SpaceAccessService {
+  _FakeSpaceAccessService_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -129,8 +132,8 @@ class _FakeSyncService_6 extends _i1.SmartFake implements _i8.SyncService {
         );
 }
 
-class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
-  _FakeAuthService_7(
+class _FakeSyncService_7 extends _i1.SmartFake implements _i9.SyncService {
+  _FakeSyncService_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -139,8 +142,8 @@ class _FakeAuthService_7 extends _i1.SmartFake implements _i9.AuthService {
         );
 }
 
-class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
-  _FakeOutboxService_8(
+class _FakeAuthService_8 extends _i1.SmartFake implements _i10.AuthService {
+  _FakeAuthService_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -149,8 +152,8 @@ class _FakeOutboxService_8 extends _i1.SmartFake implements _i10.OutboxService {
         );
 }
 
-class _FakeRoomSummary_9 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_9(
+class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
+  _FakeOutboxService_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -159,9 +162,8 @@ class _FakeRoomSummary_9 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_10<T> extends _i1.SmartFake
-    implements _i11.CachedStreamController<T> {
-  _FakeCachedStreamController_10(
+class _FakeRoomSummary_10 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -170,8 +172,9 @@ class _FakeCachedStreamController_10<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_11 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_11(
+class _FakeCachedStreamController_11<T> extends _i1.SmartFake
+    implements _i12.CachedStreamController<T> {
+  _FakeCachedStreamController_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -180,9 +183,19 @@ class _FakeDateTime_11 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_12 extends _i1.SmartFake
+class _FakeDateTime_12 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_12(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_13 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_12(
+  _FakeLatestReceiptState_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -191,8 +204,8 @@ class _FakeLatestReceiptState_12 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_13 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_13(
+class _FakeSyncUpdate_14 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -201,8 +214,8 @@ class _FakeSyncUpdate_13 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeTimeline_14 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_14(
+class _FakeTimeline_15 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -211,8 +224,8 @@ class _FakeTimeline_14 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_15 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_15(
+class _FakeUser_16 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -221,8 +234,8 @@ class _FakeUser_15 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeUri_16 extends _i1.SmartFake implements Uri {
-  _FakeUri_16(
+class _FakeUri_17 extends _i1.SmartFake implements Uri {
+  _FakeUri_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -231,8 +244,8 @@ class _FakeUri_16 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_17 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_17(
+class _FakeDatabaseApi_18 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -241,8 +254,8 @@ class _FakeDatabaseApi_17 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_18 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_18(
+class _FakeFilter_19 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -251,9 +264,9 @@ class _FakeFilter_18 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_19 extends _i1.SmartFake
+class _FakeNativeImplementations_20 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_19(
+  _FakeNativeImplementations_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -262,8 +275,8 @@ class _FakeNativeImplementations_19 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_20 extends _i1.SmartFake implements Duration {
-  _FakeDuration_20(
+class _FakeDuration_21 extends _i1.SmartFake implements Duration {
+  _FakeDuration_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -272,9 +285,9 @@ class _FakeDuration_20 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_21 extends _i1.SmartFake
+class _FakePushruleEvaluator_22 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_21(
+  _FakePushruleEvaluator_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -283,8 +296,8 @@ class _FakePushruleEvaluator_21 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_22 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_22(
+class _FakeProfile_23 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -293,8 +306,8 @@ class _FakeProfile_22 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeClient_23 extends _i1.SmartFake implements _i12.Client {
-  _FakeClient_23(
+class _FakeClient_24 extends _i1.SmartFake implements _i13.Client {
+  _FakeClient_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -303,9 +316,9 @@ class _FakeClient_23 extends _i1.SmartFake implements _i12.Client {
         );
 }
 
-class _FakeDiscoveryInformation_24 extends _i1.SmartFake
+class _FakeDiscoveryInformation_25 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_24(
+  _FakeDiscoveryInformation_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -314,9 +327,9 @@ class _FakeDiscoveryInformation_24 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_25 extends _i1.SmartFake
+class _FakeGetVersionsResponse_26 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_25(
+  _FakeGetVersionsResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -325,9 +338,9 @@ class _FakeGetVersionsResponse_25 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_26 extends _i1.SmartFake
+class _FakeRegisterResponse_27 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_26(
+  _FakeRegisterResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -336,8 +349,8 @@ class _FakeRegisterResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_27 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_27(
+class _FakeLoginResponse_28 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -346,9 +359,9 @@ class _FakeLoginResponse_27 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_28 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_29 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_28(
+  _FakeGetAuthMetadataResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -357,8 +370,8 @@ class _FakeGetAuthMetadataResponse_28 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_29<T1> extends _i1.SmartFake implements _i13.Future<T1> {
-  _FakeFuture_29(
+class _FakeFuture_30<T1> extends _i1.SmartFake implements _i14.Future<T1> {
+  _FakeFuture_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -367,9 +380,9 @@ class _FakeFuture_29<T1> extends _i1.SmartFake implements _i13.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_30 extends _i1.SmartFake
+class _FakeCachedProfileInformation_31 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_30(
+  _FakeCachedProfileInformation_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -378,8 +391,8 @@ class _FakeCachedProfileInformation_30 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_31 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_31(
+class _FakeMediaConfig_32 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -388,8 +401,8 @@ class _FakeMediaConfig_31 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_32 extends _i1.SmartFake implements _i14.FileResponse {
-  _FakeFileResponse_32(
+class _FakeFileResponse_33 extends _i1.SmartFake implements _i15.FileResponse {
+  _FakeFileResponse_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -398,8 +411,8 @@ class _FakeFileResponse_32 extends _i1.SmartFake implements _i14.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_33 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_33(
+class _FakePreviewForUrl_34 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -408,9 +421,9 @@ class _FakePreviewForUrl_33 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_34 extends _i1.SmartFake
+class _FakeCachedPresence_35 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_34(
+  _FakeCachedPresence_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -419,9 +432,9 @@ class _FakeCachedPresence_34 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_35 extends _i1.SmartFake
+class _FakeTurnServerCredentials_36 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_35(
+  _FakeTurnServerCredentials_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -430,9 +443,9 @@ class _FakeTurnServerCredentials_35 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_37 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_36(
+  _FakeRoomKeysUpdateResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -441,8 +454,8 @@ class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_37(
+class _FakeKeyBackupData_38 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -451,9 +464,9 @@ class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_39 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_38(
+  _FakeGetWellknownSupportResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -462,9 +475,9 @@ class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_40 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_39(
+  _FakeGenerateLoginTokenResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -473,9 +486,9 @@ class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_41 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_40(
+  _FakeGetRoomSummaryResponse$3_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -484,9 +497,9 @@ class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_42 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_41(
+  _FakeGetSpaceHierarchyResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -495,9 +508,9 @@ class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_43 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_42(
+  _FakeGetRelatingEventsResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -506,9 +519,9 @@ class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_44 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_43(
+  _FakeGetRelatingEventsWithRelTypeResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -517,9 +530,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -528,9 +541,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_46 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_45(
+  _FakeGetThreadRootsResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -539,9 +552,9 @@ class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_47 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_46(
+  _FakeGetEventByTimestampResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -550,9 +563,9 @@ class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_47 extends _i1.SmartFake
+class _FakeRequestTokenResponse_48 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_47(
+  _FakeRequestTokenResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -561,9 +574,9 @@ class _FakeRequestTokenResponse_47 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_49 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_48(
+  _FakeTokenOwnerInfo_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -572,8 +585,8 @@ class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_49(
+class _FakeWhoIsInfo_50 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -582,8 +595,8 @@ class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_50(
+class _FakeCapabilities_51 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -592,8 +605,8 @@ class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_51(
+class _FakeDevice_52 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -602,9 +615,9 @@ class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_53 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_52(
+  _FakeGetRoomIdByAliasResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -613,9 +626,9 @@ class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_53 extends _i1.SmartFake
+class _FakeGetEventsResponse_54 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_53(
+  _FakeGetEventsResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -624,9 +637,9 @@ class _FakeGetEventsResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_54 extends _i1.SmartFake
+class _FakePeekEventsResponse_55 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_54(
+  _FakePeekEventsResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -635,8 +648,8 @@ class _FakePeekEventsResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_55(
+class _FakeMatrixEvent_56 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -645,9 +658,9 @@ class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_57 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_56(
+  _FakeGetKeysChangesResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -656,9 +669,9 @@ class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_57 extends _i1.SmartFake
+class _FakeClaimKeysResponse_58 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_57(
+  _FakeClaimKeysResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -667,9 +680,9 @@ class _FakeClaimKeysResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_58 extends _i1.SmartFake
+class _FakeQueryKeysResponse_59 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_58(
+  _FakeQueryKeysResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -678,9 +691,9 @@ class _FakeQueryKeysResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_60 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_59(
+  _FakeGetNotificationsResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -689,9 +702,9 @@ class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_60 extends _i1.SmartFake
+class _FakeGetPresenceResponse_61 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_60(
+  _FakeGetPresenceResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -700,9 +713,9 @@ class _FakeGetPresenceResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_62 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_61(
+  _FakeGetPublicRoomsResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -711,9 +724,9 @@ class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_63 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_62(
+  _FakeQueryPublicRoomsResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -722,8 +735,8 @@ class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_63(
+class _FakePushRuleSet_64 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -732,9 +745,9 @@ class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_65 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_64(
+  _FakeGetPushRulesGlobalResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -743,8 +756,8 @@ class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_65(
+class _FakePushRule_66 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -753,9 +766,9 @@ class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_66 extends _i1.SmartFake
+class _FakeRefreshResponse_67 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_66(
+  _FakeRefreshResponse_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -764,8 +777,8 @@ class _FakeRefreshResponse_66 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_67(
+class _FakeRoomKeys_68 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -774,8 +787,8 @@ class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_68(
+class _FakeRoomKeyBackup_69 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -784,9 +797,9 @@ class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_70 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_69(
+  _FakeGetRoomKeysVersionCurrentResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -795,9 +808,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_71 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_70(
+  _FakeGetRoomKeysVersionResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -806,8 +819,8 @@ class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_71(
+class _FakeEventContext_72 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -816,9 +829,9 @@ class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_73 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_72(
+  _FakeGetRoomEventsResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -827,8 +840,8 @@ class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_73(
+class _FakeSearchResults_74 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -837,9 +850,9 @@ class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_75 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_74(
+  _FakeGetProtocolMetadataResponse$2_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -848,9 +861,9 @@ class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_75 extends _i1.SmartFake
+class _FakeOpenIdCredentials_76 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_75(
+  _FakeOpenIdCredentials_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -859,9 +872,9 @@ class _FakeOpenIdCredentials_75 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_77 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_76(
+  _FakeSearchUserDirectoryResponse_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -870,9 +883,9 @@ class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_77 extends _i1.SmartFake
+class _FakeCreateContentResponse_78 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_77(
+  _FakeCreateContentResponse_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -881,8 +894,8 @@ class _FakeCreateContentResponse_77 extends _i1.SmartFake
         );
 }
 
-class _FakeRoom_78 extends _i1.SmartFake implements _i4.Room {
-  _FakeRoom_78(
+class _FakeRoom_79 extends _i1.SmartFake implements _i4.Room {
+  _FakeRoom_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -891,8 +904,8 @@ class _FakeRoom_78 extends _i1.SmartFake implements _i4.Room {
         );
 }
 
-class _FakeMatrixFile_79 extends _i1.SmartFake implements _i4.MatrixFile {
-  _FakeMatrixFile_79(
+class _FakeMatrixFile_80 extends _i1.SmartFake implements _i4.MatrixFile {
+  _FakeMatrixFile_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -901,8 +914,8 @@ class _FakeMatrixFile_79 extends _i1.SmartFake implements _i4.MatrixFile {
         );
 }
 
-class _FakeEvent_80 extends _i1.SmartFake implements _i4.Event {
-  _FakeEvent_80(
+class _FakeEvent_81 extends _i1.SmartFake implements _i4.Event {
+  _FakeEvent_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -911,8 +924,8 @@ class _FakeEvent_80 extends _i1.SmartFake implements _i4.Event {
         );
 }
 
-class _FakeResponse_81 extends _i1.SmartFake implements _i12.Response {
-  _FakeResponse_81(
+class _FakeResponse_82 extends _i1.SmartFake implements _i13.Response {
+  _FakeResponse_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -924,7 +937,7 @@ class _FakeResponse_81 extends _i1.SmartFake implements _i12.Response {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -954,11 +967,11 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1031,43 +1044,56 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as _i7.SelectionService);
 
   @override
-  _i8.SyncService get sync => (super.noSuchMethod(
+  _i8.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_6(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_6(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i8.SpaceAccessService);
+
+  @override
+  _i9.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_6(
+        returnValue: _FakeSyncService_7(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_6(
+        returnValueForMissingStub: _FakeSyncService_7(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i8.SyncService);
+      ) as _i9.SyncService);
 
   @override
-  _i9.AuthService get auth => (super.noSuchMethod(
+  _i10.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_7(
+        returnValue: _FakeAuthService_8(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_7(
+        returnValueForMissingStub: _FakeAuthService_8(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i9.AuthService);
+      ) as _i10.AuthService);
 
   @override
-  _i10.OutboxService get outbox => (super.noSuchMethod(
+  _i11.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_8(
+        returnValue: _FakeOutboxService_9(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_8(
+        returnValueForMissingStub: _FakeOutboxService_9(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i10.OutboxService);
+      ) as _i11.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -1131,7 +1157,16 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set sync(_i8.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i8.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i9.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -1140,7 +1175,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set auth(_i9.AuthService? value) => super.noSuchMethod(
+  set auth(_i10.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -1149,7 +1184,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  set outbox(_i10.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i11.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -1165,14 +1200,14 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as bool);
 
   @override
-  _i13.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1202,7 +1237,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1212,18 +1247,18 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<bool> login({
+  _i14.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
@@ -1238,12 +1273,12 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
             #password: password,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> completeSsoLogin({
+  _i14.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1256,12 +1291,12 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> completeRegistration(
+  _i14.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1271,32 +1306,32 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1305,7 +1340,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1314,17 +1349,17 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1335,7 +1370,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1372,26 +1407,26 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+  _i14.Future<bool> didPushRouteInformation(
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1421,7 +1456,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1430,7 +1465,7 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1439,16 +1474,16 @@ class MockMatrixService extends _i1.Mock implements _i15.MatrixService {
       );
 
   @override
-  _i13.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i14.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i13.Future<_i17.AppExitResponse>);
+            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i14.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1476,11 +1511,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1510,11 +1545,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_9(
+        returnValue: _FakeRoomSummary_10(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_9(
+        returnValueForMissingStub: _FakeRoomSummary_10(
           this,
           Invocation.getter(#summary),
         ),
@@ -1544,11 +1579,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i13.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i14.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i13.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i13.Completer<dynamic>>[],
-      ) as List<_i13.Completer<dynamic>>);
+        returnValue: <_i14.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i14.Completer<dynamic>>[],
+      ) as List<_i14.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1567,51 +1602,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i11.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i12.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_10<String>(
+        returnValue: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i11.CachedStreamController<String> get onSessionKeyReceived =>
+  _i12.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_10<String>(
+        returnValue: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1627,11 +1662,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1640,11 +1675,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1687,11 +1722,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1700,11 +1735,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_11(
+        returnValue: _FakeDateTime_12(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_11(
+        returnValueForMissingStub: _FakeDateTime_12(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -1734,11 +1769,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_12(
+        returnValue: _FakeLatestReceiptState_13(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_12(
+        returnValueForMissingStub: _FakeLatestReceiptState_13(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -1759,22 +1794,29 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i13.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i14.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
         Invocation.getter(#isFavourite),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
@@ -1950,18 +1992,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i20.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i20.SpaceParent>[],
-        returnValueForMissingStub: <_i20.SpaceParent>[],
-      ) as List<_i20.SpaceParent>);
+        returnValue: <_i21.SpaceParent>[],
+        returnValueForMissingStub: <_i21.SpaceParent>[],
+      ) as List<_i21.SpaceParent>);
 
   @override
-  List<_i20.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i20.SpaceChild>[],
-        returnValueForMissingStub: <_i20.SpaceChild>[],
-      ) as List<_i20.SpaceChild>);
+        returnValue: <_i21.SpaceChild>[],
+        returnValueForMissingStub: <_i21.SpaceChild>[],
+      ) as List<_i21.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -2074,14 +2116,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i13.Future<void> postLoad() => (super.noSuchMethod(
+  _i14.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -2109,15 +2151,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i13.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i14.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i13.Future<List<_i4.User>>);
+            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i14.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -2128,14 +2170,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2145,18 +2187,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i13.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i14.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Event?> refreshLastEvent(
+  _i14.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2164,9 +2206,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -2178,12 +2220,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i13.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i14.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2191,22 +2233,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i14.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2214,17 +2256,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> addTag(
+  _i14.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2234,27 +2276,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i14.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i14.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2262,43 +2304,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i14.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i14.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i14.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
+        ),
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
+
+  @override
+  _i14.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2306,14 +2358,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2325,7 +2377,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i13.Future<String?> sendTextEvent(
+  _i14.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2357,12 +2409,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendReaction(
+  _i14.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2376,12 +2428,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendLocation(
+  _i14.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2395,12 +2447,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> sendFileEvent(
+  _i14.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2428,25 +2480,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i14.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i13.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i14.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i13.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i14.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i13.Future<_i4.EncryptionHealthState>);
+      ) as _i14.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i13.Future<String?> sendEvent(
+  _i14.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -2470,73 +2522,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i14.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> leave() => (super.noSuchMethod(
+  _i14.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> forget() => (super.noSuchMethod(
+  _i14.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> setPower(
+  _i14.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2548,7 +2600,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2559,7 +2611,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2569,10 +2621,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> invite(
+  _i14.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2582,12 +2634,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<int> requestHistory({
+  _i14.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -2604,32 +2656,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<int>.value(0),
-        returnValueForMissingStub: _i13.Future<int>.value(0),
-      ) as _i13.Future<int>);
+        returnValue: _i14.Future<int>.value(0),
+        returnValueForMissingStub: _i14.Future<int>.value(0),
+      ) as _i14.Future<int>);
 
   @override
-  _i13.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i14.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i14.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setReadMarker(
+  _i14.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2643,23 +2695,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i21.TimelineChunk?> getEventContext(String? eventId) =>
+  _i14.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i13.Future<_i21.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i13.Future<_i21.TimelineChunk?>.value(),
-      ) as _i13.Future<_i21.TimelineChunk?>);
+        returnValue: _i14.Future<_i22.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i14.Future<_i22.TimelineChunk?>.value(),
+      ) as _i14.Future<_i22.TimelineChunk?>);
 
   @override
-  _i13.Future<void> postReceipt(
+  _i14.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -2669,12 +2721,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Timeline> getTimeline({
+  _i14.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2697,7 +2749,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i13.Future<_i4.Timeline>.value(_FakeTimeline_14(
+        returnValue: _i14.Future<_i4.Timeline>.value(_FakeTimeline_15(
           this,
           Invocation.method(
             #getTimeline,
@@ -2714,7 +2766,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Timeline>.value(_FakeTimeline_14(
+            _i14.Future<_i4.Timeline>.value(_FakeTimeline_15(
           this,
           Invocation.method(
             #getTimeline,
@@ -2730,7 +2782,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Timeline>);
+      ) as _i14.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -2749,7 +2801,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i13.Future<List<_i4.User>> requestParticipants([
+  _i14.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -2767,10 +2819,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i13.Future<List<_i4.User>>);
+            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i14.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -2778,14 +2830,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_15(
+        returnValue: _FakeUser_16(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_15(
+        returnValueForMissingStub: _FakeUser_16(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -2801,14 +2853,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_15(
+        returnValue: _FakeUser_16(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_15(
+        returnValueForMissingStub: _FakeUser_16(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -2818,7 +2870,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i13.Future<_i4.User?> requestUser(
+  _i14.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2834,19 +2886,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i13.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.User?>.value(),
-      ) as _i13.Future<_i4.User?>);
+        returnValue: _i14.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.User?>.value(),
+      ) as _i14.Future<_i4.User?>);
 
   @override
-  _i13.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i14.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2859,12 +2911,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i13.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i14.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2872,14 +2924,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2902,14 +2954,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i13.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i14.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -2948,18 +3000,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i13.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i14.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEvent(
+  _i14.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -2973,12 +3025,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> setTyping(
+  _i14.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -2988,12 +3040,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setJoinRules(
+  _i14.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -3007,59 +3059,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i14.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setHistoryVisibility(
+  _i14.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i14.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i14.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i13.Future<List<_i4.DeviceKeys>>);
+            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i14.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i13.Future<void> requestSessionKey(
+  _i14.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -3071,12 +3123,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setSpaceChild(
+  _i14.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3092,44 +3144,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i14.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i13.Future<Uri>.value(_FakeUri_16(
+        returnValue: _i14.Future<Uri>.value(_FakeUri_17(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_16(
+        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_17(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i13.Future<Uri>);
+      ) as _i14.Future<Uri>);
 
   @override
-  _i13.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i14.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<
+  _i14.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -3156,21 +3208,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i13.Future<
+        returnValue: _i14.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i13.Future<
+        returnValueForMissingStub: _i14.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i13.Future<
+      ) as _i14.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -3185,23 +3237,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_17(
+        returnValue: _FakeDatabaseApi_18(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_17(
+        returnValueForMissingStub: _FakeDatabaseApi_18(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i22.KeyVerificationMethod> get verificationMethods =>
+  Set<_i23.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i22.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i22.KeyVerificationMethod>{},
-      ) as Set<_i22.KeyVerificationMethod>);
+        returnValue: <_i23.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i23.KeyVerificationMethod>{},
+      ) as Set<_i23.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3262,11 +3314,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_18(
+        returnValue: _FakeFilter_19(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_18(
+        returnValueForMissingStub: _FakeFilter_19(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -3275,11 +3327,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_19(
+        returnValue: _FakeNativeImplementations_20(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_19(
+        returnValueForMissingStub: _FakeNativeImplementations_20(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -3295,11 +3347,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_20(
+        returnValue: _FakeDuration_21(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_20(
+        returnValueForMissingStub: _FakeDuration_21(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3308,11 +3360,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_20(
+        returnValue: _FakeDuration_21(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_20(
+        returnValueForMissingStub: _FakeDuration_21(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3321,11 +3373,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -3362,11 +3414,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3396,11 +3448,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3409,11 +3461,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3436,11 +3488,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_21(
+        returnValue: _FakePushruleEvaluator_22(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_21(
+        returnValueForMissingStub: _FakePushruleEvaluator_22(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -3461,332 +3513,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i13.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i14.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i11.CachedStreamController<String> get onUserProfileUpdate =>
+  _i12.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_10<String>(
+        returnValue: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i13.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i14.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i13.Future<List<_i4.Room>>);
+            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i14.Future<List<_i4.Room>>);
 
   @override
-  _i11.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i12.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_10<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_11<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.EventUpdate>(
+            _FakeCachedStreamController_11<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.EventUpdate>);
+      ) as _i12.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i12.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_10<_i4.Event>(
+        returnValue: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i12.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_10<_i4.Event>(
+        returnValue: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onNotification =>
+  _i12.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_10<_i4.Event>(
+        returnValue: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i12.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_10<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_11<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_11<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i11.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i12.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i11.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i12.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_10<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_11<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_10<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_11<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i11.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i12.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i11.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i12.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_10<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_11<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.LoginState>(
+            _FakeCachedStreamController_11<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i11.CachedStreamController<_i4.LoginState>);
+      ) as _i12.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i11.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i12.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_10<bool>(
+        returnValue: _FakeCachedStreamController_11<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i11.CachedStreamController<bool>);
+      ) as _i12.CachedStreamController<bool>);
 
   @override
-  _i11.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i12.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_10<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_11<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i11.CachedStreamController<_i4.SdkError>);
+      ) as _i12.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i11.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i12.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_10<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_11<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.SyncUpdate>(
+            _FakeCachedStreamController_11<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i11.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i12.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i12.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_10<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_11<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_11<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i11.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i12.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i11.CachedStreamController<_i4.Presence> get onPresence =>
+  _i12.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_10<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_11<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i11.CachedStreamController<_i4.Presence>);
+      ) as _i12.CachedStreamController<_i4.Presence>);
 
   @override
-  _i11.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i12.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_10<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_11<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.CachedPresence>(
+            _FakeCachedStreamController_11<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i11.CachedStreamController<_i4.CachedPresence>);
+      ) as _i12.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i11.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i12.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_10<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_11<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.BasicEvent>(
+            _FakeCachedStreamController_11<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i11.CachedStreamController<_i4.BasicEvent>);
+      ) as _i12.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i11.CachedStreamController<_i22.RoomKeyRequest> get onRoomKeyRequest =>
+  _i12.CachedStreamController<_i23.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_10<_i22.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_11<_i23.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i22.RoomKeyRequest>(
+            _FakeCachedStreamController_11<_i23.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i11.CachedStreamController<_i22.RoomKeyRequest>);
+      ) as _i12.CachedStreamController<_i23.RoomKeyRequest>);
 
   @override
-  _i11.CachedStreamController<_i22.KeyVerification>
+  _i12.CachedStreamController<_i23.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_10<_i22.KeyVerification>(
+            returnValue: _FakeCachedStreamController_11<_i23.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_10<_i22.KeyVerification>(
+                _FakeCachedStreamController_11<_i23.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i11.CachedStreamController<_i22.KeyVerification>);
+          ) as _i12.CachedStreamController<_i23.KeyVerification>);
 
   @override
-  _i11.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i12.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_10<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_11<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_10<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_11<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i11.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i12.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i11.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i12.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_10<_i4.Event>(
+        returnValue: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i11.CachedStreamController<_i4.Event>);
+      ) as _i12.CachedStreamController<_i4.Event>);
 
   @override
-  _i11.CachedStreamController<String> get onCancelSendEvent =>
+  _i12.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_10<String>(
+        returnValue: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_10<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i11.CachedStreamController<String>);
+      ) as _i12.CachedStreamController<String>);
 
   @override
-  _i11.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i12.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_10<
+            returnValue: _FakeCachedStreamController_11<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_10<
+            returnValueForMissingStub: _FakeCachedStreamController_11<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i11.CachedStreamController<
+          ) as _i12.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -3806,11 +3858,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_11(
+        returnValue: _FakeDateTime_12(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_11(
+        returnValueForMissingStub: _FakeDateTime_12(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3883,7 +3935,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i22.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i23.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3938,7 +3990,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i13.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i14.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -3949,7 +4001,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i13.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i14.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -4060,7 +4112,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -4069,7 +4121,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -4078,7 +4130,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i13.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i14.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4105,20 +4157,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i12.Client get httpClient => (super.noSuchMethod(
+  _i13.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_23(
+        returnValue: _FakeClient_24(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_23(
+        returnValueForMissingStub: _FakeClient_24(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i12.Client);
+      ) as _i13.Client);
 
   @override
-  set httpClient(_i12.Client? value) => super.noSuchMethod(
+  set httpClient(_i13.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4145,7 +4197,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<void> refreshAccessToken(
+  _i14.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4153,9 +4205,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4173,14 +4225,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4217,33 +4269,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i13.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i14.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i13.Future<_i4.DiscoveryInformation>);
+      ) as _i14.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i13.Future<
+  _i14.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -4265,7 +4317,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i13.Future<
+        returnValue: _i14.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4273,7 +4325,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_25(
+          _FakeGetVersionsResponse_26(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4288,7 +4340,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i13.Future<
+        returnValueForMissingStub: _i14.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4296,7 +4348,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_25(
+          _FakeGetVersionsResponse_26(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4311,7 +4363,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i13.Future<
+      ) as _i14.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -4320,7 +4372,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i13.Future<_i4.DiscoveryInformation> getWellknown({
+  _i14.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4333,8 +4385,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getWellknown,
@@ -4345,8 +4397,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_24(
+        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_25(
           this,
           Invocation.method(
             #getWellknown,
@@ -4357,10 +4409,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.DiscoveryInformation>);
+      ) as _i14.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i13.Future<_i4.RegisterResponse> register({
+  _i14.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -4388,7 +4440,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
+            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
           this,
           Invocation.method(
             #register,
@@ -4407,7 +4459,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_26(
+            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
           this,
           Invocation.method(
             #register,
@@ -4425,10 +4477,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RegisterResponse>);
+      ) as _i14.Future<_i4.RegisterResponse>);
 
   @override
-  _i13.Future<_i4.LoginResponse> login(
+  _i14.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -4458,7 +4510,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
+        returnValue: _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
           this,
           Invocation.method(
             #login,
@@ -4478,7 +4530,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.LoginResponse>.value(_FakeLoginResponse_27(
+            _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
           this,
           Invocation.method(
             #login,
@@ -4497,10 +4549,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.LoginResponse>);
+      ) as _i14.Future<_i4.LoginResponse>);
 
   @override
-  _i13.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i14.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4513,8 +4565,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_28(
+        returnValue: _i14.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_29(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4526,8 +4578,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_28(
+            _i14.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_29(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4538,74 +4590,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i14.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i13.Future<void> logout() => (super.noSuchMethod(
+  _i14.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> logoutAll() => (super.noSuchMethod(
+  _i14.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<T> uiaRequestBackground<T>(
-          _i13.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i14.Future<T> uiaRequestBackground<T>(
+          _i14.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i13.Future<T>.value(v),
+              (T v) => _i14.Future<T>.value(v),
             ) ??
-            _FakeFuture_29<T>(
+            _FakeFuture_30<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i13.Future<T>.value(v),
+              (T v) => _i14.Future<T>.value(v),
             ) ??
-            _FakeFuture_29<T>(
+            _FakeFuture_30<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i13.Future<T>);
+      ) as _i14.Future<T>);
 
   @override
-  _i13.Future<String> startDirectChat(
+  _i14.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -4627,7 +4679,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4643,7 +4695,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4658,10 +4710,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<String> createGroupChat({
+  _i14.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -4692,7 +4744,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4713,7 +4765,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4733,10 +4785,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i14.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4752,7 +4804,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4765,7 +4817,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4777,21 +4829,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i14.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<String> createSpace({
+  _i14.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -4816,7 +4868,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4834,7 +4886,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4851,10 +4903,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i14.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4862,7 +4914,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4871,7 +4923,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4879,10 +4931,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i13.Future<_i4.Profile> fetchOwnProfile({
+  _i14.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4895,7 +4947,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4907,7 +4959,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4918,10 +4970,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
-  _i13.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i14.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4935,8 +4987,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i13.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_30(
+        returnValue: _i14.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_31(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4948,8 +5000,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_30(
+            _i14.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_31(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4960,10 +5012,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.CachedProfileInformation>);
+      ) as _i14.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i13.Future<_i4.Profile> getProfileFromUserId(
+  _i14.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -4981,7 +5033,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4995,7 +5047,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Profile>.value(_FakeProfile_22(
+            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -5008,7 +5060,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.Profile>);
+      ) as _i14.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -5030,31 +5082,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i13.Future<List<_i4.Room>>);
+            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i14.Future<List<_i4.Room>>);
 
   @override
-  _i13.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i14.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i13.Future<List<_i4.ArchivedRoom>>);
+            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i14.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i13.Future<_i4.GetVersionsResponse> getVersions({
+  _i14.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5067,8 +5119,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_25(
+        returnValue: _i14.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_26(
           this,
           Invocation.method(
             #getVersions,
@@ -5079,8 +5131,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_25(
+        returnValueForMissingStub: _i14.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_26(
           this,
           Invocation.method(
             #getVersions,
@@ -5091,20 +5143,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetVersionsResponse>);
+      ) as _i14.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i13.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i14.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<_i4.MediaConfig> getConfig({
+  _i14.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5117,7 +5169,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
+        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
           this,
           Invocation.method(
             #getConfig,
@@ -5129,7 +5181,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
+            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
           this,
           Invocation.method(
             #getConfig,
@@ -5140,10 +5192,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.MediaConfig>);
+      ) as _i14.Future<_i4.MediaConfig>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContent(
+  _i14.Future<_i15.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5163,7 +5215,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContent,
@@ -5179,7 +5231,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContent,
@@ -5194,10 +5246,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentOverrideName(
+  _i14.Future<_i15.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5219,7 +5271,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5236,7 +5288,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5252,10 +5304,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentThumbnail(
+  _i14.Future<_i15.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5283,7 +5335,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5303,7 +5355,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5322,10 +5374,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i14.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5335,7 +5387,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
+        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5344,7 +5396,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
+            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5352,11 +5404,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i13.Future<_i4.PreviewForUrl>);
+      ) as _i14.Future<_i4.PreviewForUrl>);
 
   @override
-  _i13.Future<Uri> uploadContent(
-    _i23.Uint8List? file, {
+  _i14.Future<Uri> uploadContent(
+    _i24.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5369,7 +5421,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i13.Future<Uri>.value(_FakeUri_16(
+        returnValue: _i14.Future<Uri>.value(_FakeUri_17(
           this,
           Invocation.method(
             #uploadContent,
@@ -5380,7 +5432,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<Uri>.value(_FakeUri_16(
+        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_17(
           this,
           Invocation.method(
             #uploadContent,
@@ -5391,10 +5443,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<Uri>);
+      ) as _i14.Future<Uri>);
 
   @override
-  _i13.Future<void> setTyping(
+  _i14.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5410,42 +5462,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> exportDump() => (super.noSuchMethod(
+  _i14.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i14.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i14.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Event?> getEventByPushNotification(
+  _i14.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -5461,12 +5513,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
-  _i13.Future<void> init({
+  _i14.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5501,9 +5553,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5515,40 +5567,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Future<void> clear() => (super.noSuchMethod(
+  _i14.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i14.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ensureNotSoftLoggedOut(
+  _i14.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> handleSync(
+  _i14.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -5558,9 +5610,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -5573,29 +5625,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i13.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i14.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i14.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDevice(
+  _i14.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5609,12 +5661,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDevicesOfUserIds(
+  _i14.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5630,12 +5682,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDeviceEncrypted(
+  _i14.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5655,12 +5707,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> sendToDeviceEncryptedChunked(
+  _i14.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -5674,23 +5726,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i14.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> joinRoom(
+  _i14.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -5708,7 +5760,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5722,7 +5774,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5735,10 +5787,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> changePassword(
+  _i14.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -5754,22 +5806,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> clearCache() => (super.noSuchMethod(
+  _i14.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ignoreUser(
+  _i14.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5779,22 +5831,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i14.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i14.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5805,7 +5857,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5814,7 +5866,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5822,32 +5874,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i13.Future<_i4.CachedPresence>);
+      ) as _i14.Future<_i4.CachedPresence>);
 
   @override
-  _i13.Future<void> abortSync() => (super.noSuchMethod(
+  _i14.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i14.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEventWithMetadata(
+  _i14.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5867,14 +5919,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i12.BaseResponse? response,
-    _i23.Uint8List? body,
+    _i13.BaseResponse? response,
+    _i24.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5906,7 +5958,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i13.Future<Map<String, Object?>> request(
+  _i14.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -5927,13 +5979,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> postPusher(
+  _i14.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -5943,57 +5995,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i14.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i14.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i14.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i13.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_35(
+        returnValue: _i14.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_36(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_35(
+        returnValueForMissingStub: _i14.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_36(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.TurnServerCredentials>);
+      ) as _i14.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6007,8 +6059,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6020,8 +6072,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6032,10 +6084,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6051,8 +6103,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6065,8 +6117,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6078,10 +6130,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i14.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6095,7 +6147,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6107,7 +6159,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6118,17 +6170,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.KeyBackupData>);
+      ) as _i14.Future<_i4.KeyBackupData>);
 
   @override
-  _i13.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i14.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i13.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_38(
+        returnValue: _i14.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_39(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6136,18 +6188,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_38(
+            _i14.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_39(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i14.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i13.Future<int> pingAppservice(
+  _i14.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6157,12 +6209,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i13.Future<int>.value(0),
-        returnValueForMissingStub: _i13.Future<int>.value(0),
-      ) as _i13.Future<int>);
+        returnValue: _i14.Future<int>.value(0),
+        returnValueForMissingStub: _i14.Future<int>.value(0),
+      ) as _i14.Future<int>);
 
   @override
-  _i13.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i14.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6170,8 +6222,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_39(
+        returnValue: _i14.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_40(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6180,8 +6232,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_39(
+            _i14.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_40(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6189,15 +6241,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i13.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i14.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i13.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i14.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
+        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6205,17 +6257,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
+            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.MediaConfig>);
+      ) as _i14.Future<_i4.MediaConfig>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentAuthed(
+  _i14.Future<_i15.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6229,7 +6281,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6241,7 +6293,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6252,10 +6304,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentOverrideNameAuthed(
+  _i14.Future<_i15.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6271,7 +6323,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6284,7 +6336,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6296,10 +6348,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i14.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6309,7 +6361,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
+        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6318,7 +6370,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
+            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6326,10 +6378,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i13.Future<_i4.PreviewForUrl>);
+      ) as _i14.Future<_i4.PreviewForUrl>);
 
   @override
-  _i13.Future<_i14.FileResponse> getContentThumbnailAuthed(
+  _i14.Future<_i15.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -6353,7 +6405,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6371,7 +6423,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i14.FileResponse>.value(_FakeFileResponse_32(
+            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6388,21 +6440,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i14.FileResponse>);
+      ) as _i14.Future<_i15.FileResponse>);
 
   @override
-  _i13.Future<bool> registrationTokenValidity(String? token) =>
+  _i14.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i14.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6412,8 +6464,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_40(
+        returnValue: _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_41(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6422,8 +6474,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_40(
+            _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_41(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6431,10 +6483,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i14.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i13.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i14.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6452,8 +6504,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_41(
+        returnValue: _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_42(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6467,8 +6519,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_41(
+            _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_42(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6481,10 +6533,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i14.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i14.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -6508,8 +6560,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i13.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_42(
+        returnValue: _i14.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_43(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6527,8 +6579,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_42(
+            _i14.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_43(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6545,10 +6597,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i14.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6576,8 +6628,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_43(
+                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6596,8 +6648,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_43(
+                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6615,10 +6667,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i13.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i13.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i14.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6647,9 +6699,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i13.Future<
+            returnValue: _i14.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6668,9 +6720,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i13.Future<
+            returnValueForMissingStub: _i14.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6689,11 +6741,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i13
+          ) as _i14
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i13.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i14.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -6709,8 +6761,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i13.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_45(
+        returnValue: _i14.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_46(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6723,8 +6775,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_45(
+            _i14.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_46(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6736,10 +6788,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetThreadRootsResponse>);
+      ) as _i14.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i13.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i14.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -6753,8 +6805,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i13.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_46(
+        returnValue: _i14.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_47(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6766,8 +6818,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_46(
+            _i14.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_47(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6778,33 +6830,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i14.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i14.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i13.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i14.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i13.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i14.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i13.Future<Uri?>.value(),
-        returnValueForMissingStub: _i13.Future<Uri?>.value(),
-      ) as _i13.Future<Uri?>);
+        returnValue: _i14.Future<Uri?>.value(),
+        returnValueForMissingStub: _i14.Future<Uri?>.value(),
+      ) as _i14.Future<Uri?>);
 
   @override
-  _i13.Future<void> add3PID(
+  _i14.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -6818,12 +6870,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> bind3PID(
+  _i14.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6839,12 +6891,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i14.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6858,14 +6910,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6887,8 +6939,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6904,8 +6956,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6921,10 +6973,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6948,8 +7000,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6966,8 +7018,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6984,10 +7036,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i14.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -7001,14 +7053,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i14.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -7023,14 +7075,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i13.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i13.Future<_i4.IdServerUnbindResult>);
+      ) as _i14.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7052,8 +7104,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7069,8 +7121,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7086,10 +7138,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7113,8 +7165,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7131,8 +7183,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7149,16 +7201,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i14.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
+            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7166,22 +7218,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
+            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.TokenOwnerInfo>);
+      ) as _i14.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i13.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i14.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
+        returnValue: _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7189,22 +7241,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
+            _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i13.Future<_i4.WhoIsInfo>);
+      ) as _i14.Future<_i4.WhoIsInfo>);
 
   @override
-  _i13.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i14.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
+        returnValue: _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7212,17 +7264,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
+            _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.Capabilities>);
+      ) as _i14.Future<_i4.Capabilities>);
 
   @override
-  _i13.Future<String> createRoom({
+  _i14.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -7255,7 +7307,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7277,7 +7329,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7298,10 +7350,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> deleteDevices(
+  _i14.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7311,22 +7363,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.Device>?>.value(),
-      ) as _i13.Future<List<_i4.Device>?>);
+        returnValue: _i14.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.Device>?>.value(),
+      ) as _i14.Future<List<_i4.Device>?>);
 
   @override
-  _i13.Future<void> deleteDevice(
+  _i14.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7336,34 +7388,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i14.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i13.Future<_i4.Device>.value(_FakeDevice_51(
+        returnValue: _i14.Future<_i4.Device>.value(_FakeDevice_52(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.Device>.value(_FakeDevice_51(
+        returnValueForMissingStub: _i14.Future<_i4.Device>.value(_FakeDevice_52(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i13.Future<_i4.Device>);
+      ) as _i14.Future<_i4.Device>);
 
   @override
-  _i13.Future<void> updateDevice(
+  _i14.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7373,12 +7425,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i14.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -7393,24 +7445,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i14.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i13.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Visibility?>.value(),
-      ) as _i13.Future<_i4.Visibility?>);
+        returnValue: _i14.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Visibility?>.value(),
+      ) as _i14.Future<_i4.Visibility?>);
 
   @override
-  _i13.Future<void> setRoomVisibilityOnDirectory(
+  _i14.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -7420,30 +7472,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i14.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i14.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_52(
+        returnValue: _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_53(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7451,18 +7503,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_52(
+            _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_53(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i14.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i13.Future<void> setRoomAlias(
+  _i14.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7474,12 +7526,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetEventsResponse> getEvents({
+  _i14.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7493,7 +7545,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
+            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
           this,
           Invocation.method(
             #getEvents,
@@ -7505,7 +7557,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
+            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
           this,
           Invocation.method(
             #getEvents,
@@ -7516,10 +7568,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetEventsResponse>);
+      ) as _i14.Future<_i4.GetEventsResponse>);
 
   @override
-  _i13.Future<_i4.PeekEventsResponse> peekEvents({
+  _i14.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7534,8 +7586,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i13.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_54(
+        returnValue: _i14.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_55(
           this,
           Invocation.method(
             #peekEvents,
@@ -7547,8 +7599,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_54(
+        returnValueForMissingStub: _i14.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_55(
           this,
           Invocation.method(
             #peekEvents,
@@ -7560,16 +7612,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.PeekEventsResponse>);
+      ) as _i14.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i13.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i14.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7577,27 +7629,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i13.Future<_i4.MatrixEvent>);
+      ) as _i14.Future<_i4.MatrixEvent>);
 
   @override
-  _i13.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i14.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i13.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
-      ) as _i13.Future<List<String>>);
+        returnValue: _i14.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
+      ) as _i14.Future<List<String>>);
 
   @override
-  _i13.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i14.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7609,8 +7661,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i13.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_56(
+        returnValue: _i14.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_57(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7621,8 +7673,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_56(
+            _i14.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_57(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7632,10 +7684,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.GetKeysChangesResponse>);
+      ) as _i14.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i13.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i14.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7646,7 +7698,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
+            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
           this,
           Invocation.method(
             #claimKeys,
@@ -7655,7 +7707,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
+            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
           this,
           Invocation.method(
             #claimKeys,
@@ -7663,10 +7715,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i13.Future<_i4.ClaimKeysResponse>);
+      ) as _i14.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i13.Future<void> uploadCrossSigningKeys({
+  _i14.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -7683,12 +7735,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.QueryKeysResponse> queryKeys(
+  _i14.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7699,7 +7751,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
+            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
           this,
           Invocation.method(
             #queryKeys,
@@ -7708,7 +7760,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
+            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
           this,
           Invocation.method(
             #queryKeys,
@@ -7716,10 +7768,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i13.Future<_i4.QueryKeysResponse>);
+      ) as _i14.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7727,14 +7779,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i13.Future<
+            returnValue: _i14.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i13.Future<
+            returnValueForMissingStub: _i14.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i13.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i13.Future<Map<String, int>> uploadKeys({
+  _i14.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -7749,13 +7801,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i13.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i14.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i13.Future<Map<String, int>>);
+            _i14.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i14.Future<Map<String, int>>);
 
   @override
-  _i13.Future<String> knockRoom(
+  _i14.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7769,7 +7821,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7781,7 +7833,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7792,20 +7844,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i14.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i13.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i14.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i14.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i13.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i14.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7820,8 +7872,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i13.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_59(
+        returnValue: _i14.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_60(
           this,
           Invocation.method(
             #getNotifications,
@@ -7834,8 +7886,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_59(
+            _i14.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_60(
           this,
           Invocation.method(
             #getNotifications,
@@ -7847,35 +7899,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetNotificationsResponse>);
+      ) as _i14.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i13.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i14.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i13.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_60(
+        returnValue: _i14.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_61(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_60(
+        returnValueForMissingStub: _i14.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_61(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i13.Future<_i4.GetPresenceResponse>);
+      ) as _i14.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i13.Future<void> setPresence(
+  _i14.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -7889,12 +7941,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, Object?>> deleteProfileField(
+  _i14.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7907,13 +7959,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getProfileField(
+  _i14.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7926,13 +7978,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<Map<String, Object?>> setProfileField(
+  _i14.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7947,13 +7999,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i14.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -7968,8 +8020,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i13.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_61(
+        returnValue: _i14.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_62(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7982,8 +8034,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_61(
+            _i14.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_62(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7995,10 +8047,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i14.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i13.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i14.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -8019,8 +8071,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i13.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_62(
+        returnValue: _i14.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_63(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8036,8 +8088,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_62(
+            _i14.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_63(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8052,25 +8104,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i14.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i13.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i14.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i13.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.Pusher>?>.value(),
-      ) as _i13.Future<List<_i4.Pusher>?>);
+        returnValue: _i14.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.Pusher>?>.value(),
+      ) as _i14.Future<List<_i4.Pusher>?>);
 
   @override
-  _i13.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i14.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
+        returnValue: _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
           this,
           Invocation.method(
             #getPushRules,
@@ -8078,24 +8130,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
+            _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.PushRuleSet>);
+      ) as _i14.Future<_i4.PushRuleSet>);
 
   @override
-  _i13.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i14.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_64(
+        returnValue: _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_65(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8103,18 +8155,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_64(
+            _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_65(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i14.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i13.Future<void> deletePushRule(
+  _i14.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8126,12 +8178,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.PushRule> getPushRule(
+  _i14.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8143,7 +8195,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<_i4.PushRule>.value(_FakePushRule_65(
+        returnValue: _i14.Future<_i4.PushRule>.value(_FakePushRule_66(
           this,
           Invocation.method(
             #getPushRule,
@@ -8154,7 +8206,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.PushRule>.value(_FakePushRule_65(
+            _i14.Future<_i4.PushRule>.value(_FakePushRule_66(
           this,
           Invocation.method(
             #getPushRule,
@@ -8164,10 +8216,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.PushRule>);
+      ) as _i14.Future<_i4.PushRule>);
 
   @override
-  _i13.Future<void> setPushRule(
+  _i14.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -8191,12 +8243,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<Object?>> getPushRuleActions(
+  _i14.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8208,13 +8260,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i14.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i13.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i13.Future<List<Object?>>);
+            _i14.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i14.Future<List<Object?>>);
 
   @override
-  _i13.Future<void> setPushRuleActions(
+  _i14.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -8228,12 +8280,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<bool> isPushRuleEnabled(
+  _i14.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8245,12 +8297,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> setPushRuleEnabled(
+  _i14.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -8264,19 +8316,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i14.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
+            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
           this,
           Invocation.method(
             #refresh,
@@ -8284,28 +8336,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
+            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i13.Future<_i4.RefreshResponse>);
+      ) as _i14.Future<_i4.RefreshResponse>);
 
   @override
-  _i13.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i14.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i13.Future<bool?>.value(),
-        returnValueForMissingStub: _i13.Future<bool?>.value(),
-      ) as _i13.Future<bool?>);
+        returnValue: _i14.Future<bool?>.value(),
+        returnValueForMissingStub: _i14.Future<bool?>.value(),
+      ) as _i14.Future<bool?>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8327,8 +8379,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8344,8 +8396,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8361,10 +8413,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8388,8 +8440,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8406,8 +8458,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8424,17 +8476,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.RequestTokenResponse>);
+      ) as _i14.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8442,23 +8494,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i14.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
+        returnValue: _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8466,17 +8518,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
+            _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeys>);
+      ) as _i14.Future<_i4.RoomKeys>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -8488,8 +8540,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8500,8 +8552,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8511,10 +8563,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8526,8 +8578,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8538,8 +8590,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8549,10 +8601,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8564,7 +8616,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
+        returnValue: _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8575,7 +8627,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
+            _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8585,10 +8637,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeyBackup>);
+      ) as _i14.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -8602,8 +8654,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8615,8 +8667,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8627,10 +8679,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8644,8 +8696,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8657,8 +8709,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8669,10 +8721,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i14.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8686,7 +8738,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8698,7 +8750,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8709,10 +8761,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.KeyBackupData>);
+      ) as _i14.Future<_i4.KeyBackupData>);
 
   @override
-  _i13.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8728,8 +8780,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8742,8 +8794,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8755,18 +8807,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_69(
+                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_70(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8774,18 +8826,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_69(
+                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_70(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i13.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i13.Future<String> postRoomKeysVersion(
+  _i14.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -8797,7 +8849,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8808,7 +8860,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8818,29 +8870,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i14.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i14.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_70(
+        returnValue: _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_71(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8848,18 +8900,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_70(
+            _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_71(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i14.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i14.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -8874,24 +8926,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i14.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i13.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i13.Future<List<String>>.value(<String>[]),
-      ) as _i13.Future<List<String>>);
+        returnValue: _i14.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
+      ) as _i14.Future<List<String>>);
 
   @override
-  _i13.Future<void> ban(
+  _i14.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8905,12 +8957,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.EventContext> getEventContext(
+  _i14.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -8928,7 +8980,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<_i4.EventContext>.value(_FakeEventContext_71(
+        returnValue: _i14.Future<_i4.EventContext>.value(_FakeEventContext_72(
           this,
           Invocation.method(
             #getEventContext,
@@ -8943,7 +8995,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.EventContext>.value(_FakeEventContext_71(
+            _i14.Future<_i4.EventContext>.value(_FakeEventContext_72(
           this,
           Invocation.method(
             #getEventContext,
@@ -8957,10 +9009,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.EventContext>);
+      ) as _i14.Future<_i4.EventContext>);
 
   @override
-  _i13.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i14.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -8972,7 +9024,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8983,7 +9035,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8993,20 +9045,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.MatrixEvent>);
+      ) as _i14.Future<_i4.MatrixEvent>);
 
   @override
-  _i13.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i14.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> inviteBy3PID(
+  _i14.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -9018,12 +9070,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> inviteUser(
+  _i14.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9037,12 +9089,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> joinRoomById(
+  _i14.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -9056,7 +9108,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9068,7 +9120,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9079,23 +9131,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i14.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i13.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i14.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i13.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i13.Future<Map<String, _i4.RoomMember>?>);
+            _i14.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i14.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i13.Future<void> kick(
+  _i14.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9109,12 +9161,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> leaveRoom(
+  _i14.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9124,12 +9176,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i14.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -9145,12 +9197,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i13.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i13.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i13.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i14.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i14.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i14.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i13.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i14.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -9172,8 +9224,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i13.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_72(
+        returnValue: _i14.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_73(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9189,8 +9241,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_72(
+        returnValueForMissingStub: _i14.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_73(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9206,10 +9258,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.GetRoomEventsResponse>);
+      ) as _i14.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i13.Future<void> setReadMarker(
+  _i14.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9225,12 +9277,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> postReceipt(
+  _i14.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -9246,12 +9298,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> redactEvent(
+  _i14.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9267,12 +9319,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<void> reportRoom(
+  _i14.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9284,12 +9336,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> reportEvent(
+  _i14.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9307,12 +9359,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> sendMessage(
+  _i14.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9328,7 +9380,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9341,7 +9393,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9353,23 +9405,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i14.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i13.Future<List<_i4.MatrixEvent>>);
+            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i14.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i14.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -9386,13 +9438,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<String> setRoomStateWithKey(
+  _i14.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9408,7 +9460,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9421,7 +9473,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9433,10 +9485,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<void> unban(
+  _i14.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9450,12 +9502,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> upgradeRoom(
+  _i14.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9469,7 +9521,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9481,7 +9533,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9492,10 +9544,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.SearchResults> search(
+  _i14.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -9505,7 +9557,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
+        returnValue: _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
           this,
           Invocation.method(
             #search,
@@ -9514,7 +9566,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
+            _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
           this,
           Invocation.method(
             #search,
@@ -9522,10 +9574,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i13.Future<_i4.SearchResults>);
+      ) as _i14.Future<_i4.SearchResults>);
 
   @override
-  _i13.Future<_i4.SyncUpdate> sync({
+  _i14.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -9546,7 +9598,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #sync,
@@ -9562,7 +9614,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_13(
+            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
           this,
           Invocation.method(
             #sync,
@@ -9577,22 +9629,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i13.Future<_i4.SyncUpdate>);
+      ) as _i14.Future<_i4.SyncUpdate>);
 
   @override
-  _i13.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i14.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i13.Future<List<_i4.Location>>);
+            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i14.Future<List<_i4.Location>>);
 
   @override
-  _i13.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i14.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9602,21 +9654,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i13.Future<List<_i4.Location>>);
+            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i14.Future<List<_i4.Location>>);
 
   @override
-  _i13.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i14.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_74(
+        returnValue: _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_75(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9624,45 +9676,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_74(
+            _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_75(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i13.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i14.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i13.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i14.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i13.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i13.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9673,13 +9725,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i13.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i13.Future<List<_i4.ThirdPartyUser>>);
+            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i13.Future<Map<String, Object?>> getAccountData(
+  _i14.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9692,13 +9744,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> setAccountData(
+  _i14.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9712,12 +9764,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> defineFilter(
+  _i14.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -9729,7 +9781,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9740,7 +9792,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9750,10 +9802,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.Filter> getFilter(
+  _i14.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9765,7 +9817,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i13.Future<_i4.Filter>.value(_FakeFilter_18(
+        returnValue: _i14.Future<_i4.Filter>.value(_FakeFilter_19(
           this,
           Invocation.method(
             #getFilter,
@@ -9775,7 +9827,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.Filter>.value(_FakeFilter_18(
+        returnValueForMissingStub: _i14.Future<_i4.Filter>.value(_FakeFilter_19(
           this,
           Invocation.method(
             #getFilter,
@@ -9785,10 +9837,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.Filter>);
+      ) as _i14.Future<_i4.Filter>);
 
   @override
-  _i13.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i14.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9801,7 +9853,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
+            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9812,7 +9864,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
+            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9822,10 +9874,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i13.Future<_i4.OpenIdCredentials>);
+      ) as _i14.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i13.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i14.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9840,13 +9892,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<void> setAccountDataPerRoom(
+  _i14.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9862,12 +9914,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i14.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9879,12 +9931,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i13.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i13.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i13.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i14.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i14.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i14.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i13.Future<void> deleteRoomTag(
+  _i14.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9898,12 +9950,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setRoomTag(
+  _i14.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9919,12 +9971,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i14.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9934,8 +9986,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i13.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_76(
+        returnValue: _i14.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_77(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9944,8 +9996,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_76(
+            _i14.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_77(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9953,10 +10005,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i13.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i14.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> reportUser(
+  _i14.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -9969,40 +10021,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 
   @override
-  _i13.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i14.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i13.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_77(
+        returnValue: _i14.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_78(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i13.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_77(
+        returnValueForMissingStub: _i14.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_78(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.CreateContentResponse>);
+      ) as _i14.Future<_i4.CreateContentResponse>);
 
   @override
-  _i13.Future<Map<String, Object?>> uploadContentToMXC(
+  _i14.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i23.Uint8List? body, {
+    _i24.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -10020,10 +10072,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i13.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i13.Future<Map<String, Object?>>);
+            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i14.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [Event].
@@ -10033,11 +10085,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   _i4.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_15(
+        returnValue: _FakeUser_16(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_15(
+        returnValueForMissingStub: _FakeUser_16(
           this,
           Invocation.getter(#sender),
         ),
@@ -10046,11 +10098,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   _i4.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_15(
+        returnValue: _FakeUser_16(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_15(
+        returnValueForMissingStub: _FakeUser_16(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10059,11 +10111,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   _i4.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_78(
+        returnValue: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_78(
+        returnValueForMissingStub: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
@@ -10086,11 +10138,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   _i4.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_15(
+        returnValue: _FakeUser_16(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_15(
+        returnValueForMissingStub: _FakeUser_16(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10099,11 +10151,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10112,11 +10164,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10125,11 +10177,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10138,11 +10190,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10151,11 +10203,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10220,11 +10272,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10233,11 +10285,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10290,11 +10342,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10303,11 +10355,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   DateTime get originServerTs => (super.noSuchMethod(
         Invocation.getter(#originServerTs),
-        returnValue: _FakeDateTime_11(
+        returnValue: _FakeDateTime_12(
           this,
           Invocation.getter(#originServerTs),
         ),
-        returnValueForMissingStub: _FakeDateTime_11(
+        returnValueForMissingStub: _FakeDateTime_12(
           this,
           Invocation.getter(#originServerTs),
         ),
@@ -10379,11 +10431,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10401,11 +10453,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10437,14 +10489,14 @@ class MockEvent extends _i1.Mock implements _i4.Event {
       );
 
   @override
-  _i13.Future<_i4.User?> fetchSenderUser() => (super.noSuchMethod(
+  _i14.Future<_i4.User?> fetchSenderUser() => (super.noSuchMethod(
         Invocation.method(
           #fetchSenderUser,
           [],
         ),
-        returnValue: _i13.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.User?>.value(),
-      ) as _i13.Future<_i4.User?>);
+        returnValue: _i14.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.User?>.value(),
+      ) as _i14.Future<_i4.User?>);
 
   @override
   Map<String, dynamic> toJson() => (super.noSuchMethod(
@@ -10466,38 +10518,38 @@ class MockEvent extends _i1.Mock implements _i4.Event {
       );
 
   @override
-  _i13.Future<bool> remove() => (super.noSuchMethod(
+  _i14.Future<bool> remove() => (super.noSuchMethod(
         Invocation.method(
           #remove,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<void> cancelSend() => (super.noSuchMethod(
+  _i14.Future<void> cancelSend() => (super.noSuchMethod(
         Invocation.method(
           #cancelSend,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String?> sendAgain({String? txid}) => (super.noSuchMethod(
+  _i14.Future<String?> sendAgain({String? txid}) => (super.noSuchMethod(
         Invocation.method(
           #sendAgain,
           [],
           {#txid: txid},
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<String?> redactEvent({
+  _i14.Future<String?> redactEvent({
     String? reason,
     String? txid,
   }) =>
@@ -10510,30 +10562,30 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #txid: txid,
           },
         ),
-        returnValue: _i13.Future<String?>.value(),
-        returnValueForMissingStub: _i13.Future<String?>.value(),
-      ) as _i13.Future<String?>);
+        returnValue: _i14.Future<String?>.value(),
+        returnValueForMissingStub: _i14.Future<String?>.value(),
+      ) as _i14.Future<String?>);
 
   @override
-  _i13.Future<_i4.Event?> getReplyEvent(_i4.Timeline? timeline) =>
+  _i14.Future<_i4.Event?> getReplyEvent(_i4.Timeline? timeline) =>
       (super.noSuchMethod(
         Invocation.method(
           #getReplyEvent,
           [timeline],
         ),
-        returnValue: _i13.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i13.Future<_i4.Event?>.value(),
-      ) as _i13.Future<_i4.Event?>);
+        returnValue: _i14.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
+      ) as _i14.Future<_i4.Event?>);
 
   @override
-  _i13.Future<void> requestKey() => (super.noSuchMethod(
+  _i14.Future<void> requestKey() => (super.noSuchMethod(
         Invocation.method(
           #requestKey,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   Uri? attachmentOrThumbnailMxcUrl({bool? getThumbnail = false}) =>
@@ -10547,7 +10599,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
       ) as Uri?);
 
   @override
-  _i13.Future<Uri?> getAttachmentUri({
+  _i14.Future<Uri?> getAttachmentUri({
     bool? getThumbnail = false,
     bool? useThumbnailMxcUrl = false,
     double? width = 800.0,
@@ -10570,9 +10622,9 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #animated: animated,
           },
         ),
-        returnValue: _i13.Future<Uri?>.value(),
-        returnValueForMissingStub: _i13.Future<Uri?>.value(),
-      ) as _i13.Future<Uri?>);
+        returnValue: _i14.Future<Uri?>.value(),
+        returnValueForMissingStub: _i14.Future<Uri?>.value(),
+      ) as _i14.Future<Uri?>);
 
   @override
   Uri? getAttachmentUrl({
@@ -10602,21 +10654,21 @@ class MockEvent extends _i1.Mock implements _i4.Event {
       ) as Uri?);
 
   @override
-  _i13.Future<bool> isAttachmentInLocalStore({bool? getThumbnail = false}) =>
+  _i14.Future<bool> isAttachmentInLocalStore({bool? getThumbnail = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #isAttachmentInLocalStore,
           [],
           {#getThumbnail: getThumbnail},
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<_i4.MatrixFile> downloadAndDecryptAttachment({
+  _i14.Future<_i4.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i13.Future<_i23.Uint8List> Function(Uri)? downloadCallback,
+    _i14.Future<_i24.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10631,7 +10683,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i13.Future<_i4.MatrixFile>.value(_FakeMatrixFile_79(
+        returnValue: _i14.Future<_i4.MatrixFile>.value(_FakeMatrixFile_80(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10645,7 +10697,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.MatrixFile>.value(_FakeMatrixFile_79(
+            _i14.Future<_i4.MatrixFile>.value(_FakeMatrixFile_80(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10658,10 +10710,10 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             },
           ),
         )),
-      ) as _i13.Future<_i4.MatrixFile>);
+      ) as _i14.Future<_i4.MatrixFile>);
 
   @override
-  _i13.Future<String> calcLocalizedBody(
+  _i14.Future<String> calcLocalizedBody(
     _i4.MatrixLocalizations? i18n, {
     bool? withSenderNamePrefix = false,
     bool? hideReply = false,
@@ -10681,7 +10733,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10696,7 +10748,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10710,7 +10762,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
   String getLocalizedBody(
@@ -10733,7 +10785,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10747,7 +10799,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10784,7 +10836,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10798,7 +10850,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10832,7 +10884,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10845,7 +10897,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10921,14 +10973,14 @@ class MockEvent extends _i1.Mock implements _i4.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_80(
+        returnValue: _FakeEvent_81(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_80(
+        returnValueForMissingStub: _FakeEvent_81(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -10945,11 +10997,11 @@ class MockUser extends _i1.Mock implements _i4.User {
   @override
   _i4.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_78(
+        returnValue: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_78(
+        returnValueForMissingStub: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
@@ -10958,11 +11010,11 @@ class MockUser extends _i1.Mock implements _i4.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -10983,19 +11035,19 @@ class MockUser extends _i1.Mock implements _i4.User {
       ) as _i4.Membership);
 
   @override
-  _i13.Future<_i4.CachedPresence> get currentPresence => (super.noSuchMethod(
+  _i14.Future<_i4.CachedPresence> get currentPresence => (super.noSuchMethod(
         Invocation.getter(#currentPresence),
         returnValue:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
           this,
           Invocation.getter(#currentPresence),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
           this,
           Invocation.getter(#currentPresence),
         )),
-      ) as _i13.Future<_i4.CachedPresence>);
+      ) as _i14.Future<_i4.CachedPresence>);
 
   @override
   bool get canBan => (super.noSuchMethod(
@@ -11028,11 +11080,11 @@ class MockUser extends _i1.Mock implements _i4.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11057,11 +11109,11 @@ class MockUser extends _i1.Mock implements _i4.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11079,11 +11131,11 @@ class MockUser extends _i1.Mock implements _i4.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11130,7 +11182,7 @@ class MockUser extends _i1.Mock implements _i4.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11142,7 +11194,7 @@ class MockUser extends _i1.Mock implements _i4.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11157,47 +11209,47 @@ class MockUser extends _i1.Mock implements _i4.User {
       ) as String);
 
   @override
-  _i13.Future<void> kick() => (super.noSuchMethod(
+  _i14.Future<void> kick() => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> ban() => (super.noSuchMethod(
+  _i14.Future<void> ban() => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> unban() => (super.noSuchMethod(
+  _i14.Future<void> unban() => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setPower(int? power) => (super.noSuchMethod(
+  _i14.Future<void> setPower(int? power) => (super.noSuchMethod(
         Invocation.method(
           #setPower,
           [power],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<String> startDirectChat({
+  _i14.Future<String> startDirectChat({
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
     bool? waitForSync = true,
@@ -11212,7 +11264,7 @@ class MockUser extends _i1.Mock implements _i4.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i13.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11225,7 +11277,7 @@ class MockUser extends _i1.Mock implements _i4.User {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<String>.value(_i16.dummyValue<String>(
+            _i14.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11237,16 +11289,16 @@ class MockUser extends _i1.Mock implements _i4.User {
             },
           ),
         )),
-      ) as _i13.Future<String>);
+      ) as _i14.Future<String>);
 
   @override
-  _i13.Future<_i4.CachedPresence> fetchCurrentPresence() => (super.noSuchMethod(
+  _i14.Future<_i4.CachedPresence> fetchCurrentPresence() => (super.noSuchMethod(
         Invocation.method(
           #fetchCurrentPresence,
           [],
         ),
         returnValue:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -11254,14 +11306,14 @@ class MockUser extends _i1.Mock implements _i4.User {
           ),
         )),
         returnValueForMissingStub:
-            _i13.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
+            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
           this,
           Invocation.method(
             #fetchCurrentPresence,
             [],
           ),
         )),
-      ) as _i13.Future<_i4.CachedPresence>);
+      ) as _i14.Future<_i4.CachedPresence>);
 
   @override
   Map<String, Object?> toJson() => (super.noSuchMethod(
@@ -11277,7 +11329,7 @@ class MockUser extends _i1.Mock implements _i4.User {
 /// A class which mocks [CallService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCallService extends _i1.Mock implements _i24.CallService {
+class MockCallService extends _i1.Mock implements _i25.CallService {
   @override
   _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -11299,36 +11351,36 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       ) as bool);
 
   @override
-  _i25.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
+  _i26.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
         Invocation.getter(#httpPostForTest),
         returnValue: (
-          _i12.Client httpClient,
+          _i13.Client httpClient,
           Uri url, {
           Object? body,
           Map<String, String>? headers,
         }) =>
-            _i13.Future<_i12.Response>.value(_FakeResponse_81(
+            _i14.Future<_i13.Response>.value(_FakeResponse_82(
           this,
           Invocation.getter(#httpPostForTest),
         )),
         returnValueForMissingStub: (
-          _i12.Client httpClient,
+          _i13.Client httpClient,
           Uri url, {
           Object? body,
           Map<String, String>? headers,
         }) =>
-            _i13.Future<_i12.Response>.value(_FakeResponse_81(
+            _i14.Future<_i13.Response>.value(_FakeResponse_82(
           this,
           Invocation.getter(#httpPostForTest),
         )),
-      ) as _i25.HttpPostFunction);
+      ) as _i26.HttpPostFunction);
 
   @override
-  List<_i26.RemoteParticipant> get participants => (super.noSuchMethod(
+  List<_i27.RemoteParticipant> get participants => (super.noSuchMethod(
         Invocation.getter(#participants),
-        returnValue: <_i26.RemoteParticipant>[],
-        returnValueForMissingStub: <_i26.RemoteParticipant>[],
-      ) as List<_i26.RemoteParticipant>);
+        returnValue: <_i27.RemoteParticipant>[],
+        returnValueForMissingStub: <_i27.RemoteParticipant>[],
+      ) as List<_i27.RemoteParticipant>);
 
   @override
   bool get isMicEnabled => (super.noSuchMethod(
@@ -11359,14 +11411,14 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       ) as bool);
 
   @override
-  List<_i26.Participant<_i26.TrackPublication<_i26.Track>>>
+  List<_i27.Participant<_i27.TrackPublication<_i27.Track>>>
       get activeSpeakers => (super.noSuchMethod(
             Invocation.getter(#activeSpeakers),
-            returnValue: <_i26
-                .Participant<_i26.TrackPublication<_i26.Track>>>[],
-            returnValueForMissingStub: <_i26
-                .Participant<_i26.TrackPublication<_i26.Track>>>[],
-          ) as List<_i26.Participant<_i26.TrackPublication<_i26.Track>>>);
+            returnValue: <_i27
+                .Participant<_i27.TrackPublication<_i27.Track>>>[],
+            returnValueForMissingStub: <_i27
+                .Participant<_i27.TrackPublication<_i27.Track>>>[],
+          ) as List<_i27.Participant<_i27.TrackPublication<_i27.Track>>>);
 
   @override
   bool get isCallingAvailable => (super.noSuchMethod(
@@ -11376,11 +11428,11 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       ) as bool);
 
   @override
-  List<_i27.CallParticipant> get allParticipants => (super.noSuchMethod(
+  List<_i28.CallParticipant> get allParticipants => (super.noSuchMethod(
         Invocation.getter(#allParticipants),
-        returnValue: <_i27.CallParticipant>[],
-        returnValueForMissingStub: <_i27.CallParticipant>[],
-      ) as List<_i27.CallParticipant>);
+        returnValue: <_i28.CallParticipant>[],
+        returnValueForMissingStub: <_i28.CallParticipant>[],
+      ) as List<_i28.CallParticipant>);
 
   @override
   bool get isSpeakerOn => (super.noSuchMethod(
@@ -11390,29 +11442,29 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       ) as bool);
 
   @override
-  _i13.Stream<_i28.IncomingCallInfo> get incomingCallStream =>
+  _i14.Stream<_i29.IncomingCallInfo> get incomingCallStream =>
       (super.noSuchMethod(
         Invocation.getter(#incomingCallStream),
-        returnValue: _i13.Stream<_i28.IncomingCallInfo>.empty(),
-        returnValueForMissingStub: _i13.Stream<_i28.IncomingCallInfo>.empty(),
-      ) as _i13.Stream<_i28.IncomingCallInfo>);
+        returnValue: _i14.Stream<_i29.IncomingCallInfo>.empty(),
+        returnValueForMissingStub: _i14.Stream<_i29.IncomingCallInfo>.empty(),
+      ) as _i14.Stream<_i29.IncomingCallInfo>);
 
   @override
-  _i13.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
+  _i14.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
         Invocation.getter(#nativeAcceptedCallStream),
-        returnValue: _i13.Stream<String>.empty(),
-        returnValueForMissingStub: _i13.Stream<String>.empty(),
-      ) as _i13.Stream<String>);
+        returnValue: _i14.Stream<String>.empty(),
+        returnValueForMissingStub: _i14.Stream<String>.empty(),
+      ) as _i14.Stream<String>);
 
   @override
-  _i29.KoheraCallState get callState => (super.noSuchMethod(
+  _i30.KoheraCallState get callState => (super.noSuchMethod(
         Invocation.getter(#callState),
-        returnValue: _i29.KoheraCallState.idle,
-        returnValueForMissingStub: _i29.KoheraCallState.idle,
-      ) as _i29.KoheraCallState);
+        returnValue: _i30.KoheraCallState.idle,
+        returnValueForMissingStub: _i30.KoheraCallState.idle,
+      ) as _i30.KoheraCallState);
 
   @override
-  set preferencesService(_i30.PreferencesService? prefs) => super.noSuchMethod(
+  set preferencesService(_i31.PreferencesService? prefs) => super.noSuchMethod(
         Invocation.setter(
           #preferencesService,
           prefs,
@@ -11421,7 +11473,7 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  set ringtoneService(_i31.RingtoneService? service) => super.noSuchMethod(
+  set ringtoneService(_i32.RingtoneService? service) => super.noSuchMethod(
         Invocation.setter(
           #ringtoneService,
           service,
@@ -11430,7 +11482,7 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  set roomFactoryForTest(_i25.LiveKitRoomFactory? factory) =>
+  set roomFactoryForTest(_i26.LiveKitRoomFactory? factory) =>
       super.noSuchMethod(
         Invocation.setter(
           #roomFactoryForTest,
@@ -11440,7 +11492,7 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  set httpPostForTest(_i25.HttpPostFunction? fn) => super.noSuchMethod(
+  set httpPostForTest(_i26.HttpPostFunction? fn) => super.noSuchMethod(
         Invocation.setter(
           #httpPostForTest,
           fn,
@@ -11474,27 +11526,27 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  _i13.Future<void> toggleMicrophone() => (super.noSuchMethod(
+  _i14.Future<void> toggleMicrophone() => (super.noSuchMethod(
         Invocation.method(
           #toggleMicrophone,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> toggleCamera() => (super.noSuchMethod(
+  _i14.Future<void> toggleCamera() => (super.noSuchMethod(
         Invocation.method(
           #toggleCamera,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> toggleScreenShare({
+  _i14.Future<void> toggleScreenShare({
     String? sourceId,
     bool? captureScreenAudio = false,
   }) =>
@@ -11507,39 +11559,39 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
             #captureScreenAudio: captureScreenAudio,
           },
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> toggleScreenAudio() => (super.noSuchMethod(
+  _i14.Future<void> toggleScreenAudio() => (super.noSuchMethod(
         Invocation.method(
           #toggleScreenAudio,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> setOutputVolume(double? volume) => (super.noSuchMethod(
+  _i14.Future<void> setOutputVolume(double? volume) => (super.noSuchMethod(
         Invocation.method(
           #setOutputVolume,
           [volume],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> toggleSpeaker() => (super.noSuchMethod(
+  _i14.Future<void> toggleSpeaker() => (super.noSuchMethod(
         Invocation.method(
           #toggleSpeaker,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void setVoipPushHandlesCallKit(bool? value) => super.noSuchMethod(
@@ -11569,7 +11621,7 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -11597,36 +11649,36 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  _i13.Future<void> joinCall(String? roomId) => (super.noSuchMethod(
+  _i14.Future<void> joinCall(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #joinCall,
           [roomId],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> leaveCall() => (super.noSuchMethod(
+  _i14.Future<void> leaveCall() => (super.noSuchMethod(
         Invocation.method(
           #leaveCall,
           [],
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
-  _i13.Future<void> acceptCall({bool? withVideo = false}) =>
+  _i14.Future<void> acceptCall({bool? withVideo = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #acceptCall,
           [],
           {#withVideo: withVideo},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   void declineCall() => super.noSuchMethod(
@@ -11648,9 +11700,9 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  _i13.Future<void> initiateCall(
+  _i14.Future<void> initiateCall(
     String? roomId, {
-    _i28.CallType? type = _i28.CallType.voice,
+    _i29.CallType? type = _i29.CallType.voice,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -11658,9 +11710,9 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
           [roomId],
           {#type: type},
         ),
-        returnValue: _i13.Future<void>.value(),
-        returnValueForMissingStub: _i13.Future<void>.value(),
-      ) as _i13.Future<void>);
+        returnValue: _i14.Future<void>.value(),
+        returnValueForMissingStub: _i14.Future<void>.value(),
+      ) as _i14.Future<void>);
 
   @override
   bool roomHasActiveCall(String? roomId) => (super.noSuchMethod(
@@ -11753,7 +11805,7 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -11762,7 +11814,7 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -11771,17 +11823,17 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  _i13.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -11792,7 +11844,7 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -11829,26 +11881,26 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  _i13.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
-  _i13.Future<bool> didPushRouteInformation(
-          _i19.RouteInformation? routeInformation) =>
+  _i14.Future<bool> didPushRouteInformation(
+          _i20.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i13.Future<bool>.value(false),
-        returnValueForMissingStub: _i13.Future<bool>.value(false),
-      ) as _i13.Future<bool>);
+        returnValue: _i14.Future<bool>.value(false),
+        returnValueForMissingStub: _i14.Future<bool>.value(false),
+      ) as _i14.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -11878,7 +11930,7 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -11887,7 +11939,7 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -11896,16 +11948,16 @@ class MockCallService extends _i1.Mock implements _i24.CallService {
       );
 
   @override
-  _i13.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i14.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i13.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
-      ) as _i13.Future<_i17.AppExitResponse>);
+            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+      ) as _i14.Future<_i18.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/shared_media_section_test.mocks.dart
+++ b/test/widgets/shared_media_section_test.mocks.dart
@@ -1114,6 +1114,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -1620,6 +1627,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/space_action_dialog_test.mocks.dart
+++ b/test/widgets/space_action_dialog_test.mocks.dart
@@ -4,33 +4,35 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i17;
-import 'dart:ui' as _i19;
+import 'dart:typed_data' as _i18;
+import 'dart:ui' as _i20;
 
-import 'package:flutter/services.dart' as _i20;
-import 'package:flutter/widgets.dart' as _i21;
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i12;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i15;
+import 'package:matrix/encryption.dart' as _i16;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i23;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i22;
+import 'package:matrix/src/utils/space_child.dart' as _i23;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -802,8 +804,9 @@ class _FakeSelectionService_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
-  _FakeSyncService_71(
+class _FakeSpaceAccessService_71 extends _i1.SmartFake
+    implements _i12.SpaceAccessService {
+  _FakeSpaceAccessService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -812,8 +815,8 @@ class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
         );
 }
 
-class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
-  _FakeAuthService_72(
+class _FakeSyncService_72 extends _i1.SmartFake implements _i13.SyncService {
+  _FakeSyncService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -822,9 +825,8 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeOutboxService_73 extends _i1.SmartFake
-    implements _i14.OutboxService {
-  _FakeOutboxService_73(
+class _FakeAuthService_73 extends _i1.SmartFake implements _i14.AuthService {
+  _FakeAuthService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -833,8 +835,9 @@ class _FakeOutboxService_73 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_74(
+class _FakeOutboxService_74 extends _i1.SmartFake
+    implements _i15.OutboxService {
+  _FakeOutboxService_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -843,9 +846,19 @@ class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_75 extends _i1.SmartFake
+class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_76 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_75(
+  _FakeLatestReceiptState_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -854,8 +867,8 @@ class _FakeLatestReceiptState_75 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_76(
+class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -864,8 +877,8 @@ class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_77(
+class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -892,12 +905,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i15.KeyVerificationMethod> get verificationMethods =>
+  Set<_i16.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i15.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
-      ) as Set<_i15.KeyVerificationMethod>);
+        returnValue: <_i16.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
+      ) as Set<_i16.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1017,11 +1030,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1058,11 +1071,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1092,11 +1105,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1105,11 +1118,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1395,34 +1408,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i15.KeyVerification>
+  _i3.CachedStreamController<_i16.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i15.KeyVerification>(
+                _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i15.KeyVerification>);
+          ) as _i3.CachedStreamController<_i16.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1578,7 +1591,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1867,14 +1880,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2262,8 +2275,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2279,8 +2292,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2321,7 +2334,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2337,7 +2350,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2386,7 +2399,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2407,7 +2420,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2510,7 +2523,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2528,7 +2541,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3047,7 +3060,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i17.Uint8List? file, {
+    _i18.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3399,7 +3412,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3413,7 +3426,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3564,7 +3577,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i17.Uint8List? body,
+    _i18.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4942,7 +4955,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4964,7 +4977,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5458,7 +5471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5470,7 +5483,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6478,7 +6491,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6489,7 +6502,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6737,7 +6750,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6749,7 +6762,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7009,7 +7022,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7022,7 +7035,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7089,7 +7102,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7102,7 +7115,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7150,7 +7163,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7162,7 +7175,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7410,7 +7423,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7421,7 +7434,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7683,7 +7696,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i17.Uint8List? body, {
+    _i18.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7710,7 +7723,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7740,11 +7753,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7817,43 +7830,56 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i11.SelectionService);
 
   @override
-  _i12.SyncService get sync => (super.noSuchMethod(
+  _i12.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i12.SpaceAccessService);
+
+  @override
+  _i13.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_71(
+        returnValue: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_71(
+        returnValueForMissingStub: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i12.SyncService);
+      ) as _i13.SyncService);
 
   @override
-  _i13.AuthService get auth => (super.noSuchMethod(
+  _i14.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_72(
+        returnValue: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_72(
+        returnValueForMissingStub: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i13.AuthService);
+      ) as _i14.AuthService);
 
   @override
-  _i14.OutboxService get outbox => (super.noSuchMethod(
+  _i15.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_73(
+        returnValue: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_73(
+        returnValueForMissingStub: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i14.OutboxService);
+      ) as _i15.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7917,7 +7943,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set sync(_i12.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i12.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i13.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7926,7 +7961,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set auth(_i13.AuthService? value) => super.noSuchMethod(
+  set auth(_i14.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7935,7 +7970,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i15.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -7988,7 +8023,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8082,7 +8117,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8091,7 +8126,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8110,7 +8145,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8121,7 +8156,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8169,7 +8204,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i21.RouteInformation? routeInformation) =>
+          _i22.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8207,7 +8242,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8216,7 +8251,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8225,16 +8260,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
-      ) as _i5.Future<_i19.AppExitResponse>);
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i5.Future<_i20.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8262,11 +8297,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8296,11 +8331,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_74(
+        returnValue: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_74(
+        returnValueForMissingStub: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
@@ -8353,11 +8388,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8393,11 +8428,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8413,11 +8448,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8426,11 +8461,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8473,11 +8508,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8520,11 +8555,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_75(
+        returnValue: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_75(
+        returnValueForMissingStub: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8561,6 +8596,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   bool get isFavourite => (super.noSuchMethod(
         Invocation.getter(#isFavourite),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
@@ -8736,18 +8778,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i22.SpaceParent>[],
-        returnValueForMissingStub: <_i22.SpaceParent>[],
-      ) as List<_i22.SpaceParent>);
+        returnValue: <_i23.SpaceParent>[],
+        returnValueForMissingStub: <_i23.SpaceParent>[],
+      ) as List<_i23.SpaceParent>);
 
   @override
-  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i22.SpaceChild>[],
-        returnValueForMissingStub: <_i22.SpaceChild>[],
-      ) as List<_i22.SpaceChild>);
+        returnValue: <_i23.SpaceChild>[],
+        returnValueForMissingStub: <_i23.SpaceChild>[],
+      ) as List<_i23.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8914,14 +8956,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8969,7 +9011,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8977,7 +9019,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -8992,7 +9034,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9000,7 +9042,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9078,13 +9120,23 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   _i5.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9092,7 +9144,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9334,7 +9386,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9345,7 +9397,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9434,15 +9486,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i23.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i23.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i23.TimelineChunk?>.value(),
-      ) as _i5.Future<_i23.TimelineChunk?>);
+        returnValue: _i5.Future<_i24.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i24.TimelineChunk?>.value(),
+      ) as _i5.Future<_i24.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9483,7 +9535,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -9500,7 +9552,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -9564,14 +9616,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9587,14 +9639,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9650,7 +9702,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9658,7 +9710,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/space_context_menu_test.mocks.dart
+++ b/test/widgets/space_context_menu_test.mocks.dart
@@ -4,33 +4,35 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i17;
-import 'dart:ui' as _i19;
+import 'dart:typed_data' as _i18;
+import 'dart:ui' as _i20;
 
-import 'package:flutter/services.dart' as _i20;
-import 'package:flutter/widgets.dart' as _i21;
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i12;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i15;
+import 'package:matrix/encryption.dart' as _i16;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i23;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i22;
+import 'package:matrix/src/utils/space_child.dart' as _i23;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -802,8 +804,9 @@ class _FakeSelectionService_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
-  _FakeSyncService_71(
+class _FakeSpaceAccessService_71 extends _i1.SmartFake
+    implements _i12.SpaceAccessService {
+  _FakeSpaceAccessService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -812,8 +815,8 @@ class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
         );
 }
 
-class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
-  _FakeAuthService_72(
+class _FakeSyncService_72 extends _i1.SmartFake implements _i13.SyncService {
+  _FakeSyncService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -822,9 +825,8 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeOutboxService_73 extends _i1.SmartFake
-    implements _i14.OutboxService {
-  _FakeOutboxService_73(
+class _FakeAuthService_73 extends _i1.SmartFake implements _i14.AuthService {
+  _FakeAuthService_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -833,8 +835,9 @@ class _FakeOutboxService_73 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_74(
+class _FakeOutboxService_74 extends _i1.SmartFake
+    implements _i15.OutboxService {
+  _FakeOutboxService_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -843,9 +846,19 @@ class _FakeRoomSummary_74 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_75 extends _i1.SmartFake
+class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_76 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_75(
+  _FakeLatestReceiptState_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -854,8 +867,8 @@ class _FakeLatestReceiptState_75 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_76(
+class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -864,8 +877,8 @@ class _FakeTimeline_76 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_77(
+class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -874,8 +887,8 @@ class _FakeUser_77 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_78 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_78(
+class _FakeRoom_79 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -884,8 +897,8 @@ class _FakeRoom_78 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeMatrixFile_79 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_79(
+class _FakeMatrixFile_80 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -894,8 +907,8 @@ class _FakeMatrixFile_79 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_80 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_80(
+class _FakeEvent_81 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -922,12 +935,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i15.KeyVerificationMethod> get verificationMethods =>
+  Set<_i16.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i15.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
-      ) as Set<_i15.KeyVerificationMethod>);
+        returnValue: <_i16.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
+      ) as Set<_i16.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1047,11 +1060,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1088,11 +1101,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1122,11 +1135,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1135,11 +1148,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1425,34 +1438,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i15.KeyVerification>
+  _i3.CachedStreamController<_i16.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i15.KeyVerification>(
+                _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i15.KeyVerification>);
+          ) as _i3.CachedStreamController<_i16.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1608,7 +1621,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1897,14 +1910,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2292,8 +2305,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2309,8 +2322,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2351,7 +2364,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2367,7 +2380,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2416,7 +2429,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2437,7 +2450,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2540,7 +2553,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2558,7 +2571,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3077,7 +3090,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i17.Uint8List? file, {
+    _i18.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3429,7 +3442,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3443,7 +3456,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3594,7 +3607,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i17.Uint8List? body,
+    _i18.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4972,7 +4985,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4994,7 +5007,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5488,7 +5501,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5500,7 +5513,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6508,7 +6521,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6519,7 +6532,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6767,7 +6780,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6779,7 +6792,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7039,7 +7052,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7052,7 +7065,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7119,7 +7132,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7132,7 +7145,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7180,7 +7193,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7192,7 +7205,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7440,7 +7453,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7451,7 +7464,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7713,7 +7726,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i17.Uint8List? body, {
+    _i18.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7740,7 +7753,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7770,11 +7783,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7847,43 +7860,56 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i11.SelectionService);
 
   @override
-  _i12.SyncService get sync => (super.noSuchMethod(
+  _i12.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i12.SpaceAccessService);
+
+  @override
+  _i13.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_71(
+        returnValue: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_71(
+        returnValueForMissingStub: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i12.SyncService);
+      ) as _i13.SyncService);
 
   @override
-  _i13.AuthService get auth => (super.noSuchMethod(
+  _i14.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_72(
+        returnValue: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_72(
+        returnValueForMissingStub: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i13.AuthService);
+      ) as _i14.AuthService);
 
   @override
-  _i14.OutboxService get outbox => (super.noSuchMethod(
+  _i15.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_73(
+        returnValue: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_73(
+        returnValueForMissingStub: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i14.OutboxService);
+      ) as _i15.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7947,7 +7973,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set sync(_i12.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i12.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i13.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7956,7 +7991,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set auth(_i13.AuthService? value) => super.noSuchMethod(
+  set auth(_i14.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7965,7 +8000,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i15.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -8018,7 +8053,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8112,7 +8147,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8121,7 +8156,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8140,7 +8175,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8151,7 +8186,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8199,7 +8234,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i21.RouteInformation? routeInformation) =>
+          _i22.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8237,7 +8272,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8246,7 +8281,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8255,16 +8290,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
-      ) as _i5.Future<_i19.AppExitResponse>);
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i5.Future<_i20.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8292,11 +8327,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8326,11 +8361,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_74(
+        returnValue: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_74(
+        returnValueForMissingStub: _FakeRoomSummary_75(
           this,
           Invocation.getter(#summary),
         ),
@@ -8383,11 +8418,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8423,11 +8458,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8443,11 +8478,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8456,11 +8491,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8503,11 +8538,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8550,11 +8585,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_75(
+        returnValue: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_75(
+        returnValueForMissingStub: _FakeLatestReceiptState_76(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8591,6 +8626,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   bool get isFavourite => (super.noSuchMethod(
         Invocation.getter(#isFavourite),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
@@ -8766,18 +8808,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i22.SpaceParent>[],
-        returnValueForMissingStub: <_i22.SpaceParent>[],
-      ) as List<_i22.SpaceParent>);
+        returnValue: <_i23.SpaceParent>[],
+        returnValueForMissingStub: <_i23.SpaceParent>[],
+      ) as List<_i23.SpaceParent>);
 
   @override
-  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i22.SpaceChild>[],
-        returnValueForMissingStub: <_i22.SpaceChild>[],
-      ) as List<_i22.SpaceChild>);
+        returnValue: <_i23.SpaceChild>[],
+        returnValueForMissingStub: <_i23.SpaceChild>[],
+      ) as List<_i23.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8944,14 +8986,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8999,7 +9041,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9007,7 +9049,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9022,7 +9064,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9030,7 +9072,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9108,13 +9150,23 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
   _i5.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9122,7 +9174,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9364,7 +9416,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9375,7 +9427,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9464,15 +9516,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i23.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i23.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i23.TimelineChunk?>.value(),
-      ) as _i5.Future<_i23.TimelineChunk?>);
+        returnValue: _i5.Future<_i24.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i24.TimelineChunk?>.value(),
+      ) as _i5.Future<_i24.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9513,7 +9565,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -9530,7 +9582,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_76(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
           this,
           Invocation.method(
             #getTimeline,
@@ -9594,14 +9646,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9617,14 +9669,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9680,7 +9732,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9688,7 +9740,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10000,11 +10052,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.getter(#sender),
         ),
@@ -10013,11 +10065,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10026,11 +10078,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_78(
+        returnValue: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_78(
+        returnValueForMissingStub: _FakeRoom_79(
           this,
           Invocation.getter(#room),
         ),
@@ -10053,11 +10105,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_77(
+        returnValue: _FakeUser_78(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_77(
+        returnValueForMissingStub: _FakeUser_78(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10066,11 +10118,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10079,11 +10131,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10092,11 +10144,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10105,11 +10157,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10118,11 +10170,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10187,11 +10239,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10200,11 +10252,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10257,11 +10309,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10346,11 +10398,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10368,11 +10420,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10583,7 +10635,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i17.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i18.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10598,7 +10650,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_79(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_80(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10612,7 +10664,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_79(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_80(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10648,7 +10700,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10663,7 +10715,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10700,7 +10752,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10714,7 +10766,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10751,7 +10803,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10765,7 +10817,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10799,7 +10851,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10812,7 +10864,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10888,14 +10940,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_80(
+        returnValue: _FakeEvent_81(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_80(
+        returnValueForMissingStub: _FakeEvent_81(
           this,
           Invocation.method(
             #getDisplayEvent,

--- a/test/widgets/space_details_panel_test.mocks.dart
+++ b/test/widgets/space_details_panel_test.mocks.dart
@@ -8612,6 +8612,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -9118,6 +9125,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/space_discovery_search_test.mocks.dart
+++ b/test/widgets/space_discovery_search_test.mocks.dart
@@ -4,31 +4,33 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i17;
-import 'dart:ui' as _i19;
+import 'dart:typed_data' as _i18;
+import 'dart:ui' as _i20;
 
-import 'package:flutter/services.dart' as _i20;
-import 'package:flutter/widgets.dart' as _i21;
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i12;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i15;
+import 'package:matrix/encryption.dart' as _i16;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -800,8 +802,9 @@ class _FakeSelectionService_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
-  _FakeSyncService_71(
+class _FakeSpaceAccessService_71 extends _i1.SmartFake
+    implements _i12.SpaceAccessService {
+  _FakeSpaceAccessService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -810,8 +813,8 @@ class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
         );
 }
 
-class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
-  _FakeAuthService_72(
+class _FakeSyncService_72 extends _i1.SmartFake implements _i13.SyncService {
+  _FakeSyncService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -820,9 +823,19 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeOutboxService_73 extends _i1.SmartFake
-    implements _i14.OutboxService {
-  _FakeOutboxService_73(
+class _FakeAuthService_73 extends _i1.SmartFake implements _i14.AuthService {
+  _FakeAuthService_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeOutboxService_74 extends _i1.SmartFake
+    implements _i15.OutboxService {
+  _FakeOutboxService_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -849,12 +862,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i15.KeyVerificationMethod> get verificationMethods =>
+  Set<_i16.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i15.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
-      ) as Set<_i15.KeyVerificationMethod>);
+        returnValue: <_i16.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
+      ) as Set<_i16.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -974,11 +987,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1015,11 +1028,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1049,11 +1062,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1062,11 +1075,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1352,34 +1365,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i15.KeyVerification>
+  _i3.CachedStreamController<_i16.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i15.KeyVerification>(
+                _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i15.KeyVerification>);
+          ) as _i3.CachedStreamController<_i16.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1535,7 +1548,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1824,14 +1837,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2219,8 +2232,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2236,8 +2249,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2278,7 +2291,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2294,7 +2307,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2343,7 +2356,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2364,7 +2377,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2467,7 +2480,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2485,7 +2498,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3004,7 +3017,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i17.Uint8List? file, {
+    _i18.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3356,7 +3369,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3370,7 +3383,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3521,7 +3534,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i17.Uint8List? body,
+    _i18.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4899,7 +4912,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4921,7 +4934,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5415,7 +5428,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5427,7 +5440,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6435,7 +6448,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6446,7 +6459,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6694,7 +6707,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6706,7 +6719,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6966,7 +6979,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6979,7 +6992,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7046,7 +7059,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7059,7 +7072,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7107,7 +7120,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7119,7 +7132,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7367,7 +7380,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7378,7 +7391,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7640,7 +7653,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i17.Uint8List? body, {
+    _i18.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7667,7 +7680,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7697,11 +7710,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7774,43 +7787,56 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i11.SelectionService);
 
   @override
-  _i12.SyncService get sync => (super.noSuchMethod(
+  _i12.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i12.SpaceAccessService);
+
+  @override
+  _i13.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_71(
+        returnValue: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_71(
+        returnValueForMissingStub: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i12.SyncService);
+      ) as _i13.SyncService);
 
   @override
-  _i13.AuthService get auth => (super.noSuchMethod(
+  _i14.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_72(
+        returnValue: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_72(
+        returnValueForMissingStub: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i13.AuthService);
+      ) as _i14.AuthService);
 
   @override
-  _i14.OutboxService get outbox => (super.noSuchMethod(
+  _i15.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_73(
+        returnValue: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_73(
+        returnValueForMissingStub: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i14.OutboxService);
+      ) as _i15.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7874,7 +7900,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set sync(_i12.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i12.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i13.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7883,7 +7918,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set auth(_i13.AuthService? value) => super.noSuchMethod(
+  set auth(_i14.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7892,7 +7927,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i15.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -7945,7 +7980,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8039,7 +8074,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8048,7 +8083,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8067,7 +8102,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8078,7 +8113,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8126,7 +8161,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i21.RouteInformation? routeInformation) =>
+          _i22.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8164,7 +8199,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8173,7 +8208,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8182,16 +8217,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
-      ) as _i5.Future<_i19.AppExitResponse>);
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i5.Future<_i20.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/space_discovery_server_test.mocks.dart
+++ b/test/widgets/space_discovery_server_test.mocks.dart
@@ -4,31 +4,33 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i17;
-import 'dart:ui' as _i19;
+import 'dart:typed_data' as _i18;
+import 'dart:ui' as _i20;
 
-import 'package:flutter/services.dart' as _i20;
-import 'package:flutter/widgets.dart' as _i21;
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i12;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i15;
+import 'package:matrix/encryption.dart' as _i16;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -800,8 +802,9 @@ class _FakeSelectionService_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
-  _FakeSyncService_71(
+class _FakeSpaceAccessService_71 extends _i1.SmartFake
+    implements _i12.SpaceAccessService {
+  _FakeSpaceAccessService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -810,8 +813,8 @@ class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
         );
 }
 
-class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
-  _FakeAuthService_72(
+class _FakeSyncService_72 extends _i1.SmartFake implements _i13.SyncService {
+  _FakeSyncService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -820,9 +823,19 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeOutboxService_73 extends _i1.SmartFake
-    implements _i14.OutboxService {
-  _FakeOutboxService_73(
+class _FakeAuthService_73 extends _i1.SmartFake implements _i14.AuthService {
+  _FakeAuthService_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeOutboxService_74 extends _i1.SmartFake
+    implements _i15.OutboxService {
+  _FakeOutboxService_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -849,12 +862,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i15.KeyVerificationMethod> get verificationMethods =>
+  Set<_i16.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i15.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
-      ) as Set<_i15.KeyVerificationMethod>);
+        returnValue: <_i16.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
+      ) as Set<_i16.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -974,11 +987,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1015,11 +1028,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1049,11 +1062,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1062,11 +1075,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1352,34 +1365,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i15.KeyVerification>
+  _i3.CachedStreamController<_i16.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i15.KeyVerification>(
+                _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i15.KeyVerification>);
+          ) as _i3.CachedStreamController<_i16.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1535,7 +1548,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1824,14 +1837,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2219,8 +2232,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2236,8 +2249,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2278,7 +2291,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2294,7 +2307,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2343,7 +2356,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2364,7 +2377,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2467,7 +2480,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2485,7 +2498,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3004,7 +3017,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i17.Uint8List? file, {
+    _i18.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3356,7 +3369,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3370,7 +3383,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3521,7 +3534,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i17.Uint8List? body,
+    _i18.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4899,7 +4912,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4921,7 +4934,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5415,7 +5428,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5427,7 +5440,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6435,7 +6448,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6446,7 +6459,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6694,7 +6707,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6706,7 +6719,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6966,7 +6979,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6979,7 +6992,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7046,7 +7059,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7059,7 +7072,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7107,7 +7120,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7119,7 +7132,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7367,7 +7380,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7378,7 +7391,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7640,7 +7653,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i17.Uint8List? body, {
+    _i18.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7667,7 +7680,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7697,11 +7710,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7774,43 +7787,56 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i11.SelectionService);
 
   @override
-  _i12.SyncService get sync => (super.noSuchMethod(
+  _i12.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i12.SpaceAccessService);
+
+  @override
+  _i13.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_71(
+        returnValue: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_71(
+        returnValueForMissingStub: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i12.SyncService);
+      ) as _i13.SyncService);
 
   @override
-  _i13.AuthService get auth => (super.noSuchMethod(
+  _i14.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_72(
+        returnValue: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_72(
+        returnValueForMissingStub: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i13.AuthService);
+      ) as _i14.AuthService);
 
   @override
-  _i14.OutboxService get outbox => (super.noSuchMethod(
+  _i15.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_73(
+        returnValue: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_73(
+        returnValueForMissingStub: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i14.OutboxService);
+      ) as _i15.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7874,7 +7900,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set sync(_i12.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i12.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i13.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7883,7 +7918,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set auth(_i13.AuthService? value) => super.noSuchMethod(
+  set auth(_i14.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7892,7 +7927,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i15.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -7945,7 +7980,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8039,7 +8074,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8048,7 +8083,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8067,7 +8102,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8078,7 +8113,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8126,7 +8161,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i21.RouteInformation? routeInformation) =>
+          _i22.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8164,7 +8199,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8173,7 +8208,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8182,16 +8217,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
-      ) as _i5.Future<_i19.AppExitResponse>);
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i5.Future<_i20.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/space_discovery_servers_edit_test.mocks.dart
+++ b/test/widgets/space_discovery_servers_edit_test.mocks.dart
@@ -4,31 +4,33 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i17;
-import 'dart:ui' as _i19;
+import 'dart:typed_data' as _i18;
+import 'dart:ui' as _i20;
 
-import 'package:flutter/services.dart' as _i20;
-import 'package:flutter/widgets.dart' as _i21;
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i12;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i15;
+import 'package:matrix/encryption.dart' as _i16;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -800,8 +802,9 @@ class _FakeSelectionService_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
-  _FakeSyncService_71(
+class _FakeSpaceAccessService_71 extends _i1.SmartFake
+    implements _i12.SpaceAccessService {
+  _FakeSpaceAccessService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -810,8 +813,8 @@ class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
         );
 }
 
-class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
-  _FakeAuthService_72(
+class _FakeSyncService_72 extends _i1.SmartFake implements _i13.SyncService {
+  _FakeSyncService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -820,9 +823,19 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeOutboxService_73 extends _i1.SmartFake
-    implements _i14.OutboxService {
-  _FakeOutboxService_73(
+class _FakeAuthService_73 extends _i1.SmartFake implements _i14.AuthService {
+  _FakeAuthService_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeOutboxService_74 extends _i1.SmartFake
+    implements _i15.OutboxService {
+  _FakeOutboxService_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -849,12 +862,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i15.KeyVerificationMethod> get verificationMethods =>
+  Set<_i16.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i15.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
-      ) as Set<_i15.KeyVerificationMethod>);
+        returnValue: <_i16.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
+      ) as Set<_i16.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -974,11 +987,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1015,11 +1028,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1049,11 +1062,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1062,11 +1075,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1352,34 +1365,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i15.KeyVerification>
+  _i3.CachedStreamController<_i16.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i15.KeyVerification>(
+                _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i15.KeyVerification>);
+          ) as _i3.CachedStreamController<_i16.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1535,7 +1548,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1824,14 +1837,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2219,8 +2232,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2236,8 +2249,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2278,7 +2291,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2294,7 +2307,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2343,7 +2356,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2364,7 +2377,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2467,7 +2480,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2485,7 +2498,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3004,7 +3017,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i17.Uint8List? file, {
+    _i18.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3356,7 +3369,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3370,7 +3383,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3521,7 +3534,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i17.Uint8List? body,
+    _i18.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4899,7 +4912,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4921,7 +4934,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5415,7 +5428,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5427,7 +5440,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6435,7 +6448,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6446,7 +6459,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6694,7 +6707,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6706,7 +6719,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6966,7 +6979,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6979,7 +6992,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7046,7 +7059,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7059,7 +7072,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7107,7 +7120,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7119,7 +7132,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7367,7 +7380,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7378,7 +7391,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7640,7 +7653,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i17.Uint8List? body, {
+    _i18.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7667,7 +7680,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7697,11 +7710,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7774,43 +7787,56 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i11.SelectionService);
 
   @override
-  _i12.SyncService get sync => (super.noSuchMethod(
+  _i12.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i12.SpaceAccessService);
+
+  @override
+  _i13.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_71(
+        returnValue: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_71(
+        returnValueForMissingStub: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i12.SyncService);
+      ) as _i13.SyncService);
 
   @override
-  _i13.AuthService get auth => (super.noSuchMethod(
+  _i14.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_72(
+        returnValue: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_72(
+        returnValueForMissingStub: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i13.AuthService);
+      ) as _i14.AuthService);
 
   @override
-  _i14.OutboxService get outbox => (super.noSuchMethod(
+  _i15.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_73(
+        returnValue: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_73(
+        returnValueForMissingStub: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i14.OutboxService);
+      ) as _i15.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7874,7 +7900,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set sync(_i12.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i12.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i13.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7883,7 +7918,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set auth(_i13.AuthService? value) => super.noSuchMethod(
+  set auth(_i14.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7892,7 +7927,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i15.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -7945,7 +7980,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8039,7 +8074,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8048,7 +8083,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8067,7 +8102,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8078,7 +8113,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8126,7 +8161,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i21.RouteInformation? routeInformation) =>
+          _i22.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8164,7 +8199,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8173,7 +8208,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8182,16 +8217,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
-      ) as _i5.Future<_i19.AppExitResponse>);
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i5.Future<_i20.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/state_event_tile_test.mocks.dart
+++ b/test/widgets/state_event_tile_test.mocks.dart
@@ -2360,6 +2360,13 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
+  bool get isLowPriority => (super.noSuchMethod(
+        Invocation.getter(#isLowPriority),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   Map<String, _i2.MatrixFile> get sendingFilePlaceholders =>
       (super.noSuchMethod(
         Invocation.getter(#sendingFilePlaceholders),
@@ -2866,6 +2873,16 @@ class MockRoom extends _i1.Mock implements _i2.Room {
         Invocation.method(
           #setFavourite,
           [favourite],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+        Invocation.method(
+          #setLowPriority,
+          [lowPriority],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),

--- a/test/widgets/verification_request_listener_test.mocks.dart
+++ b/test/widgets/verification_request_listener_test.mocks.dart
@@ -4,31 +4,33 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i17;
-import 'dart:ui' as _i19;
+import 'dart:typed_data' as _i18;
+import 'dart:ui' as _i20;
 
-import 'package:flutter/services.dart' as _i20;
-import 'package:flutter/widgets.dart' as _i21;
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i18;
-import 'package:kohera/core/services/sub_services/auth_service.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
-import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i14;
+import 'package:kohera/core/services/sub_services/outbox_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/selection_service.dart'
     as _i11;
-import 'package:kohera/core/services/sub_services/sync_service.dart' as _i12;
+import 'package:kohera/core/services/sub_services/space_access_service.dart'
+    as _i12;
+import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i15;
+import 'package:matrix/encryption.dart' as _i16;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -800,8 +802,9 @@ class _FakeSelectionService_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
-  _FakeSyncService_71(
+class _FakeSpaceAccessService_71 extends _i1.SmartFake
+    implements _i12.SpaceAccessService {
+  _FakeSpaceAccessService_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -810,8 +813,8 @@ class _FakeSyncService_71 extends _i1.SmartFake implements _i12.SyncService {
         );
 }
 
-class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
-  _FakeAuthService_72(
+class _FakeSyncService_72 extends _i1.SmartFake implements _i13.SyncService {
+  _FakeSyncService_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -820,9 +823,19 @@ class _FakeAuthService_72 extends _i1.SmartFake implements _i13.AuthService {
         );
 }
 
-class _FakeOutboxService_73 extends _i1.SmartFake
-    implements _i14.OutboxService {
-  _FakeOutboxService_73(
+class _FakeAuthService_73 extends _i1.SmartFake implements _i14.AuthService {
+  _FakeAuthService_73(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeOutboxService_74 extends _i1.SmartFake
+    implements _i15.OutboxService {
+  _FakeOutboxService_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -849,12 +862,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i15.KeyVerificationMethod> get verificationMethods =>
+  Set<_i16.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i15.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i15.KeyVerificationMethod>{},
-      ) as Set<_i15.KeyVerificationMethod>);
+        returnValue: <_i16.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
+      ) as Set<_i16.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -974,11 +987,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1015,11 +1028,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1049,11 +1062,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1062,11 +1075,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1352,34 +1365,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i15.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i15.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i15.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i15.KeyVerification>
+  _i3.CachedStreamController<_i16.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i15.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i15.KeyVerification>(
+                _FakeCachedStreamController_6<_i16.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i15.KeyVerification>);
+          ) as _i3.CachedStreamController<_i16.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1535,7 +1548,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i15.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1824,14 +1837,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2219,8 +2232,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2236,8 +2249,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2278,7 +2291,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2294,7 +2307,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2343,7 +2356,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2364,7 +2377,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2467,7 +2480,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2485,7 +2498,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3004,7 +3017,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i17.Uint8List? file, {
+    _i18.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3356,7 +3369,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3370,7 +3383,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3521,7 +3534,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i17.Uint8List? body,
+    _i18.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4899,7 +4912,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4921,7 +4934,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5415,7 +5428,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5427,7 +5440,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6435,7 +6448,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6446,7 +6459,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6694,7 +6707,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6706,7 +6719,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6966,7 +6979,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6979,7 +6992,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7046,7 +7059,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7059,7 +7072,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7107,7 +7120,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7119,7 +7132,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7367,7 +7380,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7378,7 +7391,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7640,7 +7653,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i17.Uint8List? body, {
+    _i18.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7667,7 +7680,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7697,11 +7710,11 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7774,43 +7787,56 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i11.SelectionService);
 
   @override
-  _i12.SyncService get sync => (super.noSuchMethod(
+  _i12.SpaceAccessService get spaceAccess => (super.noSuchMethod(
+        Invocation.getter(#spaceAccess),
+        returnValue: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+        returnValueForMissingStub: _FakeSpaceAccessService_71(
+          this,
+          Invocation.getter(#spaceAccess),
+        ),
+      ) as _i12.SpaceAccessService);
+
+  @override
+  _i13.SyncService get sync => (super.noSuchMethod(
         Invocation.getter(#sync),
-        returnValue: _FakeSyncService_71(
+        returnValue: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-        returnValueForMissingStub: _FakeSyncService_71(
+        returnValueForMissingStub: _FakeSyncService_72(
           this,
           Invocation.getter(#sync),
         ),
-      ) as _i12.SyncService);
+      ) as _i13.SyncService);
 
   @override
-  _i13.AuthService get auth => (super.noSuchMethod(
+  _i14.AuthService get auth => (super.noSuchMethod(
         Invocation.getter(#auth),
-        returnValue: _FakeAuthService_72(
+        returnValue: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-        returnValueForMissingStub: _FakeAuthService_72(
+        returnValueForMissingStub: _FakeAuthService_73(
           this,
           Invocation.getter(#auth),
         ),
-      ) as _i13.AuthService);
+      ) as _i14.AuthService);
 
   @override
-  _i14.OutboxService get outbox => (super.noSuchMethod(
+  _i15.OutboxService get outbox => (super.noSuchMethod(
         Invocation.getter(#outbox),
-        returnValue: _FakeOutboxService_73(
+        returnValue: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-        returnValueForMissingStub: _FakeOutboxService_73(
+        returnValueForMissingStub: _FakeOutboxService_74(
           this,
           Invocation.getter(#outbox),
         ),
-      ) as _i14.OutboxService);
+      ) as _i15.OutboxService);
 
   @override
   bool get hasSkippedSetup => (super.noSuchMethod(
@@ -7874,7 +7900,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set sync(_i12.SyncService? value) => super.noSuchMethod(
+  set spaceAccess(_i12.SpaceAccessService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #spaceAccess,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  set sync(_i13.SyncService? value) => super.noSuchMethod(
         Invocation.setter(
           #sync,
           value,
@@ -7883,7 +7918,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set auth(_i13.AuthService? value) => super.noSuchMethod(
+  set auth(_i14.AuthService? value) => super.noSuchMethod(
         Invocation.setter(
           #auth,
           value,
@@ -7892,7 +7927,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  set outbox(_i14.OutboxService? value) => super.noSuchMethod(
+  set outbox(_i15.OutboxService? value) => super.noSuchMethod(
         Invocation.setter(
           #outbox,
           value,
@@ -7945,7 +7980,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8039,7 +8074,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8048,7 +8083,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8067,7 +8102,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8078,7 +8113,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8126,7 +8161,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i21.RouteInformation? routeInformation) =>
+          _i22.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8164,7 +8199,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8173,7 +8208,7 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8182,16 +8217,16 @@ class MockMatrixService extends _i1.Mock implements _i18.MatrixService {
       );
 
   @override
-  _i5.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
-      ) as _i5.Future<_i19.AppExitResponse>);
+            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i5.Future<_i20.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8277,7 +8312,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> runKeyRecovery({_i15.OpenSSSS? ssssKey}) =>
+  _i5.Future<void> runKeyRecovery({_i16.OpenSSSS? ssssKey}) =>
       (super.noSuchMethod(
         Invocation.method(
           #runKeyRecovery,
@@ -8331,7 +8366,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8340,7 +8375,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],


### PR DESCRIPTION
Closes #451

## Summary

- Adds `RoomRole` sealed class with `admin` / `moderator` / `member` / `custom` variants
- `fromPowerLevel(int)` factory maps standard levels (100/50/0) to presets, custom otherwise
- `toPowerLevel()` inverse using direct switch destructuring (no casts)
- `label` and `description` getters for UI consumption
- `canAssignRole()` static method enforcing Matrix hierarchy rules
- `map()` / `maybeMap()` for exhaustive pattern matching
- All subclasses annotated `@immutable` with proper `==` / `hashCode`
- 54 unit tests covering round-trips, hierarchy rules, equality, and edge cases
- Zero analyzer issues (`flutter analyze` clean)

## Out of scope (per issue)

UI widgets and write helpers for updating power levels.

## Test plan

- [x] `flutter test test/models/room_role_test.dart` -- 54/54 passing
- [x] `flutter analyze` -- no issues

Generated with [Claude Code](https://claude.com/claude-code)