### PR TITLE
feat(chat): forward message to another room (#81)

### DIFF
--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -28,6 +28,7 @@ import 'package:kohera/features/chat/widgets/chat_app_bar.dart';
 import 'package:kohera/features/chat/widgets/compose_bar_section.dart';
 import 'package:kohera/features/chat/widgets/desktop_drop_wrapper.dart';
 import 'package:kohera/features/chat/widgets/file_send_handler.dart';
+import 'package:kohera/features/chat/widgets/forward_message_dialog.dart';
 import 'package:kohera/features/chat/widgets/gif_send_handler.dart';
 import 'package:kohera/features/chat/widgets/join_call_banner.dart';
 import 'package:kohera/features/chat/widgets/message_list_view.dart';
@@ -199,6 +200,13 @@ class _ChatScreenState extends State<ChatScreen>
 
   void _closeThreadList() {
     setState(() => _showThreadList = false);
+  }
+
+  Future<void> _forwardMessage(Event event) async {
+    final client = context.read<MatrixService>().client;
+    final targetRoom = await ForwardMessageDialog.show(context, client: client);
+    if (targetRoom == null) return;
+    await _actions.forward(event, targetRoom);
   }
 
   void _replyInThread(Event event) {
@@ -412,6 +420,7 @@ class _ChatScreenState extends State<ChatScreen>
             onScrollBack: isTouchDevice ? _dismissKeyboard : null,
             onOpenThread: _openThread,
             onReplyInThread: _replyInThread,
+            onForward: (event) => unawaited(_forwardMessage(event)),
             onTimelineChanged: _onTimelineChanged,
           ),
         ),

--- a/lib/features/chat/screens/thread_screen.dart
+++ b/lib/features/chat/screens/thread_screen.dart
@@ -9,6 +9,7 @@ import 'package:kohera/features/chat/services/compose_state_controller.dart';
 import 'package:kohera/features/chat/services/thread_roots_service.dart';
 import 'package:kohera/features/chat/widgets/compose_bar_section.dart';
 import 'package:kohera/features/chat/widgets/file_send_handler.dart';
+import 'package:kohera/features/chat/widgets/forward_message_dialog.dart';
 import 'package:kohera/features/chat/widgets/message_list_view.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
@@ -66,6 +67,13 @@ class _ThreadScreenState extends State<ThreadScreen> {
       if (!mounted) return;
       unawaited(_loadRoot());
     });
+  }
+
+  Future<void> _forwardMessage(Event event) async {
+    final client = context.read<MatrixService>().client;
+    final targetRoom = await ForwardMessageDialog.show(context, client: client);
+    if (targetRoom == null) return;
+    await _actions.forward(event, targetRoom);
   }
 
   Future<void> _loadRoot() async {
@@ -225,6 +233,7 @@ class _ThreadScreenState extends State<ThreadScreen> {
                   _compose.setEditEvent(event, timeline, _msgCtrl),
               onToggleReaction: _actions.toggleReaction,
               onPin: _actions.togglePin,
+              onForward: (event) => unawaited(_forwardMessage(event)),
               onHighlight: (_) {},
             ),
           ),

--- a/lib/features/chat/services/chat_message_actions.dart
+++ b/lib/features/chat/services/chat_message_actions.dart
@@ -82,6 +82,38 @@ class ChatMessageActions {
     }
   }
 
+  // ── Forward ─────────────────────────────────────────────
+
+  Future<void> forward(Event event, Room targetRoom) async {
+    final scaffold = getScaffold();
+    try {
+      final msgtype = event.messageType;
+      if (msgtype == MessageTypes.Text ||
+          msgtype == MessageTypes.Notice ||
+          msgtype == MessageTypes.Emote) {
+        await targetRoom.sendTextEvent(event.body);
+      } else {
+        final content = Map<String, dynamic>.from(event.content)
+          ..remove('m.relates_to');
+        await targetRoom.sendEvent(content, type: event.type);
+      }
+      scaffold.showSnackBar(
+        SnackBar(
+          content: Text('Forwarded to ${targetRoom.getLocalizedDisplayname()}'),
+        ),
+      );
+    } catch (e) {
+      debugPrint('[Kohera] Failed to forward message: $e');
+      scaffold.showSnackBar(
+        SnackBar(
+          content: Text(
+            'Failed to forward: ${MatrixService.friendlyAuthError(e)}',
+          ),
+        ),
+      );
+    }
+  }
+
   // ── Send ───────────────────────────────────────────────
 
   Future<void> send() async {

--- a/lib/features/chat/widgets/chat_message_item.dart
+++ b/lib/features/chat/widgets/chat_message_item.dart
@@ -32,6 +32,7 @@ class ChatMessageItem extends StatelessWidget {
     this.onTapReply,
     this.onReplyInThread,
     this.onOpenThread,
+    this.onForward,
     this.inThread = false,
     super.key,
   });
@@ -50,6 +51,7 @@ class ChatMessageItem extends StatelessWidget {
   final void Function(Event event)? onTapReply;
   final void Function(Event event)? onReplyInThread;
   final void Function(Event event)? onOpenThread;
+  final void Function(Event event)? onForward;
   final bool inThread;
   final Future<void> Function(Event event, String emoji) onToggleReaction;
 
@@ -115,6 +117,8 @@ class ChatMessageItem extends StatelessWidget {
       onPin: canPin ? () => onPin?.call(event) : null,
       onReplyInThread:
           isRedacted || inThread ? null : () => onReplyInThread?.call(event),
+      onForward:
+          !isRedacted && onForward != null ? () => onForward?.call(event) : null,
       reactionBubble: reactionBubble,
       subBubble: subBubble,
       threadIndicator: hasThread
@@ -231,6 +235,12 @@ class ChatMessageItem extends StatelessWidget {
             );
           },
         ),
+        if (onForward != null)
+          MessageAction(
+            label: 'Forward',
+            icon: Icons.forward_rounded,
+            onTap: () => onForward?.call(event),
+          ),
         if (event.canRedact)
           MessageAction(
             label: isMe ? 'Delete' : 'Remove',

--- a/lib/features/chat/widgets/forward_message_dialog.dart
+++ b/lib/features/chat/widgets/forward_message_dialog.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:kohera/shared/widgets/room_avatar.dart';
+import 'package:matrix/matrix.dart';
+
+// ── Forward Message Dialog ───────────────────────────────────────
+
+class ForwardMessageDialog extends StatefulWidget {
+  const ForwardMessageDialog._({required this.client});
+
+  final Client client;
+
+  static Future<Room?> show(
+    BuildContext context, {
+    required Client client,
+  }) {
+    return showDialog<Room>(
+      context: context,
+      builder: (_) => ForwardMessageDialog._(client: client),
+    );
+  }
+
+  @override
+  State<ForwardMessageDialog> createState() => _ForwardMessageDialogState();
+}
+
+class _ForwardMessageDialogState extends State<ForwardMessageDialog> {
+  final _searchController = TextEditingController();
+  String _query = '';
+  late List<Room> _rooms;
+
+  @override
+  void initState() {
+    super.initState();
+    _rooms = _computeRooms();
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  List<Room> _computeRooms() {
+    return widget.client.rooms
+        .where((r) => r.membership == Membership.join && !r.isSpace)
+        .toList()
+      ..sort((a, b) => a
+          .getLocalizedDisplayname()
+          .toLowerCase()
+          .compareTo(b.getLocalizedDisplayname().toLowerCase()),);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final filtered = _query.isEmpty
+        ? _rooms
+        : _rooms
+            .where((r) => r
+                .getLocalizedDisplayname()
+                .toLowerCase()
+                .contains(_query.toLowerCase()),)
+            .toList();
+
+    return AlertDialog(
+      title: const Text('Forward to'),
+      content: SizedBox(
+        width: 400,
+        height: 400,
+        child: _rooms.isEmpty
+            ? const Center(child: Text('No rooms available.'))
+            : Column(
+                children: [
+                  TextField(
+                    controller: _searchController,
+                    autofocus: true,
+                    decoration: const InputDecoration(
+                      labelText: 'Search rooms',
+                      prefixIcon: Icon(Icons.search_rounded),
+                      border: OutlineInputBorder(),
+                    ),
+                    onChanged: (v) => setState(() => _query = v.trim()),
+                  ),
+                  const SizedBox(height: 8),
+                  Expanded(
+                    child: filtered.isEmpty
+                        ? const Center(child: Text('No matching rooms.'))
+                        : ListView.builder(
+                            itemCount: filtered.length,
+                            itemBuilder: (context, index) {
+                              final room = filtered[index];
+                              return ListTile(
+                                leading:
+                                    RoomAvatarWidget(room: room, size: 36),
+                                title: Text(
+                                  room.getLocalizedDisplayname(),
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                                onTap: () => Navigator.pop(context, room),
+                              );
+                            },
+                          ),
+                  ),
+                ],
+              ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/chat/widgets/message_bubble.dart
+++ b/lib/features/chat/widgets/message_bubble.dart
@@ -27,6 +27,7 @@ class MessageBubble extends StatefulWidget {
     this.onQuickReact,
     this.onPin,
     this.onReplyInThread,
+    this.onForward,
     this.reactionBubble,
     this.subBubble,
     this.threadIndicator,
@@ -71,6 +72,9 @@ class MessageBubble extends StatefulWidget {
   /// Called to start a thread reply rooted at this event.
   final VoidCallback? onReplyInThread;
 
+  /// Called to forward this message to another room.
+  final VoidCallback? onForward;
+
   /// Reaction chips overlapping the bottom edge of the bubble (Signal-style).
   final Widget? reactionBubble;
 
@@ -109,6 +113,7 @@ class _MessageBubbleState extends State<MessageBubble> {
       onPin: widget.onPin,
       onDelete: widget.onDelete,
       onReplyInThread: widget.onReplyInThread,
+      onForward: widget.onForward,
     ),);
   }
 

--- a/lib/features/chat/widgets/message_bubble_context_menu.dart
+++ b/lib/features/chat/widgets/message_bubble_context_menu.dart
@@ -16,6 +16,7 @@ Future<void> showMessageContextMenu(
   VoidCallback? onPin,
   VoidCallback? onDelete,
   VoidCallback? onReplyInThread,
+  VoidCallback? onForward,
 }) async {
   final cs = Theme.of(context).colorScheme;
   final isFailed = event.status.isError;
@@ -36,6 +37,8 @@ Future<void> showMessageContextMenu(
       if (onReact != null)
         _menuItem(Icons.add_reaction_outlined, 'React', 'react'),
       if (!event.redacted) _menuItem(Icons.copy_rounded, 'Copy', 'copy'),
+      if (onForward != null)
+        _menuItem(Icons.forward_rounded, 'Forward', 'forward'),
       if (onPin != null)
         _menuItem(
           isPinned ? Icons.push_pin_rounded : Icons.push_pin_outlined,
@@ -88,6 +91,7 @@ Future<void> showMessageContextMenu(
         ClipboardData(text: stripReplyFallback(displayEvent.body)),);
   }
   if (value == 'delete') onDelete?.call();
+  if (value == 'forward') onForward?.call();
 }
 
 PopupMenuItem<String> _menuItem(

--- a/lib/features/chat/widgets/message_list_view.dart
+++ b/lib/features/chat/widgets/message_list_view.dart
@@ -30,6 +30,7 @@ class MessageListView extends StatefulWidget {
     this.threadRootEventId,
     this.onReplyInThread,
     this.onOpenThread,
+    this.onForward,
     this.emptyText,
     this.onTimelineChanged,
     this.extraEvents,
@@ -51,6 +52,7 @@ class MessageListView extends StatefulWidget {
   final VoidCallback? onScrollBack;
   final void Function(Event event)? onReplyInThread;
   final void Function(Event event)? onOpenThread;
+  final void Function(Event event)? onForward;
   final String? emptyText;
   final VoidCallback? onTimelineChanged;
   final List<Event>? extraEvents;
@@ -559,6 +561,7 @@ class MessageListViewState extends State<MessageListView> {
               onTapReply: _navigateToEvent,
               onReplyInThread: widget.onReplyInThread,
               onOpenThread: widget.onOpenThread,
+              onForward: widget.onForward,
               inThread: widget.threadRootEventId != null,
             );
           }

--- a/test/widgets/forward_message_dialog_test.dart
+++ b/test/widgets/forward_message_dialog_test.dart
@@ -1,0 +1,166 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/features/chat/widgets/forward_message_dialog.dart';
+import 'package:matrix/matrix.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+@GenerateNiceMocks([
+  MockSpec<Client>(),
+  MockSpec<Room>(),
+])
+import 'forward_message_dialog_test.mocks.dart';
+
+void main() {
+  late MockClient mockClient;
+
+  MockRoom buildRoom(String name) {
+    final room = MockRoom();
+    when(room.id).thenReturn('!${name.toLowerCase()}:example.com');
+    when(room.membership).thenReturn(Membership.join);
+    when(room.isSpace).thenReturn(false);
+    when(room.avatar).thenReturn(null);
+    when(room.client).thenReturn(mockClient);
+    when(room.getLocalizedDisplayname()).thenReturn(name);
+    return room;
+  }
+
+  setUp(() {
+    mockClient = MockClient();
+    when(mockClient.rooms).thenReturn([]);
+  });
+
+  Widget buildTestWidget() {
+    return MaterialApp(
+      theme: ThemeData(splashFactory: InkRipple.splashFactory),
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => Center(
+            child: ElevatedButton(
+              onPressed: () {
+                unawaited(
+                  ForwardMessageDialog.show(context, client: mockClient),
+                );
+              },
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> openDialog(WidgetTester tester) async {
+    await tester.pumpWidget(buildTestWidget());
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+  }
+
+  group('ForwardMessageDialog', () {
+    testWidgets('shows search field and title', (tester) async {
+      await openDialog(tester);
+
+      expect(find.text('Forward to'), findsOneWidget);
+      expect(find.widgetWithText(TextField, 'Search rooms'), findsOneWidget);
+    });
+
+    testWidgets('lists joined non-space rooms', (tester) async {
+      when(mockClient.rooms).thenReturn([
+        buildRoom('Alpha'),
+        buildRoom('Bravo'),
+      ]);
+
+      await openDialog(tester);
+
+      expect(find.text('Alpha'), findsOneWidget);
+      expect(find.text('Bravo'), findsOneWidget);
+    });
+
+    testWidgets('excludes spaces and non-joined rooms', (tester) async {
+      final space = buildRoom('SpaceRoom');
+      when(space.isSpace).thenReturn(true);
+      final invited = buildRoom('InvitedRoom');
+      when(invited.membership).thenReturn(Membership.invite);
+      when(mockClient.rooms).thenReturn([
+        buildRoom('Alpha'),
+        space,
+        invited,
+      ]);
+
+      await openDialog(tester);
+
+      expect(find.text('Alpha'), findsOneWidget);
+      expect(find.text('SpaceRoom'), findsNothing);
+      expect(find.text('InvitedRoom'), findsNothing);
+    });
+
+    testWidgets('filters rooms by search text', (tester) async {
+      when(mockClient.rooms).thenReturn([
+        buildRoom('Alpha'),
+        buildRoom('Bravo'),
+      ]);
+
+      await openDialog(tester);
+
+      await tester.enterText(
+        find.widgetWithText(TextField, 'Search rooms'),
+        'brav',
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Alpha'), findsNothing);
+      expect(find.text('Bravo'), findsOneWidget);
+    });
+
+    testWidgets('returns selected room on tap', (tester) async {
+      final alpha = buildRoom('Alpha');
+      when(mockClient.rooms).thenReturn([alpha]);
+
+      Room? picked;
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(splashFactory: InkRipple.splashFactory),
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => Center(
+                child: ElevatedButton(
+                  onPressed: () async {
+                    picked = await ForwardMessageDialog.show(
+                      context,
+                      client: mockClient,
+                    );
+                  },
+                  child: const Text('Open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Alpha'));
+      await tester.pumpAndSettle();
+
+      expect(picked, same(alpha));
+    });
+
+    testWidgets('shows empty state when no rooms', (tester) async {
+      await openDialog(tester);
+
+      expect(find.text('No rooms available.'), findsOneWidget);
+    });
+
+    testWidgets('cancel button closes dialog', (tester) async {
+      await openDialog(tester);
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Forward to'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Closes #81. Adds a "Forward" action that re-sends a message to another room.

- "Forward" item added to the desktop context menu (`message_bubble_context_menu.dart`) and the mobile long-press sheet (`chat_message_item.dart`), gated on a new `onForward` callback plumbed through `message_bubble.dart` / `message_list_view.dart` up to `chat_screen.dart` and `thread_screen.dart`.
- New `ForwardMessageDialog` (`lib/features/chat/widgets/forward_message_dialog.dart`): searchable picker over joined, non-space rooms, sorted by display name; returns the chosen `Room`.
- New `ChatMessageActions.forward(event, targetRoom)`: text/notice/emote are re-sent via `sendTextEvent(event.body)`; media/file/sticker are re-sent by content reference (`sendEvent(content..remove('m.relates_to'), type: event.type)`). Snackbar confirmation on success, friendly error on failure.

## Test plan
- [x] `test/widgets/forward_message_dialog_test.dart`: lists joined rooms, excludes spaces/non-joined, filters by search, returns room on tap, empty + cancel states.
- [ ] **CI must run `dart run build_runner build --delete-conflicting-outputs`** before tests — the new test declares `@GenerateNiceMocks`, and the toolchain was unavailable locally so mocks were not generated and nothing was compiled/run.
- [ ] Manual: forward a text message and an image/file to another room; verify it arrives and the confirmation snackbar shows.

## Note
Media is forwarded by reference (reusing the original `mxc://`), which works for unencrypted content. Cross-room forwarding of E2EE media (re-upload) is out of scope for this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LK1kU4qCrjPLzfRFQCFvGQ)_