### PR TITLE
fix(chat): order call events chronologically in timeline

### DIFF
--- a/lib/features/chat/widgets/message_list_view.dart
+++ b/lib/features/chat/widgets/message_list_view.dart
@@ -186,24 +186,30 @@ class MessageListViewState extends State<MessageListView> {
     if (_cachedVisibleEvents != null) return _cachedVisibleEvents!;
     final timelineEvents = _timeline?.events;
     if (timelineEvents == null) return [];
-    final threadRootId = widget.threadRootEventId;
-    final extra = widget.extraEvents;
-    final Iterable<Event> source;
-    if (extra != null && extra.isNotEmpty) {
-      final seen = <String>{};
-      final merged = <Event>[];
-      for (final e in timelineEvents) {
-        if (seen.add(e.eventId)) merged.add(e);
-      }
-      for (final e in extra) {
-        if (seen.add(e.eventId)) merged.add(e);
-      }
-      merged.sort((a, b) => b.originServerTs.compareTo(a.originServerTs));
-      source = merged;
-    } else {
-      source = timelineEvents;
+    _cachedVisibleEvents = buildVisibleEvents(
+      timelineEvents,
+      extraEvents: widget.extraEvents,
+      threadRootId: widget.threadRootEventId,
+    );
+    return _cachedVisibleEvents!;
+  }
+
+  static List<Event> buildVisibleEvents(
+    Iterable<Event> timelineEvents, {
+    List<Event>? extraEvents,
+    String? threadRootId,
+  }) {
+    final seen = <String>{};
+    final merged = <Event>[];
+    for (final e in timelineEvents) {
+      if (seen.add(e.eventId)) merged.add(e);
     }
-    _cachedVisibleEvents = source
+    if (extraEvents != null) {
+      for (final e in extraEvents) {
+        if (seen.add(e.eventId)) merged.add(e);
+      }
+    }
+    return merged
         .where((e) =>
             (((e.type == EventTypes.Message ||
                             e.type == EventTypes.Encrypted) &&
@@ -213,8 +219,8 @@ class MessageListViewState extends State<MessageListView> {
                     _isStateEvent(e) ||
                     e.type == EventTypes.Sticker) &&
             _matchesThread(e, threadRootId),)
-        .toList();
-    return _cachedVisibleEvents!;
+        .toList()
+      ..sort((a, b) => b.originServerTs.compareTo(a.originServerTs));
   }
 
   static bool _matchesThread(Event event, String? threadRootId) {

--- a/test/widgets/message_list_view_order_test.dart
+++ b/test/widgets/message_list_view_order_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/features/chat/widgets/message_list_view.dart';
+import 'package:matrix/matrix.dart';
+import 'package:mockito/mockito.dart';
+
+import 'call_event_tile_test.mocks.dart';
+
+MockEvent _event(String id, String type, DateTime ts) {
+  final e = MockEvent();
+  when(e.eventId).thenReturn(id);
+  when(e.type).thenReturn(type);
+  when(e.originServerTs).thenReturn(ts);
+  when(e.body).thenReturn('');
+  return e;
+}
+
+List<String> _ids(List<Event> events) =>
+    events.map((e) => e.eventId).toList();
+
+void main() {
+  test('orders call events and messages chronologically (newest first)', () {
+    final msgEarly =
+        _event(r'$m1', EventTypes.Message, DateTime(2026, 1, 15, 22, 8));
+    final callInvite =
+        _event(r'$c1', 'm.call.invite', DateTime(2026, 1, 15, 22, 9));
+    final callHangup =
+        _event(r'$c2', 'm.call.hangup', DateTime(2026, 1, 15, 22, 10));
+    final msgLate =
+        _event(r'$m2', EventTypes.Message, DateTime(2026, 1, 15, 22, 11));
+
+    // Supplied in a deliberately scrambled order, as the SDK's internal
+    // sortOrder can diverge from originServerTs for call signaling events.
+    final visible = MessageListViewState.buildVisibleEvents(
+      [msgLate, callInvite, callHangup, msgEarly],
+    );
+
+    expect(_ids(visible), [r'$m2', r'$c2', r'$c1', r'$m1']);
+  });
+
+  test('deduplicates by eventId when merging extra events', () {
+    final a = _event(r'$a', EventTypes.Message, DateTime(2026, 1, 15, 10));
+    final aDup = _event(r'$a', EventTypes.Message, DateTime(2026, 1, 15, 10));
+    final b = _event(r'$b', EventTypes.Message, DateTime(2026, 1, 15, 11));
+
+    final visible = MessageListViewState.buildVisibleEvents(
+      [a],
+      extraEvents: [aDup, b],
+    );
+
+    expect(_ids(visible), [r'$b', r'$a']);
+  });
+}


### PR DESCRIPTION
Call signaling events (m.call.invite/answer/hangup) could appear out of
sequence because the timeline relied on the SDK's internal sortOrder,
which can diverge from originServerTs for events sent in rapid succession.
Sort all visible events by originServerTs so display order matches the
timestamps shown on each tile, matching the behavior already used for the
thread/extra-events path.

https://claude.ai/code/session_019qQA6YqNvYd81xSimEsXp4