### PR TITLE
feat(chat): use YouTube oEmbed API for accurate video title and thumbnail

### DIFF
--- a/lib/features/chat/services/opengraph_service.dart
+++ b/lib/features/chat/services/opengraph_service.dart
@@ -217,9 +217,77 @@ class OpenGraphService {
   }
 
   Future<OpenGraphData?> _doFetch(String url) async {
-    final homeserver = await _fetchViaHomeserver(url);
-    if (homeserver != null) return homeserver;
-    return _doDirectFetch(url);
+    var result = await _fetchViaHomeserver(url) ?? await _doDirectFetch(url);
+
+    // For YouTube video URLs, fetch oEmbed data to get the accurate title,
+    // channel name, and video-specific thumbnail (the homeserver returns generic
+    // YouTube branding instead of per-video metadata).
+    if (result != null && _youtubeVideoId(url) != null) {
+      final oembed = await _fetchYouTubeOEmbed(url, result);
+      if (oembed != null) result = oembed;
+    }
+
+    return result;
+  }
+
+  /// Extracts the YouTube video ID from [url], or `null` if not a YouTube video.
+  @visibleForTesting
+  static String? youtubeVideoId(String url) => _youtubeVideoId(url);
+
+  static String? _youtubeVideoId(String url) {
+    final uri = Uri.tryParse(url);
+    if (uri == null) return null;
+
+    final host = uri.host
+        .replaceFirst('www.', '')
+        .replaceFirst('m.', '');
+
+    if (host == 'youtube.com' || host == 'youtube-nocookie.com') {
+      final segments = uri.pathSegments;
+      if (segments.isEmpty) return null;
+      switch (segments.first) {
+        case 'watch':
+          return uri.queryParameters['v'];
+        case 'shorts' || 'embed' || 'v':
+          return segments.length > 1 ? segments[1] : null;
+      }
+    } else if (host == 'youtu.be') {
+      return uri.pathSegments.isNotEmpty ? uri.pathSegments.first : null;
+    }
+
+    return null;
+  }
+
+  /// Calls the YouTube oEmbed API and overlays accurate title, channel name,
+  /// and video thumbnail onto [base]. Returns `null` on any failure so the
+  /// caller can fall back to [base] unchanged.
+  Future<OpenGraphData?> _fetchYouTubeOEmbed(
+      String url, OpenGraphData base,) async {
+    try {
+      final oEmbedUri = Uri.https('www.youtube.com', '/oembed', {
+        'url': url,
+        'format': 'json',
+      });
+      final response =
+          await _client.get(oEmbedUri).timeout(_fetchTimeout);
+      if (response.statusCode != 200) return null;
+
+      final json = jsonDecode(response.body) as Map<String, Object?>;
+      final title = json['title'] as String?;
+      final authorName = json['author_name'] as String?;
+      final thumbnailUrl = json['thumbnail_url'] as String?;
+
+      return OpenGraphData(
+        url: base.url,
+        title: title ?? base.title,
+        description: base.description,
+        siteName: authorName ?? base.siteName,
+        imageUrl: thumbnailUrl ?? base.imageUrl,
+        fetchedAt: base.fetchedAt,
+      );
+    } catch (_) {
+      return null;
+    }
   }
 
   Future<OpenGraphData?> _doDirectFetch(String url) async {

--- a/test/services/opengraph_service_test.dart
+++ b/test/services/opengraph_service_test.dart
@@ -585,4 +585,170 @@ void main() {
       expect(data, isNull);
     });
   });
+
+  // ── YouTube oEmbed ─────────────────────────────────────────
+
+  group('YouTube oEmbed', () {
+    late MockMatrixClient mockMatrixClient;
+
+    setUp(() {
+      mockMatrixClient = MockMatrixClient();
+      when(mockMatrixClient.accessToken).thenReturn('test-token');
+      when(mockMatrixClient.baseUri)
+          .thenReturn(Uri.parse('https://matrix.example.com'));
+    });
+
+    OpenGraphService createOEmbedService({
+      required http.Response Function(http.Request) onHomeserver,
+      required http.Response Function(http.Request) onOEmbed,
+    }) {
+      final httpClient = MockClient((request) async {
+        if (request.url.host == 'www.youtube.com' &&
+            request.url.path == '/oembed') {
+          return onOEmbed(request);
+        }
+        return onHomeserver(request);
+      });
+      return OpenGraphService(client: httpClient, matrixClient: mockMatrixClient)
+        ..dnsResolver = (_) async => [_publicIp];
+    }
+
+    test('overlays oEmbed title, channel name, and thumbnail on homeserver result',
+        () async {
+      const videoId = 'dQw4w9WgXcQ';
+      final svc = createOEmbedService(
+        onHomeserver: (_) => http.Response(
+          '{"og:title":"- YouTube","og:description":"Enjoy the videos...","og:site_name":"YouTube"}',
+          200,
+          headers: {'content-type': 'application/json'},
+        ),
+        onOEmbed: (_) => http.Response(
+          '{"title":"Never Gonna Give You Up","author_name":"Rick Astley","thumbnail_url":"https://i.ytimg.com/vi/$videoId/hqdefault.jpg"}',
+          200,
+          headers: {'content-type': 'application/json'},
+        ),
+      );
+      addTearDown(svc.dispose);
+
+      final data = await svc.fetch('https://www.youtube.com/watch?v=$videoId');
+      expect(data, isNotNull);
+      expect(data!.title, 'Never Gonna Give You Up');
+      expect(data.siteName, 'Rick Astley');
+      expect(data.imageUrl, 'https://i.ytimg.com/vi/$videoId/hqdefault.jpg');
+      expect(data.description, 'Enjoy the videos...');
+    });
+
+    test('falls back to base result when oEmbed returns non-200', () async {
+      final svc = createOEmbedService(
+        onHomeserver: (_) => http.Response(
+          '{"og:title":"- YouTube","og:description":"Enjoy the videos..."}',
+          200,
+          headers: {'content-type': 'application/json'},
+        ),
+        onOEmbed: (_) => http.Response('', 404),
+      );
+      addTearDown(svc.dispose);
+
+      final data =
+          await svc.fetch('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+      expect(data, isNotNull);
+      expect(data!.title, '- YouTube');
+    });
+
+    test('does not call oEmbed for non-YouTube URLs', () async {
+      var oEmbedCalled = false;
+      final svc = createOEmbedService(
+        onHomeserver: (_) => http.Response(
+          _ogHtml(title: 'Some Page'),
+          200,
+          headers: {'content-type': 'text/html'},
+        ),
+        onOEmbed: (_) {
+          oEmbedCalled = true;
+          return http.Response('', 200);
+        },
+      );
+      addTearDown(svc.dispose);
+
+      await svc.fetch('https://example.com/page');
+      expect(oEmbedCalled, isFalse);
+    });
+
+    test('does not call oEmbed for YouTube channel URLs (no video ID)', () async {
+      var oEmbedCalled = false;
+      final svc = createOEmbedService(
+        onHomeserver: (_) => http.Response(
+          '{"og:title":"Rick Astley - YouTube","og:description":"Subscribe"}',
+          200,
+          headers: {'content-type': 'application/json'},
+        ),
+        onOEmbed: (_) {
+          oEmbedCalled = true;
+          return http.Response('', 200);
+        },
+      );
+      addTearDown(svc.dispose);
+
+      await svc.fetch('https://www.youtube.com/@RickAstleyYT');
+      expect(oEmbedCalled, isFalse);
+    });
+  });
+
+  // ── youtubeVideoId ─────────────────────────────────────────
+
+  group('youtubeVideoId', () {
+    test('extracts ID from watch URL', () {
+      expect(
+        OpenGraphService.youtubeVideoId(
+            'https://www.youtube.com/watch?v=dQw4w9WgXcQ',),
+        'dQw4w9WgXcQ',
+      );
+    });
+
+    test('extracts ID from youtu.be short URL', () {
+      expect(
+        OpenGraphService.youtubeVideoId('https://youtu.be/dQw4w9WgXcQ'),
+        'dQw4w9WgXcQ',
+      );
+    });
+
+    test('extracts ID from /shorts/ URL', () {
+      expect(
+        OpenGraphService.youtubeVideoId(
+            'https://www.youtube.com/shorts/dQw4w9WgXcQ',),
+        'dQw4w9WgXcQ',
+      );
+    });
+
+    test('extracts ID from /embed/ URL', () {
+      expect(
+        OpenGraphService.youtubeVideoId(
+            'https://www.youtube.com/embed/dQw4w9WgXcQ',),
+        'dQw4w9WgXcQ',
+      );
+    });
+
+    test('handles mobile subdomain', () {
+      expect(
+        OpenGraphService.youtubeVideoId(
+            'https://m.youtube.com/watch?v=dQw4w9WgXcQ',),
+        'dQw4w9WgXcQ',
+      );
+    });
+
+    test('returns null for channel URL', () {
+      expect(
+        OpenGraphService.youtubeVideoId(
+            'https://www.youtube.com/@RickAstleyYT',),
+        isNull,
+      );
+    });
+
+    test('returns null for non-YouTube URL', () {
+      expect(
+        OpenGraphService.youtubeVideoId('https://example.com/watch?v=abc'),
+        isNull,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- Calls `https://www.youtube.com/oembed?url={url}&format=json` after the homeserver URL preview for any recognised YouTube video URL (watch, shorts, embed, youtu.be)
- Overlays the real video title, channel name (`author_name` → `siteName`), and video-specific thumbnail onto the result
- Falls back silently to the homeserver result if oEmbed fails or times out — no user-visible degradation
- Does not call oEmbed for non-video YouTube URLs (channels, playlists, homepage)

**Why oEmbed instead of the homeserver result:** YouTube's bot detection causes the homeserver to receive generic branding (`- YouTube` title, YouTube logo image) instead of per-video metadata. The oEmbed endpoint is YouTube's official embeds API — public, CORS-safe, no auth required.

## Test plan

- [ ] Paste a YouTube watch link — preview shows real video title and channel name
- [ ] Paste a `youtu.be` short link — same
- [ ] Paste a YouTube channel URL — oEmbed not called, homeserver result shown as-is
- [ ] Disconnect network after homeserver fetch (or use a URL where oEmbed returns 404) — falls back gracefully to homeserver result
- [ ] `flutter test test/services/opengraph_service_test.dart` — all 58 pass

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)