### PR TITLE
fix(ci): force pod install --repo-update for macOS build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
           channel: ${{ env.FLUTTER_CHANNEL }}
           cache: true
       - run: flutter pub get
-      - run: pod repo update
+      - name: Pre-build macOS Pods (force repo update)
         working-directory: macos
+        run: |
+          flutter precache --macos
+          pod install --repo-update
       - run: flutter build macos --release --dart-define=GIPHY_API_KEY=${{ secrets.GIPHY_API_KEY }}


### PR DESCRIPTION
## Summary
- Previous fix added \`pod repo update\` but it is effectively a no-op when CocoaPods uses the CDN (default on macos-latest), so macOS build kept failing with \"CocoaPods's specs repository is too out-of-date\".
- Run \`flutter precache --macos\` then \`pod install --repo-update\` in \`macos/\` before \`flutter build macos\` to force a real spec refresh.

Latest failing run: https://github.com/Quantumheart/Kohera/actions/runs/26335915443

## Test plan
- [ ] CI \`build-macos\` job passes