### PR TITLE
fix(docker): bump Flutter to 3.44.0 to match local and CI SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # ── Build Stage ──────────────────────────────────────────────────────
 FROM docker.io/library/debian:bookworm-slim AS build
 
-ARG FLUTTER_VERSION=3.41.6
+ARG FLUTTER_VERSION=3.44.0
 ARG VODOZEMAC_VERSION=0.5.0
 ARG GIPHY_API_KEY
 


### PR DESCRIPTION
## Summary

The Dockerfile was pinned to Flutter `3.41.6` while the codebase was updated to use Flutter 3.44 APIs in commit 5c7696b (May 19). This caused the Docker web build to fail with:

```
Error: No named parameter with the name 'alignment'.   (room_list.dart)
Error: No named parameter with the name 'onReorderItem'. (space_rail.dart)
```

## Why it's safe

All other CI jobs (analyze, unit tests, Linux, macOS, Windows) use `subosito/flutter-action` with `channel: stable` or `flutter-version: '3.44.x'` and have been passing on 3.44 all along. The Dockerfile was the only straggler.

## Change

```diff
- ARG FLUTTER_VERSION=3.41.6
+ ARG FLUTTER_VERSION=3.44.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)