### PR TITLE
fix(chat): suppress web paste permission popup on Ctrl+V

### DIFF
--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -441,7 +441,7 @@ class _ChatScreenState extends State<ChatScreen>
                   );
                 }
               : null,
-          onPasteImage: (_isDesktop || kIsWeb) ? _handlePasteImage : null,
+          onPasteImage: _isDesktop ? _handlePasteImage : null,
           uploadNotifier: _compose.uploadNotifier,
           room: room,
           joinedRooms: context.read<SelectionService>().rooms,


### PR DESCRIPTION
## Summary

- Restricts `onPasteImage` to native desktop only (removes `kIsWeb` from the condition)
- On web, `Pasteboard.image` calls `navigator.clipboard.read()` which triggers the browser's clipboard-read permission dialog on every Ctrl+V keypress — even when the user just wants to paste text
- Image paste via Ctrl+V on web is disabled; file/image attachment via the attach button remains unaffected

## Root cause

`ComposeBar._handleKeyEvent` detects Ctrl+V and calls `onPasteImage()` when the callback is non-null. The `pasteboard` package's web implementation calls `navigator.clipboard.read()` unconditionally, which the browser gates behind a permission prompt.

## Test plan

- [x] Tested locally on Chrome: Ctrl+V in compose bar no longer triggers the paste permission popup
- [ ] Verify native desktop (macOS/Linux/Windows) image paste still works via Ctrl+V
- [ ] Verify web file attachment button still works normally

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)