### PR TITLE
feat(chat): show link preview in compose bar before sending

### DIFF
--- a/lib/features/chat/widgets/compose_bar.dart
+++ b/lib/features/chat/widgets/compose_bar.dart
@@ -10,8 +10,10 @@ import 'package:kohera/features/chat/services/typing_controller.dart';
 import 'package:kohera/features/chat/services/voice_recording_controller.dart';
 import 'package:kohera/features/chat/widgets/attachment_preview_bar.dart';
 import 'package:kohera/features/chat/widgets/edit_preview_banner.dart';
+import 'package:kohera/features/chat/widgets/link_preview_card.dart';
 import 'package:kohera/features/chat/widgets/mention_autocomplete_controller.dart';
 import 'package:kohera/features/chat/widgets/mention_suggestion_overlay.dart';
+import 'package:kohera/features/chat/widgets/message_bubble_link_preview.dart';
 import 'package:kohera/features/chat/widgets/recording_indicator.dart';
 import 'package:kohera/features/chat/widgets/reply_preview_banner.dart';
 import 'package:kohera/features/chat/widgets/upload_progress_banner.dart';
@@ -88,11 +90,16 @@ class _ComposeBarState extends State<ComposeBar> {
 
   MentionAutocompleteController? _mentionController;
 
+  Timer? _previewDebounce;
+  String? _previewUrl;
+  String? _dismissedUrl;
+
   @override
   void initState() {
     super.initState();
     _initMentionController();
     widget.controller.addListener(_onTextChangedForTyping);
+    widget.controller.addListener(_onTextChangedForPreview);
     _focusNode.addListener(_onFocusChanged);
   }
 
@@ -102,10 +109,18 @@ class _ComposeBarState extends State<ComposeBar> {
     if (old.room?.id != widget.room?.id) {
       _mentionController?.dispose();
       _initMentionController();
+      _previewDebounce?.cancel();
+      _previewUrl = null;
+      _dismissedUrl = null;
     }
     if (old.controller != widget.controller) {
       old.controller.removeListener(_onTextChangedForTyping);
+      old.controller.removeListener(_onTextChangedForPreview);
       widget.controller.addListener(_onTextChangedForTyping);
+      widget.controller.addListener(_onTextChangedForPreview);
+      _previewDebounce?.cancel();
+      _previewUrl = null;
+      _dismissedUrl = null;
     }
   }
 
@@ -126,6 +141,20 @@ class _ComposeBarState extends State<ComposeBar> {
     widget.typingController?.onTextChanged(widget.controller.text);
   }
 
+  void _onTextChangedForPreview() {
+    _previewDebounce?.cancel();
+    _previewDebounce = Timer(const Duration(milliseconds: 600), () {
+      if (!mounted) return;
+      final url = extractFirstPreviewUrl(widget.controller.text);
+      setState(() {
+        if (url != _dismissedUrl) {
+          _previewUrl = url;
+          if (url == null) _dismissedUrl = null;
+        }
+      });
+    });
+  }
+
   void _onFocusChanged() {
     if (!_focusNode.hasFocus) {
       widget.typingController?.stop();
@@ -135,6 +164,8 @@ class _ComposeBarState extends State<ComposeBar> {
   @override
   void dispose() {
     widget.controller.removeListener(_onTextChangedForTyping);
+    widget.controller.removeListener(_onTextChangedForPreview);
+    _previewDebounce?.cancel();
     _focusNode.removeListener(_onFocusChanged);
     _mentionController?.dispose();
     _ownedFocusNode?.dispose();
@@ -252,6 +283,12 @@ class _ComposeBarState extends State<ComposeBar> {
               onRemove: widget.onRemoveAttachment,
               onClearAll: widget.onClearAttachments,
             ),
+          if (_previewUrl != null &&
+              widget.editEvent == null &&
+              context.select<PreferencesService, bool>(
+                (p) => p.showLinkPreviews,
+              ))
+            _buildLinkPreviewBanner(_previewUrl!),
           if (widget.uploadNotifier != null)
             ValueListenableBuilder<UploadState?>(
               valueListenable: widget.uploadNotifier!,
@@ -266,6 +303,34 @@ class _ComposeBarState extends State<ComposeBar> {
           _buildComposeRow(cs),
         ],
       ),
+    );
+  }
+
+  Widget _buildLinkPreviewBanner(String url) {
+    final cs = Theme.of(context).colorScheme;
+    return Stack(
+      alignment: Alignment.topRight,
+      children: [
+        LinkPreviewCard(url: url, isMe: false),
+        Positioned(
+          top: 8,
+          right: 2,
+          child: GestureDetector(
+            onTap: () => setState(() {
+              _dismissedUrl = _previewUrl;
+              _previewUrl = null;
+            }),
+            child: Container(
+              padding: const EdgeInsets.all(2),
+              decoration: BoxDecoration(
+                color: cs.surface,
+                shape: BoxShape.circle,
+              ),
+              child: Icon(Icons.close, size: 14, color: cs.onSurfaceVariant),
+            ),
+          ),
+        ),
+      ],
     );
   }
 

--- a/test/widgets/chat/compose_bar_test.dart
+++ b/test/widgets/chat/compose_bar_test.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/services/preferences_service.dart';
+import 'package:kohera/features/chat/services/opengraph_service.dart';
 import 'package:kohera/features/chat/services/typing_controller.dart';
 import 'package:kohera/features/chat/widgets/compose_bar.dart';
+import 'package:kohera/features/chat/widgets/link_preview_card.dart';
 import 'package:kohera/features/chat/widgets/mention_suggestion_overlay.dart';
 import 'package:matrix/matrix.dart';
 import 'package:mockito/annotations.dart';
@@ -16,6 +18,7 @@ import 'package:shared_preferences/shared_preferences.dart';
   MockSpec<User>(),
   MockSpec<Client>(),
   MockSpec<TypingController>(),
+  MockSpec<OpenGraphService>(),
 ])
 import 'compose_bar_test.mocks.dart';
 
@@ -27,27 +30,38 @@ Widget _wrap({
   PreferencesService? prefs,
   TypingController? typingController,
   VoidCallback? onGif,
+  OpenGraphService? openGraphService,
+  Event? editEvent,
 }) {
-  return ChangeNotifierProvider<PreferencesService>.value(
+  final bar = ComposeBar(
+    controller: controller,
+    onSend: onSend,
+    onCancelReply: () {},
+    onCancelEdit: () {},
+    editEvent: editEvent,
+    room: room,
+    joinedRooms: joinedRooms,
+    typingController: typingController,
+    onRemoveAttachment: (_) {},
+    onClearAttachments: () {},
+    onGif: onGif,
+  );
+
+  final withPrefs = ChangeNotifierProvider<PreferencesService>.value(
     value: prefs ?? PreferencesService(),
     child: MaterialApp(
       theme: ThemeData(splashFactory: InkRipple.splashFactory),
-      home: Scaffold(
-        body: ComposeBar(
-          controller: controller,
-          onSend: onSend,
-          onCancelReply: () {},
-          onCancelEdit: () {},
-          room: room,
-          joinedRooms: joinedRooms,
-          typingController: typingController,
-          onRemoveAttachment: (_) {},
-          onClearAttachments: () {},
-          onGif: onGif,
-        ),
-      ),
+      home: Scaffold(body: bar),
     ),
   );
+
+  if (openGraphService != null) {
+    return Provider<OpenGraphService>.value(
+      value: openGraphService,
+      child: withPrefs,
+    );
+  }
+  return withPrefs;
 }
 
 MockUser _makeUser(String id, String? displayName) {
@@ -380,6 +394,139 @@ void main() {
       await tester.pump();
 
       expect(find.byType(MentionSuggestionList), findsNothing);
+    });
+  });
+
+  group('ComposeBar link preview', () {
+    late TextEditingController controller;
+    late MockOpenGraphService mockOgService;
+
+    setUp(() {
+      controller = TextEditingController();
+      mockOgService = MockOpenGraphService();
+      when(mockOgService.fetch(any)).thenAnswer(
+        (_) async => OpenGraphData(url: 'https://example.com', title: 'Example'),
+      );
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    testWidgets('preview appears after debounce when URL is typed',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        controller: controller,
+        onSend: () {},
+        openGraphService: mockOgService,
+      ),);
+
+      await tester.enterText(find.byType(TextField), 'https://example.com');
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(LinkPreviewCard), findsOneWidget);
+    });
+
+    testWidgets('no preview when text contains no URL', (tester) async {
+      await tester.pumpWidget(_wrap(
+        controller: controller,
+        onSend: () {},
+        openGraphService: mockOgService,
+      ),);
+
+      await tester.enterText(find.byType(TextField), 'just plain text');
+      await tester.pump(const Duration(milliseconds: 600));
+
+      expect(find.byType(LinkPreviewCard), findsNothing);
+    });
+
+    testWidgets('close button removes preview', (tester) async {
+      await tester.pumpWidget(_wrap(
+        controller: controller,
+        onSend: () {},
+        openGraphService: mockOgService,
+      ),);
+
+      await tester.enterText(find.byType(TextField), 'https://example.com');
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pumpAndSettle();
+      expect(find.byType(LinkPreviewCard), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pump();
+
+      expect(find.byType(LinkPreviewCard), findsNothing);
+    });
+
+    testWidgets('dismissed URL does not reappear while URL stays in text',
+        (tester) async {
+      await tester.pumpWidget(_wrap(
+        controller: controller,
+        onSend: () {},
+        openGraphService: mockOgService,
+      ),);
+
+      await tester.enterText(find.byType(TextField), 'https://example.com');
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pump();
+
+      // Add surrounding text — URL is still present, dismissed state must hold.
+      await tester.enterText(
+        find.byType(TextField),
+        'check this out https://example.com please',
+      );
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(LinkPreviewCard), findsNothing);
+    });
+
+    testWidgets('new URL appears after previous URL was dismissed',
+        (tester) async {
+      when(mockOgService.fetch('https://other.com')).thenAnswer(
+        (_) async => OpenGraphData(url: 'https://other.com', title: 'Other'),
+      );
+
+      await tester.pumpWidget(_wrap(
+        controller: controller,
+        onSend: () {},
+        openGraphService: mockOgService,
+      ),);
+
+      await tester.enterText(find.byType(TextField), 'https://example.com');
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pump();
+
+      await tester.enterText(find.byType(TextField), 'https://other.com');
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(LinkPreviewCard), findsOneWidget);
+    });
+
+    testWidgets('preview hidden when showLinkPreviews preference is off',
+        (tester) async {
+      SharedPreferences.setMockInitialValues({'show_link_previews': false});
+      final sp = await SharedPreferences.getInstance();
+      final prefs = PreferencesService(prefs: sp);
+
+      await tester.pumpWidget(_wrap(
+        controller: controller,
+        onSend: () {},
+        openGraphService: mockOgService,
+        prefs: prefs,
+      ),);
+
+      await tester.enterText(find.byType(TextField), 'https://example.com');
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(LinkPreviewCard), findsNothing);
     });
   });
 }

--- a/test/widgets/chat/compose_bar_test.mocks.dart
+++ b/test/widgets/chat/compose_bar_test.mocks.dart
@@ -4,9 +4,11 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
+import 'dart:io' as _i14;
 import 'dart:typed_data' as _i11;
 
 import 'package:http/http.dart' as _i4;
+import 'package:kohera/features/chat/services/opengraph_service.dart' as _i13;
 import 'package:kohera/features/chat/services/typing_controller.dart' as _i12;
 import 'package:matrix/encryption.dart' as _i10;
 import 'package:matrix/matrix.dart' as _i2;
@@ -9725,4 +9727,55 @@ class MockTypingController extends _i1.Mock implements _i12.TypingController {
         ),
         returnValueForMissingStub: null,
       );
+}
+
+/// A class which mocks [OpenGraphService].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockOpenGraphService extends _i1.Mock implements _i13.OpenGraphService {
+  @override
+  set dnsResolver(
+          _i5.Future<List<_i14.InternetAddress>> Function(String)? value) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #dnsResolver,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void dispose() => super.noSuchMethod(
+        Invocation.method(
+          #dispose,
+          [],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<_i13.OpenGraphData?> fetch(String? url) => (super.noSuchMethod(
+        Invocation.method(
+          #fetch,
+          [url],
+        ),
+        returnValue: _i5.Future<_i13.OpenGraphData?>.value(),
+        returnValueForMissingStub: _i5.Future<_i13.OpenGraphData?>.value(),
+      ) as _i5.Future<_i13.OpenGraphData?>);
+
+  @override
+  _i13.OpenGraphData? parse(
+    String? html,
+    String? url,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #parse,
+          [
+            html,
+            url,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      ) as _i13.OpenGraphData?);
 }


### PR DESCRIPTION
## Summary

- Detects the first URL typed in the compose bar (600ms debounce) and shows a `LinkPreviewCard` above the input row
- Dismiss button (×) hides the preview; dismissed URL does not reappear while it remains in the text
- Suppressed during message edits and when the `showLinkPreviews` preference is off
- Reuses existing `LinkPreviewCard`, `extractFirstPreviewUrl`, and `OpenGraphService` — no new files

## Test plan

- [x] 6 new widget tests covering: debounce appearance, no URL = no preview, dismiss, dismiss-stays-hidden, new URL after dismiss, preference off
- [x] All 22 `compose_bar_test.dart` tests pass
- [x] Manually verified on Windows app: YouTube URL shows oEmbed title/thumbnail in compose bar; dismiss button works; preview clears on send

🤖 Generated with [Claude Code](https://claude.com/claude-code)