### PR TITLE
fix(macos): bump flutter-webrtc fork to WebRTC-SDK 144 for livekit 2.7

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -614,8 +614,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: bebc809
-      resolved-ref: bebc80907cbc27c0c581edafc87332736c86cd84
+      ref: cc693ec
+      resolved-ref: cc693ec8fd38288ffb7d266af21183a54d0f99c9
       url: "https://github.com/Quantumheart/flutter-webrtc.git"
     source: git
     version: "1.3.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -81,4 +81,4 @@ dependency_overrides:
   flutter_webrtc:
     git:
       url: https://github.com/Quantumheart/flutter-webrtc.git
-      ref: "bebc809"
+      ref: "cc693ec"


### PR DESCRIPTION
## Summary
- macOS CI broke after #c740fa8 bumped `livekit_client` 2.6.4 → 2.7.0; livekit 2.7 pins `WebRTC-SDK 144.7559.01`, but the Quantumheart/flutter-webrtc fork ref `bebc809` still pinned `WebRTC-SDK 137.7151.04`. CocoaPods could not resolve the conflict.
- Bumped the fork on a new branch `fix/webrtc-sdk-144` (commit `cc693ec`) to `WebRTC-SDK 144.7559.04` across android/iOS/macOS — same version upstream flutter-webrtc moved to in #2040.
- Updated `pubspec.yaml` `dependency_overrides` ref to the new fork commit; `pubspec.lock` updated to match.

Companion fork PR: https://github.com/Quantumheart/flutter-webrtc/pull/new/fix/webrtc-sdk-144

## Test plan
- [x] `flutter pub get` succeeds against the new ref
- [x] `flutter analyze` clean
- [x] `flutter test` — full suite passes (1791/1791)
- [ ] CI: `build-macos` job succeeds (the failure this PR is for)
- [ ] CI: `build-linux`, `test`, `test-windows`, `analyze` still green