### PR TITLE
fix(ci): pod repo update before macOS build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,4 +81,6 @@ jobs:
           channel: ${{ env.FLUTTER_CHANNEL }}
           cache: true
       - run: flutter pub get
+      - run: pod repo update
+        working-directory: macos
       - run: flutter build macos --release --dart-define=GIPHY_API_KEY=${{ secrets.GIPHY_API_KEY }}


### PR DESCRIPTION
## Summary
- macOS CI build failing with `CocoaPods's specs repository is too out-of-date to satisfy dependencies.` during `pod install`.
- Add `pod repo update` step in `macos/` before `flutter build macos`.

Failing run: https://github.com/Quantumheart/Kohera/actions/runs/26335546516/job/77528921609

## Test plan
- [ ] CI `build-macos` job passes