### PR TITLE
feat(rooms): advanced power-level editor section

### DIFF
--- a/lib/features/rooms/screens/room_permissions_screen.dart
+++ b/lib/features/rooms/screens/room_permissions_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/features/rooms/services/power_level_service.dart';
 import 'package:matrix/matrix.dart';
@@ -75,6 +76,7 @@ class _RoomPermissionsScreenState extends State<RoomPermissionsScreen> {
           _RolesSection(room: room),
           _WhoCanSection(room: room),
           _DangerZoneSection(room: room),
+          _AdvancedSection(room: room),
         ],
       ),
     );
@@ -906,6 +908,449 @@ class _DangerZoneSectionState extends State<_DangerZoneSection> {
 
         const SizedBox(height: 24),
       ],
+    );
+  }
+}
+// ── Advanced section ──────────────────────────────────────────
+
+/// One row in the per-event-type editor: an event type string + integer level.
+class _EventRowData {
+  _EventRowData({required String type, required String level})
+      : typeCtrl = TextEditingController(text: type),
+        levelCtrl = TextEditingController(text: level);
+
+  final TextEditingController typeCtrl;
+  final TextEditingController levelCtrl;
+
+  void dispose() {
+    typeCtrl.dispose();
+    levelCtrl.dispose();
+  }
+}
+
+/// Collapsed-by-default section that exposes raw `m.room.power_levels` fields
+/// (scalars + per-event-type map). Changes are applied atomically via a single
+/// [setRoomStateWithKey] call so deletions are possible (PowerLevelService
+/// never removes existing keys).
+///
+/// Hidden entirely when the local user cannot change power levels.
+class _AdvancedSection extends StatefulWidget {
+  const _AdvancedSection({required this.room});
+
+  final Room room;
+
+  @override
+  State<_AdvancedSection> createState() => _AdvancedSectionState();
+}
+
+class _AdvancedSectionState extends State<_AdvancedSection> {
+  bool _expanded = false;
+  bool _saving = false;
+  String? _error;
+
+  late TextEditingController _usersDefaultCtrl;
+  late TextEditingController _stateDefaultCtrl;
+  late TextEditingController _eventsDefaultCtrl;
+  final List<_EventRowData> _eventRows = [];
+
+  Map<String, Object?> get _currentContent =>
+      widget.room.getState(EventTypes.RoomPowerLevels)?.content ?? {};
+
+  @override
+  void initState() {
+    super.initState();
+    _initFromContent(_currentContent);
+  }
+
+  void _initFromContent(Map<String, Object?> c) {
+    _usersDefaultCtrl = TextEditingController(
+      text: _plScalar(c, 'users_default', 0).toString(),
+    );
+    _stateDefaultCtrl = TextEditingController(
+      text: _plScalar(c, 'state_default', 50).toString(),
+    );
+    _eventsDefaultCtrl = TextEditingController(
+      text: _plScalar(c, 'events_default', 0).toString(),
+    );
+    final events = c.tryGetMap<String, Object?>('events') ?? {};
+    _eventRows
+      ..clear()
+      ..addAll(
+        events.entries.map(
+          (e) => _EventRowData(
+            type: e.key,
+            level: (e.value as int? ?? 0).toString(),
+          ),
+        ),
+      );
+  }
+
+  @override
+  void dispose() {
+    _usersDefaultCtrl.dispose();
+    _stateDefaultCtrl.dispose();
+    _eventsDefaultCtrl.dispose();
+    for (final r in _eventRows) {
+      r.dispose();
+    }
+    super.dispose();
+  }
+
+  void _reset() {
+    for (final r in _eventRows) {
+      r.dispose();
+    }
+    _initFromContent(_currentContent);
+    setState(() => _error = null);
+  }
+
+  /// Validates and returns a human-readable error, or null if clean.
+  String? _validate() {
+    for (final ctrl in [_usersDefaultCtrl, _stateDefaultCtrl, _eventsDefaultCtrl]) {
+      if (int.tryParse(ctrl.text.trim()) == null) {
+        return 'Scalar values must be integers.';
+      }
+    }
+    final types = <String>[];
+    for (final row in _eventRows) {
+      final t = row.typeCtrl.text.trim();
+      final l = row.levelCtrl.text.trim();
+      if (t.isEmpty) return 'Event type cannot be empty.';
+      if (int.tryParse(l) == null) return 'Level for "$t" must be an integer.';
+      if (types.contains(t)) return 'Duplicate event type: "$t".';
+      types.add(t);
+    }
+    return null;
+  }
+
+  Future<void> _apply() async {
+    final validationError = _validate();
+    if (validationError != null) {
+      setState(() => _error = validationError);
+      return;
+    }
+
+    setState(() {
+      _saving = true;
+      _error = null;
+    });
+
+    try {
+      final content = _currentContent.copy();
+
+      content['users_default'] = int.parse(_usersDefaultCtrl.text.trim());
+      content['state_default'] = int.parse(_stateDefaultCtrl.text.trim());
+      content['events_default'] = int.parse(_eventsDefaultCtrl.text.trim());
+
+      final eventsMap = <String, Object?>{};
+      for (final row in _eventRows) {
+        eventsMap[row.typeCtrl.text.trim()] =
+            int.parse(row.levelCtrl.text.trim());
+      }
+      content['events'] = eventsMap;
+
+      await widget.room.client.setRoomStateWithKey(
+        widget.room.id,
+        EventTypes.RoomPowerLevels,
+        '',
+        content,
+      );
+    } on MatrixException catch (e) {
+      if (mounted) setState(() => _error = e.errorMessage);
+    } catch (e) {
+      if (mounted) setState(() => _error = e.toString());
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  bool get _isDirty {
+    final c = _currentContent;
+    if (_usersDefaultCtrl.text.trim() !=
+        _plScalar(c, 'users_default', 0).toString()) {
+      return true;
+    }
+    if (_stateDefaultCtrl.text.trim() !=
+        _plScalar(c, 'state_default', 50).toString()) {
+      return true;
+    }
+    if (_eventsDefaultCtrl.text.trim() !=
+        _plScalar(c, 'events_default', 0).toString()) {
+      return true;
+    }
+    final savedEvents = c.tryGetMap<String, Object?>('events') ?? {};
+    if (_eventRows.length != savedEvents.length) return true;
+    for (final row in _eventRows) {
+      final t = row.typeCtrl.text.trim();
+      final saved = savedEvents[t];
+      if (saved == null) return true;
+      if (row.levelCtrl.text.trim() != saved.toString()) return true;
+    }
+    return false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.room.canChangePowerLevel) return const SizedBox.shrink();
+
+    final tt = Theme.of(context).textTheme;
+    final cs = Theme.of(context).colorScheme;
+    final validationError = _validate();
+    final canApply = !_saving && _isDirty && validationError == null;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        InkWell(
+          onTap: () => setState(() => _expanded = !_expanded),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+            child: Row(
+              children: [
+                Text(
+                  'ADVANCED',
+                  style: tt.labelSmall?.copyWith(
+                    color: cs.error,
+                    letterSpacing: 1.5,
+                  ),
+                ),
+                const Spacer(),
+                AnimatedRotation(
+                  turns: _expanded ? 0.5 : 0,
+                  duration: const Duration(milliseconds: 200),
+                  child: Icon(Icons.expand_more, size: 20, color: cs.error),
+                ),
+              ],
+            ),
+          ),
+        ),
+        AnimatedSize(
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeInOut,
+          child: _expanded ? _buildBody(context, tt, cs, canApply, validationError) : const SizedBox.shrink(),
+        ),
+        const SizedBox(height: 16),
+      ],
+    );
+  }
+
+  Widget _buildBody(
+    BuildContext context,
+    TextTheme tt,
+    ColorScheme cs,
+    bool canApply,
+    String? validationError,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Warning banner
+          Container(
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: cs.errorContainer,
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(
+                  Icons.warning_amber_rounded,
+                  size: 18,
+                  color: cs.onErrorContainer,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'These are raw power-level values. Incorrect settings can '
+                    'lock everyone out of the room.',
+                    style: tt.bodySmall
+                        ?.copyWith(color: cs.onErrorContainer),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+
+          // Scalar fields
+          Text('Scalar defaults', style: tt.labelMedium),
+          const SizedBox(height: 8),
+          _ScalarField(
+            label: 'users_default',
+            controller: _usersDefaultCtrl,
+            onChanged: (_) => setState(() {}),
+          ),
+          const SizedBox(height: 8),
+          _ScalarField(
+            label: 'state_default',
+            controller: _stateDefaultCtrl,
+            onChanged: (_) => setState(() {}),
+          ),
+          const SizedBox(height: 8),
+          _ScalarField(
+            label: 'events_default',
+            controller: _eventsDefaultCtrl,
+            onChanged: (_) => setState(() {}),
+          ),
+          const SizedBox(height: 16),
+
+          // Per-event rows
+          Row(
+            children: [
+              Text('Per-event overrides', style: tt.labelMedium),
+              const Spacer(),
+              TextButton.icon(
+                icon: const Icon(Icons.add, size: 16),
+                label: const Text('Add'),
+                onPressed: () => setState(() {
+                  _eventRows.add(_EventRowData(type: '', level: '50'));
+                }),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          for (int i = 0; i < _eventRows.length; i++)
+            _EventRow(
+              key: ObjectKey(_eventRows[i]),
+              row: _eventRows[i],
+              onChanged: () => setState(() {}),
+              onRemove: () => setState(() {
+                _eventRows[i].dispose();
+                _eventRows.removeAt(i);
+              }),
+            ),
+
+          // Validation or server error
+          if (validationError != null && _isDirty)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Text(
+                validationError,
+                style: tt.bodySmall?.copyWith(color: cs.error),
+              ),
+            )
+          else if (_error != null)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Text(
+                _error!,
+                style: tt.bodySmall?.copyWith(color: cs.error),
+              ),
+            ),
+
+          const SizedBox(height: 12),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              TextButton(
+                onPressed: _saving ? null : _reset,
+                child: const Text('Reset'),
+              ),
+              const SizedBox(width: 8),
+              FilledButton(
+                onPressed: canApply ? _apply : null,
+                child: _saving
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Apply'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+}
+
+class _ScalarField extends StatelessWidget {
+  const _ScalarField({
+    required this.label,
+    required this.controller,
+    required this.onChanged,
+  });
+
+  final String label;
+  final TextEditingController controller;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(
+        labelText: label,
+        isDense: true,
+        border: const OutlineInputBorder(),
+      ),
+      keyboardType: TextInputType.number,
+      inputFormatters: [
+        FilteringTextInputFormatter.allow(RegExp(r'-?\d*')),
+      ],
+      onChanged: onChanged,
+    );
+  }
+}
+
+class _EventRow extends StatelessWidget {
+  const _EventRow({
+    required this.row,
+    required this.onChanged,
+    required this.onRemove,
+    super.key,
+  });
+
+  final _EventRowData row;
+  final VoidCallback onChanged;
+  final VoidCallback onRemove;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        children: [
+          Expanded(
+            flex: 3,
+            child: TextField(
+              controller: row.typeCtrl,
+              decoration: const InputDecoration(
+                labelText: 'Event type',
+                isDense: true,
+                border: OutlineInputBorder(),
+              ),
+              onChanged: (_) => onChanged(),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: TextField(
+              controller: row.levelCtrl,
+              decoration: const InputDecoration(
+                labelText: 'Level',
+                isDense: true,
+                border: OutlineInputBorder(),
+              ),
+              keyboardType: TextInputType.number,
+              inputFormatters: [
+                FilteringTextInputFormatter.allow(RegExp(r'-?\d*')),
+              ],
+              onChanged: (_) => onChanged(),
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.remove_circle_outline, size: 20),
+            onPressed: onRemove,
+            tooltip: 'Remove',
+          ),
+        ],
+      ),
     );
   }
 }

--- a/test/screens/room_permissions_screen_test.dart
+++ b/test/screens/room_permissions_screen_test.dart
@@ -499,4 +499,401 @@ void main() {
       expect(events[EventTypes.RoomPowerLevels], 100);
     });
   });
+  group('Advanced section', () {
+    Future<void> scrollToAdvanced(WidgetTester tester) async {
+      await tester.drag(find.byType(ListView), const Offset(0, -3000));
+      await tester.pumpAndSettle();
+    }
+
+    Future<void> expandAdvanced(WidgetTester tester) async {
+      await scrollToAdvanced(tester);
+      await tester.tap(find.text('ADVANCED'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('ADVANCED header is hidden when canChangePowerLevel is false',
+        (tester) async {
+      when(mockRoom.canChangePowerLevel).thenReturn(false);
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await scrollToAdvanced(tester);
+
+      expect(find.text('ADVANCED'), findsNothing);
+    });
+
+    testWidgets('ADVANCED header is visible when canChangePowerLevel is true',
+        (tester) async {
+      when(mockRoom.canChangePowerLevel).thenReturn(true);
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await scrollToAdvanced(tester);
+
+      expect(find.text('ADVANCED'), findsOneWidget);
+    });
+
+    testWidgets('section is collapsed by default', (tester) async {
+      when(mockRoom.canChangePowerLevel).thenReturn(true);
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await scrollToAdvanced(tester);
+
+      expect(find.text('users_default'), findsNothing);
+    });
+
+    testWidgets('tapping ADVANCED expands scalar fields', (tester) async {
+      when(mockRoom.canChangePowerLevel).thenReturn(true);
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await expandAdvanced(tester);
+
+      expect(find.text('users_default'), findsOneWidget);
+      expect(find.text('state_default'), findsOneWidget);
+      expect(find.text('events_default'), findsOneWidget);
+    });
+
+    testWidgets('scalar fields show values from power_levels content',
+        (tester) async {
+      when(mockRoom.canChangePowerLevel).thenReturn(true);
+      when(mockPlEvent.content).thenReturn(
+        _plContent(stateDefault: 75, eventsDefault: 25),
+      );
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await expandAdvanced(tester);
+
+      // state_default label field should have '75' as its value.
+      final stateField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'state_default'),
+      );
+      expect(stateField.controller?.text, '75');
+
+      final eventsField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'events_default'),
+      );
+      expect(eventsField.controller?.text, '25');
+    });
+
+    testWidgets('Apply button is disabled when nothing has changed',
+        (tester) async {
+      when(mockRoom.canChangePowerLevel).thenReturn(true);
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await expandAdvanced(tester);
+
+      final applyButton = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Apply'),
+      );
+      expect(applyButton.onPressed, isNull);
+    });
+
+    testWidgets('editing a scalar field enables Apply button', (tester) async {
+      when(mockRoom.canChangePowerLevel).thenReturn(true);
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await expandAdvanced(tester);
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'users_default'),
+        '10',
+      );
+      await tester.pump();
+
+      final applyButton = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Apply'),
+      );
+      expect(applyButton.onPressed, isNotNull);
+    });
+
+    testWidgets('Apply calls setRoomStateWithKey with updated scalar',
+        (tester) async {
+      when(mockRoom.canChangePowerLevel).thenReturn(true);
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await expandAdvanced(tester);
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'users_default'),
+        '10',
+      );
+      await tester.pump();
+
+      await tester.ensureVisible(find.widgetWithText(FilledButton, 'Apply'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilledButton, 'Apply'));
+      await tester.pumpAndSettle();
+
+      final captured = verify(
+        mockClient.setRoomStateWithKey(
+          _roomId,
+          EventTypes.RoomPowerLevels,
+          '',
+          captureAny,
+        ),
+      ).captured.single as Map<String, Object?>;
+
+      expect(captured['users_default'], 10);
+    });
+
+    testWidgets('non-integer input shows validation error and disables Apply',
+        (tester) async {
+      when(mockRoom.canChangePowerLevel).thenReturn(true);
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await expandAdvanced(tester);
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'state_default'),
+        'abc',
+      );
+      await tester.pump();
+
+      expect(find.text('Scalar values must be integers.'), findsOneWidget);
+      final applyButton = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Apply'),
+      );
+      expect(applyButton.onPressed, isNull);
+    });
+
+    testWidgets('Reset restores fields to server values', (tester) async {
+      when(mockRoom.canChangePowerLevel).thenReturn(true);
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await expandAdvanced(tester);
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'users_default'),
+        '99',
+      );
+      await tester.pump();
+
+      await tester.ensureVisible(find.text('Reset'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Reset'));
+      await tester.pumpAndSettle();
+
+      final usersField = tester.widget<TextField>(
+        find.widgetWithText(TextField, 'users_default'),
+      );
+      expect(usersField.controller?.text, '0');
+    });
+
+    testWidgets('existing per-event rows are rendered when expanded',
+        (tester) async {
+      when(mockRoom.canChangePowerLevel).thenReturn(true);
+      when(mockPlEvent.content).thenReturn(
+        _plContent(events: {'m.room.encryption': 100}),
+      );
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await expandAdvanced(tester);
+
+      expect(find.text('m.room.encryption'), findsOneWidget);
+    });
+
+    testWidgets('Add button appends a new event row', (tester) async {
+      when(mockRoom.canChangePowerLevel).thenReturn(true);
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await expandAdvanced(tester);
+
+      expect(find.widgetWithText(TextField, 'Event type'), findsNothing);
+
+      // Scroll to the Add icon (inside TextButton.icon) before tapping.
+      await tester.ensureVisible(find.byIcon(Icons.add));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.add));
+      await tester.pumpAndSettle();
+
+      expect(find.widgetWithText(TextField, 'Event type'), findsOneWidget);
+    });
+
+    testWidgets('Remove button deletes the event row', (tester) async {
+      when(mockRoom.canChangePowerLevel).thenReturn(true);
+      when(mockPlEvent.content).thenReturn(
+        _plContent(events: {'m.room.encryption': 100}),
+      );
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await expandAdvanced(tester);
+
+      expect(find.text('m.room.encryption'), findsOneWidget);
+
+      // Use the icon widget directly — byTooltip resolves to the overlay render
+      // object which can be off-screen even after ensureVisible.
+      await tester.ensureVisible(find.byIcon(Icons.remove_circle_outline));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.remove_circle_outline));
+      await tester.pumpAndSettle();
+
+      expect(find.text('m.room.encryption'), findsNothing);
+    });
+
+    testWidgets('duplicate event type shows validation error', (tester) async {
+      when(mockRoom.canChangePowerLevel).thenReturn(true);
+      when(mockPlEvent.content).thenReturn(
+        _plContent(events: {'m.room.encryption': 100}),
+      );
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await expandAdvanced(tester);
+
+      // Add a second row.
+      await tester.ensureVisible(find.byIcon(Icons.add));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.add));
+      await tester.pumpAndSettle();
+
+      // enterText works off-screen (uses semantics, not hit-test).
+      final typeFields = find.widgetWithText(TextField, 'Event type');
+      await tester.enterText(typeFields.last, 'm.room.encryption');
+      await tester.pump();
+
+      expect(
+        find.textContaining('Duplicate event type'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('empty event type shows validation error and disables Apply',
+        (tester) async {
+      when(mockRoom.canChangePowerLevel).thenReturn(true);
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await expandAdvanced(tester);
+
+      await tester.ensureVisible(find.byIcon(Icons.add));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.add));
+      await tester.pumpAndSettle();
+
+      // New row starts with an empty type — validation fires immediately.
+      expect(find.text('Event type cannot be empty.'), findsOneWidget);
+      final applyButton = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Apply'),
+      );
+      expect(applyButton.onPressed, isNull);
+    });
+
+    testWidgets(
+        'Apply with removed row sends events map without the deleted key',
+        (tester) async {
+      when(mockRoom.canChangePowerLevel).thenReturn(true);
+      when(mockPlEvent.content).thenReturn(
+        _plContent(events: {'m.room.encryption': 100, 'm.room.name': 50}),
+      );
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await expandAdvanced(tester);
+
+      // Remove whichever row appears first (m.room.encryption).
+      await tester.ensureVisible(find.byIcon(Icons.remove_circle_outline).first);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.remove_circle_outline).first);
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(find.widgetWithText(FilledButton, 'Apply'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilledButton, 'Apply'));
+      await tester.pumpAndSettle();
+
+      final captured = verify(
+        mockClient.setRoomStateWithKey(any, any, any, captureAny),
+      ).captured.single as Map<String, Object?>;
+
+      final events = captured['events']! as Map<String, Object?>;
+      expect(events.length, 1);
+      expect(events.containsKey('m.room.encryption'), isFalse);
+      expect(events['m.room.name'], 50);
+    });
+
+    testWidgets('Apply with added row includes new key in payload',
+        (tester) async {
+      when(mockRoom.canChangePowerLevel).thenReturn(true);
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await expandAdvanced(tester);
+
+      await tester.ensureVisible(find.byIcon(Icons.add));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.add));
+      await tester.pumpAndSettle();
+
+      final typeFields = find.widgetWithText(TextField, 'Event type');
+      await tester.enterText(typeFields.last, 'm.room.history_visibility');
+
+      final levelFields = find.widgetWithText(TextField, 'Level');
+      await tester.enterText(levelFields.last, '100');
+      await tester.pump();
+
+      await tester.ensureVisible(find.widgetWithText(FilledButton, 'Apply'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilledButton, 'Apply'));
+      await tester.pumpAndSettle();
+
+      final captured = verify(
+        mockClient.setRoomStateWithKey(any, any, any, captureAny),
+      ).captured.single as Map<String, Object?>;
+
+      final events = captured['events']! as Map<String, Object?>;
+      expect(events['m.room.history_visibility'], 100);
+    });
+
+    testWidgets('server error is shown after failed Apply', (tester) async {
+      when(mockRoom.canChangePowerLevel).thenReturn(true);
+      when(mockClient.setRoomStateWithKey(any, any, any, any))
+          .thenAnswer((_) async => throw MatrixException.fromJson({
+                'errcode': 'M_FORBIDDEN',
+                'error': 'You do not have permission',
+              },),);
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await expandAdvanced(tester);
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'users_default'),
+        '10',
+      );
+      await tester.pump();
+
+      await tester.ensureVisible(find.widgetWithText(FilledButton, 'Apply'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilledButton, 'Apply'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('You do not have permission'), findsOneWidget);
+    });
+
+    testWidgets('second tap on ADVANCED collapses the section', (tester) async {
+      when(mockRoom.canChangePowerLevel).thenReturn(true);
+
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+      await expandAdvanced(tester);
+
+      expect(find.text('users_default'), findsOneWidget);
+
+      await tester.tap(find.text('ADVANCED'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('users_default'), findsNothing);
+    });
+  });
 }


### PR DESCRIPTION
Closes #458

## Summary

- Adds a collapsed-by-default **ADVANCED** section at the bottom of the permissions screen
- Exposes raw `m.room.power_levels` scalar fields (`users_default`, `state_default`, `events_default`) as editable text inputs
- Dynamic per-event-type override editor: add rows, remove rows, set integer levels
- Writes changes atomically via a single `setRoomStateWithKey` call so row deletions are correctly reflected (bypasses `PowerLevelService` which only merges, never deletes)
- Section is hidden entirely when the local user lacks `canChangePowerLevel`
- Warning banner reminds users that incorrect settings can lock everyone out

## Test plan

- [ ] Section hidden when not admin (default in setUp)
- [ ] Section visible, collapsed by default when admin
- [ ] Tap ADVANCED → expands scalar fields with correct initial values
- [ ] Apply disabled when unchanged; enabled after editing a scalar
- [ ] Apply calls `setRoomStateWithKey` with updated content
- [ ] Non-integer input shows validation error, disables Apply
- [ ] Reset button restores all fields to server state
- [ ] Existing per-event rows rendered on expansion
- [ ] Add button appends a new blank event row
- [ ] Remove button deletes the row
- [ ] Duplicate event type key shows validation error

33 tests total in `test/screens/room_permissions_screen_test.dart` — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)