### PR TITLE
fix(windows): suppress experimental coroutine deprecation for MSVC 14.5+

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -32,6 +32,11 @@ set(CMAKE_CXX_FLAGS_PROFILE "${CMAKE_CXX_FLAGS_RELEASE}")
 # Use Unicode for all projects.
 add_definitions(-DUNICODE -D_UNICODE)
 
+# Suppress MSVC deprecation errors for <experimental/coroutine> used by some
+# plugins (flutter_local_notifications_windows, permission_handler_windows).
+# Remove once upstream plugins migrate to <coroutine>.
+add_definitions(-D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+
 # Compilation settings that should be applied to most targets.
 #
 # Be cautious about adding new options here, as plugins use this function by


### PR DESCRIPTION
## Summary

- Adds `-D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS` to `windows/CMakeLists.txt` global compile definitions
- Unblocks Windows builds on Visual Studio 2026 / MSVC 14.51+ where `<experimental/coroutine>` is a hard error
- Affects `flutter_local_notifications_windows` and `permission_handler_windows` plugins
- One-liner cmake change; remove this once upstream plugins migrate to C++20 `<coroutine>`

## Test plan

- [x] `flutter build windows` succeeds on MSVC 14.51+
- [ ] No regression on earlier MSVC versions (define is a no-op there)

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)