### PR TITLE
feat(rooms): selectable MXID + copy-to-clipboard in member sheet

### DIFF
--- a/lib/features/rooms/widgets/room_members_section.dart
+++ b/lib/features/rooms/widgets/room_members_section.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
@@ -640,10 +641,30 @@ class _MemberSheetDialogState extends State<_MemberSheetDialog> {
             style: tt.titleMedium,
             textAlign: TextAlign.center,
           ),
-          Text(
-            user.id,
-            style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant),
-            textAlign: TextAlign.center,
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Flexible(
+                child: SelectableText(
+                  user.id,
+                  style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.copy_outlined),
+                iconSize: 14,
+                visualDensity: VisualDensity.compact,
+                tooltip: 'Copy MXID',
+                color: cs.onSurfaceVariant,
+                onPressed: () {
+                  unawaited(Clipboard.setData(ClipboardData(text: user.id)));
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Copied to clipboard')),
+                  );
+                },
+              ),
+            ],
           ),
           const SizedBox(height: 4),
           Text(

--- a/test/widgets/room_members_section_test.dart
+++ b/test/widgets/room_members_section_test.dart
@@ -1,6 +1,7 @@
 ﻿import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/features/rooms/models/room_role.dart';
@@ -669,6 +670,56 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.byType(DropdownButton<RoomRole>), findsNothing);
+      });
+    });
+
+    group('MXID copy', () {
+      testWidgets('copy button writes MXID to clipboard', (tester) async {
+        final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
+        when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [alice]);
+
+        String? copiedText;
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          (call) async {
+            if (call.method == 'Clipboard.setData') {
+              copiedText = (call.arguments as Map)['text'] as String;
+            }
+            return null;
+          },
+        );
+
+        await tester.pumpWidget(buildTestWidget());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Alice'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byIcon(Icons.copy_outlined));
+        await tester.pumpAndSettle();
+
+        expect(copiedText, '@alice:example.com');
+      });
+
+      testWidgets('copy button shows snackbar confirmation', (tester) async {
+        final alice = _makeUser('@alice:example.com', 'Alice', room: mockRoom);
+        when(mockRoom.requestParticipants(any)).thenAnswer((_) async => [alice]);
+
+        tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          (_) async => null,
+        );
+
+        await tester.pumpWidget(buildTestWidget());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Alice'));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byIcon(Icons.copy_outlined));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Copied to clipboard'), findsOneWidget);
       });
     });
   });


### PR DESCRIPTION
## Summary

- Replaces the plain `Text` widget for `user.id` in `_MemberSheetDialog` with `SelectableText` — tap-hold shows the system copy menu
- Adds an `Icons.copy_outlined` icon button inline with the MXID that writes it to the clipboard and shows a `SnackBar` confirmation ("Copied to clipboard")
- Long MXIDs wrap correctly via `Flexible` wrapping the `SelectableText`

## Test plan

- [x] `copy button writes MXID to clipboard` — verifies `Clipboard.setData` receives the correct MXID
- [x] `copy button shows snackbar confirmation` — verifies the SnackBar appears after tapping copy
- [x] All 30 existing member section tests still pass

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)