### PR TITLE
feat(rooms): live reactivity for permissions screen and member sheet

### DIFF
--- a/lib/features/rooms/screens/room_permissions_screen.dart
+++ b/lib/features/rooms/screens/room_permissions_screen.dart
@@ -11,15 +11,56 @@ import 'package:provider/provider.dart';
 /// Displays a "Roles" summary section followed by a "Who can…" section where
 /// each row maps to one or more `m.room.power_levels` fields. Changes are
 /// written immediately via [PowerLevelService.update].
-class RoomPermissionsScreen extends StatelessWidget {
+///
+/// Subscribes to the sync stream and rebuilds when power levels, join rules,
+/// or encryption state change so a concurrent admin's edits appear live.
+class RoomPermissionsScreen extends StatefulWidget {
   const RoomPermissionsScreen({required this.roomId, super.key});
 
   final String roomId;
 
   @override
+  State<RoomPermissionsScreen> createState() => _RoomPermissionsScreenState();
+}
+
+class _RoomPermissionsScreenState extends State<RoomPermissionsScreen> {
+  StreamSubscription<SyncUpdate>? _syncSub;
+  Timer? _debounce;
+
+  static const Set<String> _watchedTypes = {
+    EventTypes.RoomPowerLevels,
+    EventTypes.RoomJoinRules,
+    EventTypes.Encryption,
+  };
+
+  @override
+  void initState() {
+    super.initState();
+    final client = context.read<MatrixService>().client;
+    _syncSub = client.onSync.stream.listen(_onSync);
+  }
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    unawaited(_syncSub?.cancel());
+    super.dispose();
+  }
+
+  void _onSync(SyncUpdate update) {
+    final stateEvents =
+        update.rooms?.join?[widget.roomId]?.state ?? [];
+    if (!stateEvents.any((e) => _watchedTypes.contains(e.type))) return;
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 300), () {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     final room =
-        context.read<MatrixService>().client.getRoomById(roomId);
+        context.read<MatrixService>().client.getRoomById(widget.roomId);
     if (room == null) {
       return Scaffold(
         appBar: AppBar(title: const Text('Permissions')),

--- a/lib/features/rooms/widgets/room_members_section.dart
+++ b/lib/features/rooms/widgets/room_members_section.dart
@@ -30,19 +30,34 @@ class _RoomMembersSectionState extends State<RoomMembersSection> {
   int _loadGeneration = 0;
   final TextEditingController _searchController = TextEditingController();
   String _query = '';
+  StreamSubscription<SyncUpdate>? _syncSub;
+  Timer? _syncDebounce;
 
   @override
   void initState() {
     super.initState();
     unawaited(_loadMembers());
     _searchController.addListener(_onSearchChanged);
+    _syncSub = widget.room.client.onSync.stream.listen(_onSync);
   }
 
   @override
   void dispose() {
+    _syncDebounce?.cancel();
+    unawaited(_syncSub?.cancel());
     _searchController.removeListener(_onSearchChanged);
     _searchController.dispose();
     super.dispose();
+  }
+
+  void _onSync(SyncUpdate update) {
+    final stateEvents =
+        update.rooms?.join?[widget.room.id]?.state ?? [];
+    if (!stateEvents.any((e) => e.type == EventTypes.RoomPowerLevels)) return;
+    _syncDebounce?.cancel();
+    _syncDebounce = Timer(const Duration(milliseconds: 300), () {
+      if (mounted) unawaited(_loadMembers());
+    });
   }
 
   void _onSearchChanged() {
@@ -334,6 +349,31 @@ class _MemberSheetDialogState extends State<_MemberSheetDialog> {
   String? _roleError;
   bool _actionLoading = false;
   String? _actionError;
+  StreamSubscription<SyncUpdate>? _syncSub;
+  Timer? _syncDebounce;
+
+  @override
+  void initState() {
+    super.initState();
+    _syncSub = widget.room.client.onSync.stream.listen(_onSync);
+  }
+
+  @override
+  void dispose() {
+    _syncDebounce?.cancel();
+    unawaited(_syncSub?.cancel());
+    super.dispose();
+  }
+
+  void _onSync(SyncUpdate update) {
+    final stateEvents =
+        update.rooms?.join?[widget.room.id]?.state ?? [];
+    if (!stateEvents.any((e) => e.type == EventTypes.RoomPowerLevels)) return;
+    _syncDebounce?.cancel();
+    _syncDebounce = Timer(const Duration(milliseconds: 300), () {
+      if (mounted) setState(() {});
+    });
+  }
 
   Future<void> _changeRole(RoomRole newRole, int currentPowerLevel) async {
     final currentRole = RoomRole.fromPowerLevel(currentPowerLevel);

--- a/test/screens/room_permissions_screen_test.dart
+++ b/test/screens/room_permissions_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/features/rooms/screens/room_permissions_screen.dart';
 import 'package:matrix/matrix.dart';
+import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
@@ -53,6 +54,7 @@ void main() {
     mockPlEvent = MockEvent();
 
     when(mockMatrixService.client).thenReturn(mockClient);
+    when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
     when(mockClient.getRoomById(_roomId)).thenReturn(mockRoom);
     when(mockRoom.id).thenReturn(_roomId);
     when(mockRoom.client).thenReturn(mockClient);

--- a/test/widgets/room_members_section_test.dart
+++ b/test/widgets/room_members_section_test.dart
@@ -6,6 +6,7 @@ import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/features/rooms/models/room_role.dart';
 import 'package:kohera/features/rooms/widgets/room_members_section.dart';
 import 'package:matrix/matrix.dart';
+import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
@@ -38,6 +39,7 @@ void main() {
     mockRoom = MockRoom();
 
     when(mockMatrixService.client).thenReturn(mockClient);
+    when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
     when(mockRoom.id).thenReturn('!room:example.com');
     when(mockRoom.client).thenReturn(mockClient);
     when(mockRoom.summary).thenReturn(RoomSummary.fromJson({


### PR DESCRIPTION
## Summary

- `RoomPermissionsScreen` converted to `StatefulWidget`; subscribes to `client.onSync.stream` and rebuilds (300 ms debounce) when `m.room.power_levels`, `m.room.join_rules`, or `m.room.encryption` state events arrive for this room — a concurrent admin's changes now appear live
- `_RoomMembersSectionState` subscribes to power-level events and re-loads/re-sorts the member list when they change, so role badges update without reopening the panel
- `_MemberSheetDialogState` subscribes to power-level events and rebuilds the role dropdown live, so the viewed user's role reflects changes made from another client
- All subscriptions use a 300 ms debounce and are cancelled cleanly in `dispose()`

## Test plan

- [x] All 47 tests in `room_permissions_screen_test.dart` + `room_members_section_test.dart` pass
- [x] `client.onSync` stubbed with `CachedStreamController` in both test suites — no regressions
- [ ] Manual test: open Permissions screen on two clients, change a permission on one, verify the other updates within ~1 s
- [ ] Manual test: open member sheet, change a user's role from another client, verify the dropdown updates live

Closes #459

🤖 Generated with [Claude Code](https://claude.com/claude-code)