### PR TITLE
chore(ci): remove windows test job from PR pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,18 +44,6 @@ jobs:
           files: coverage/lcov.info
           fail_ci_if_error: false
 
-  test-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: ${{ env.FLUTTER_CHANNEL }}
-          cache: true
-      - run: flutter pub get
-      - run: dart run build_runner build --delete-conflicting-outputs
-      - run: flutter test
-
   build-linux:
     if: github.event_name == 'push'
     needs: [analyze, test]


### PR DESCRIPTION
## Summary

- Removes the `test-windows` job from `ci.yml` so it no longer runs on every PR
- Windows is already covered at release time by the `build-windows` job in `release.yml`
- The Flutter unit test suite is platform-independent — the `test` job on `ubuntu-latest` provides equivalent signal at a fraction of the cost and wait time

## Test plan

- [ ] Verify CI on this PR only shows `analyze` and `test` (ubuntu) jobs — no `test-windows`
- [ ] Confirm `release.yml` still has `build-windows` for release builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)