### PR TITLE
fix(chat): unstick voice recording UI on iOS

### DIFF
--- a/lib/features/chat/services/voice_recording_controller.dart
+++ b/lib/features/chat/services/voice_recording_controller.dart
@@ -39,14 +39,22 @@ class VoiceRecordingController extends ChangeNotifier {
     }
 
     if (kIsWeb) {
-      _filePath = 'recording.opus';
+      _filePath = 'recording.m4a';
     } else {
       final dir = await getTemporaryDirectory();
       _filePath =
-          '${dir.path}/kohera_voice_${DateTime.now().millisecondsSinceEpoch}.mp3';
+          '${dir.path}/kohera_voice_${DateTime.now().millisecondsSinceEpoch}.m4a';
     }
 
-    await _service.start(_filePath!);
+    try {
+      await _service.start(_filePath!);
+    } catch (e, st) {
+      debugPrint('[Kohera] Voice recording start failed: $e\n$st');
+      _state = VoiceRecordingState.idle;
+      _filePath = null;
+      notifyListeners();
+      return false;
+    }
 
     _elapsed = Duration.zero;
     _timer = Timer.periodic(const Duration(seconds: 1), (_) {
@@ -60,6 +68,10 @@ class VoiceRecordingController extends ChangeNotifier {
   }
 
   Future<String?> stopRecording() async {
+    if (_state == VoiceRecordingState.requesting) {
+      await cancelRecording();
+      return null;
+    }
     if (_state != VoiceRecordingState.recording) return null;
 
     _state = VoiceRecordingState.stopping;
@@ -78,7 +90,10 @@ class VoiceRecordingController extends ChangeNotifier {
   }
 
   Future<void> cancelRecording() async {
-    if (_state != VoiceRecordingState.recording) return;
+    if (_state != VoiceRecordingState.recording &&
+        _state != VoiceRecordingState.requesting) {
+      return;
+    }
 
     _timer?.cancel();
     _timer = null;

--- a/lib/features/chat/services/voice_recording_service.dart
+++ b/lib/features/chat/services/voice_recording_service.dart
@@ -9,10 +9,7 @@ class VoiceRecordingService {
   Future<bool> hasPermission() => _recorder.hasPermission();
 
   Future<void> start(String path) async {
-    await _recorder.start(
-      const RecordConfig(encoder: AudioEncoder.opus),
-      path: path,
-    );
+    await _recorder.start(const RecordConfig(), path: path);
   }
 
   Future<String?> stop() => _recorder.stop();


### PR DESCRIPTION
## Summary
- Recording was stuck in the `requesting` state on iOS because `AudioEncoder.opus` was paired with a `.mp3` file extension, causing `_service.start()` to throw. With no try/catch, the controller never advanced to `recording`.
- Both `stopRecording()` and `cancelRecording()` early-returned unless state was exactly `recording`, so the indicator's stop/cancel buttons silently no-op'd — matching the symptom in the issue.
- Switched to the default AAC-LC encoder with a matching `.m4a` extension, added error handling in `startRecording()`, and let cancel/stop run during `requesting` as well.

Fixes #479

## Test plan
- [x] `flutter analyze` on changed files — clean
- [x] `flutter test test/widgets/voice_banner_test.dart` — passes
- [ ] Manual: record, stop, and cancel on a physical iOS device
- [ ] Manual: deny microphone permission and confirm the UI returns to idle