### PR TITLE
ci(macos): pin build-macos to macos-26 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
   build-macos:
     if: github.event_name == 'push'
     needs: [analyze, test]
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2


### PR DESCRIPTION
## Summary
- `build-macos` was failing because `connectivity_plus` 7.1.1 references `NWPath.isUltraConstrained`, which is only declared in the macOS 26 SDK. The current `macos-latest` runner ships Xcode 16.4 (macOS 15.5 SDK), so Swift compilation fails with:
  ```
  PathMonitorConnectivityProvider.swift:29:42: error: value of type 'NWPath' has no member 'isUltraConstrained'
  ```
- `release.yml` already pins one of its jobs to `macos-26` and that runs cleanly, so this PR uses the same image for the CI build job.

## Test plan
- [ ] CI's `build-macos` job completes successfully against this branch