### PR TITLE
feat(chat): custom emoji autocomplete with : trigger (#150)

### DIFF
--- a/lib/features/chat/widgets/compose_bar.dart
+++ b/lib/features/chat/widgets/compose_bar.dart
@@ -6,10 +6,13 @@ import 'package:flutter/services.dart';
 import 'package:kohera/core/models/pending_attachment.dart';
 import 'package:kohera/core/models/upload_state.dart';
 import 'package:kohera/core/services/preferences_service.dart';
+import 'package:kohera/core/services/sticker_pack_service.dart';
 import 'package:kohera/features/chat/services/typing_controller.dart';
 import 'package:kohera/features/chat/services/voice_recording_controller.dart';
 import 'package:kohera/features/chat/widgets/attachment_preview_bar.dart';
 import 'package:kohera/features/chat/widgets/edit_preview_banner.dart';
+import 'package:kohera/features/chat/widgets/emoji_autocomplete_controller.dart';
+import 'package:kohera/features/chat/widgets/emoji_suggestion_overlay.dart';
 import 'package:kohera/features/chat/widgets/link_preview_card.dart';
 import 'package:kohera/features/chat/widgets/mention_autocomplete_controller.dart';
 import 'package:kohera/features/chat/widgets/mention_suggestion_overlay.dart';
@@ -89,6 +92,7 @@ class _ComposeBarState extends State<ComposeBar> {
   FocusNode get _focusNode => widget.focusNode ?? (_ownedFocusNode ??= FocusNode());
 
   MentionAutocompleteController? _mentionController;
+  EmojiAutocompleteController? _emojiController;
 
   Timer? _previewDebounce;
   String? _previewUrl;
@@ -98,6 +102,7 @@ class _ComposeBarState extends State<ComposeBar> {
   void initState() {
     super.initState();
     _initMentionController();
+    _initEmojiController();
     widget.controller.addListener(_onTextChangedForTyping);
     widget.controller.addListener(_onTextChangedForPreview);
     _focusNode.addListener(_onFocusChanged);
@@ -109,6 +114,8 @@ class _ComposeBarState extends State<ComposeBar> {
     if (old.room?.id != widget.room?.id) {
       _mentionController?.dispose();
       _initMentionController();
+      _emojiController?.dispose();
+      _initEmojiController();
       _previewDebounce?.cancel();
       _previewUrl = null;
       _dismissedUrl = null;
@@ -133,6 +140,18 @@ class _ComposeBarState extends State<ComposeBar> {
       );
     } else {
       _mentionController = null;
+    }
+  }
+
+  void _initEmojiController() {
+    if (widget.room != null) {
+      _emojiController = EmojiAutocompleteController(
+        textController: widget.controller,
+        room: widget.room!,
+        stickerPacks: context.read<StickerPackService>(),
+      );
+    } else {
+      _emojiController = null;
     }
   }
 
@@ -168,17 +187,23 @@ class _ComposeBarState extends State<ComposeBar> {
     _previewDebounce?.cancel();
     _focusNode.removeListener(_onFocusChanged);
     _mentionController?.dispose();
+    _emojiController?.dispose();
     _ownedFocusNode?.dispose();
     super.dispose();
   }
 
   void _handleSend() {
+    if (_emojiController != null && _emojiController!.hasSuggestions) {
+      _emojiController!.confirmSelection();
+      return;
+    }
     if (_mentionController != null && _mentionController!.hasSuggestions) {
       _mentionController!.confirmSelection();
       return;
     }
     // Dismiss empty autocomplete so it doesn't linger after send.
     _mentionController?.dismiss();
+    _emojiController?.dismiss();
     final hasText = widget.controller.text.trim().isNotEmpty;
     final hasAttachments = widget.pendingAttachments.isNotEmpty;
     if (hasText || hasAttachments) {
@@ -210,23 +235,41 @@ class _ComposeBarState extends State<ComposeBar> {
       return KeyEventResult.ignored;
     }
 
-    final mc = _mentionController;
-    if (mc == null || !mc.hasSuggestions) return KeyEventResult.ignored;
+    if (_mentionController?.hasSuggestions ?? false) {
+      return _handleAutocompleteKey(event, _mentionController!.moveUp,
+          _mentionController!.moveDown, _mentionController!.confirmSelection,
+          _mentionController!.dismiss,);
+    }
+    if (_emojiController?.hasSuggestions ?? false) {
+      return _handleAutocompleteKey(event, _emojiController!.moveUp,
+          _emojiController!.moveDown, _emojiController!.confirmSelection,
+          _emojiController!.dismiss,);
+    }
 
+    return KeyEventResult.ignored;
+  }
+
+  KeyEventResult _handleAutocompleteKey(
+    KeyEvent event,
+    VoidCallback moveUp,
+    VoidCallback moveDown,
+    VoidCallback confirm,
+    VoidCallback dismiss,
+  ) {
     if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-      mc.moveUp();
+      moveUp();
       return KeyEventResult.handled;
     }
     if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
-      mc.moveDown();
+      moveDown();
       return KeyEventResult.handled;
     }
     if (event.logicalKey == LogicalKeyboardKey.tab) {
-      mc.confirmSelection();
+      confirm();
       return KeyEventResult.handled;
     }
     if (event.logicalKey == LogicalKeyboardKey.escape) {
-      mc.dismiss();
+      dismiss();
       return KeyEventResult.handled;
     }
 
@@ -263,6 +306,20 @@ class _ComposeBarState extends State<ComposeBar> {
                 }
                 return MentionSuggestionList(
                   controller: _mentionController!,
+                  client: widget.room!.client,
+                );
+              },
+            ),
+          if (_emojiController != null)
+            ListenableBuilder(
+              listenable: _emojiController!,
+              builder: (context, _) {
+                if (!_emojiController!.isActive ||
+                    _emojiController!.suggestions.isEmpty) {
+                  return const SizedBox.shrink();
+                }
+                return EmojiSuggestionList(
+                  controller: _emojiController!,
                   client: widget.room!.client,
                 );
               },

--- a/lib/features/chat/widgets/emoji_autocomplete_controller.dart
+++ b/lib/features/chat/widgets/emoji_autocomplete_controller.dart
@@ -1,0 +1,202 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:kohera/core/services/sticker_pack_service.dart';
+import 'package:matrix/matrix.dart';
+
+/// A suggestion entry for the custom emoji autocomplete overlay.
+class EmojiSuggestion {
+  final String shortcode;
+  final Uri url;
+
+  const EmojiSuggestion({required this.shortcode, required this.url});
+}
+
+/// Encapsulates autocomplete state and logic for `:shortcode:` custom emoji.
+///
+/// Listens to a [TextEditingController], detects the `:` trigger character,
+/// filters custom emoji from the room's MSC2545 packs by shortcode, and
+/// inserts the selected `:shortcode:` text.
+class EmojiAutocompleteController extends ChangeNotifier {
+  EmojiAutocompleteController({
+    required this.textController,
+    required this.room,
+    required this.stickerPacks,
+    this.debounceDuration = const Duration(milliseconds: 150),
+  }) {
+    textController.addListener(_onTextChanged);
+  }
+
+  final TextEditingController textController;
+  final Room room;
+  final StickerPackService stickerPacks;
+  @visibleForTesting
+  final Duration debounceDuration;
+
+  static final _queryRegex = RegExp(r'^[\w-]*$');
+
+  /// Minimum query length before activating, to reduce noise (e.g. `http://`).
+  static const _minQueryLength = 2;
+
+  Timer? _debounce;
+  bool _isActive = false;
+  int _triggerOffset = -1;
+  String _query = '';
+  List<EmojiSuggestion> _suggestions = [];
+  int _selectedIndex = 0;
+
+  bool get isActive => _isActive;
+  String get query => _query;
+  List<EmojiSuggestion> get suggestions => _suggestions;
+  int get selectedIndex => _selectedIndex;
+
+  /// Whether the overlay has visible suggestions that can be confirmed.
+  bool get hasSuggestions => _isActive && _suggestions.isNotEmpty;
+
+  // ── Trigger detection ──────────────────────────────────────
+
+  void _onTextChanged() {
+    final text = textController.text;
+    final selection = textController.selection;
+
+    if (!selection.isValid || !selection.isCollapsed) {
+      _dismiss();
+      return;
+    }
+
+    final cursorPos = selection.baseOffset;
+    if (cursorPos < 0 || cursorPos > text.length) {
+      _dismiss();
+      return;
+    }
+
+    // Walk backwards from cursor to find the last `:`.
+    final textBeforeCursor = text.substring(0, cursorPos);
+    final triggerPos = textBeforeCursor.lastIndexOf(':');
+
+    if (triggerPos < 0) {
+      _dismiss();
+      return;
+    }
+
+    // Trigger must be at start of text or preceded by whitespace.
+    if (triggerPos > 0 &&
+        text[triggerPos - 1] != ' ' &&
+        text[triggerPos - 1] != '\n') {
+      _dismiss();
+      return;
+    }
+
+    // Query must contain only shortcode characters (no spaces/colons).
+    final queryText = text.substring(triggerPos + 1, cursorPos);
+    if (!_queryRegex.hasMatch(queryText)) {
+      _dismiss();
+      return;
+    }
+
+    // Require a minimum length to reduce noise from stray colons.
+    if (queryText.length < _minQueryLength) {
+      _dismiss();
+      return;
+    }
+
+    _triggerOffset = triggerPos;
+    _query = queryText;
+    _isActive = true;
+    _selectedIndex = 0;
+
+    _debounce?.cancel();
+    if (debounceDuration == Duration.zero) {
+      _updateSuggestions();
+    } else {
+      _debounce = Timer(debounceDuration, _updateSuggestions);
+    }
+  }
+
+  // ── Filtering ──────────────────────────────────────────────
+
+  void _updateSuggestions() {
+    final lowerQuery = _query.toLowerCase();
+    final seen = <String>{};
+    final results = <EmojiSuggestion>[];
+
+    for (final pack in stickerPacks.packsForRoom(room)) {
+      for (final image in pack.emoji) {
+        if (!seen.add(image.shortcode)) continue;
+        if (!image.shortcode.toLowerCase().contains(lowerQuery)) continue;
+        results.add(
+          EmojiSuggestion(shortcode: image.shortcode, url: image.url),
+        );
+        if (results.length >= 30) break;
+      }
+      if (results.length >= 30) break;
+    }
+
+    _suggestions = results;
+    notifyListeners();
+  }
+
+  // ── Keyboard navigation ────────────────────────────────────
+
+  void moveUp() {
+    if (_suggestions.isEmpty) return;
+    _selectedIndex = (_selectedIndex - 1).clamp(0, _suggestions.length - 1);
+    notifyListeners();
+  }
+
+  void moveDown() {
+    if (_suggestions.isEmpty) return;
+    _selectedIndex = (_selectedIndex + 1).clamp(0, _suggestions.length - 1);
+    notifyListeners();
+  }
+
+  // ── Selection ──────────────────────────────────────────────
+
+  /// Confirm the currently selected suggestion.
+  void confirmSelection() {
+    if (_suggestions.isEmpty) return;
+    selectSuggestion(_suggestions[_selectedIndex]);
+  }
+
+  /// Insert `:shortcode:` for [suggestion], replacing the trigger + query.
+  void selectSuggestion(EmojiSuggestion suggestion) {
+    final text = textController.text;
+    final emojiText = ':${suggestion.shortcode}: ';
+
+    final before = text.substring(0, _triggerOffset);
+    final cursorPos = textController.selection.baseOffset;
+    final after = text.substring(cursorPos);
+
+    final newText = '$before$emojiText$after';
+    final newCursor = before.length + emojiText.length;
+
+    textController.value = TextEditingValue(
+      text: newText,
+      selection: TextSelection.collapsed(offset: newCursor),
+    );
+
+    _dismiss();
+  }
+
+  // ── Dismissal ──────────────────────────────────────────────
+
+  void dismiss() => _dismiss();
+
+  void _dismiss() {
+    _debounce?.cancel();
+    if (!_isActive) return;
+    _isActive = false;
+    _triggerOffset = -1;
+    _query = '';
+    _suggestions = [];
+    _selectedIndex = 0;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    textController.removeListener(_onTextChanged);
+    super.dispose();
+  }
+}

--- a/lib/features/chat/widgets/emoji_suggestion_overlay.dart
+++ b/lib/features/chat/widgets/emoji_suggestion_overlay.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:kohera/features/chat/widgets/emoji_autocomplete_controller.dart';
+import 'package:kohera/shared/widgets/mxc_image.dart';
+import 'package:matrix/matrix.dart';
+
+/// Displays filtered custom emoji suggestions above the compose bar text field.
+class EmojiSuggestionList extends StatelessWidget {
+  const EmojiSuggestionList({
+    required this.controller, required this.client, super.key,
+  });
+
+  final EmojiAutocompleteController controller;
+  final Client client;
+
+  static const _maxHeight = 280.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final suggestions = controller.suggestions;
+
+    if (suggestions.isEmpty) return const SizedBox.shrink();
+
+    return Container(
+      constraints: const BoxConstraints(maxHeight: _maxHeight),
+      margin: const EdgeInsets.only(bottom: 4),
+      decoration: BoxDecoration(
+        color: cs.surfaceContainer,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: cs.shadow.withValues(alpha: 0.1),
+            blurRadius: 8,
+            offset: const Offset(0, -2),
+          ),
+        ],
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: ListView.builder(
+        padding: EdgeInsets.zero,
+        shrinkWrap: true,
+        itemCount: suggestions.length,
+        itemBuilder: (context, index) {
+          final suggestion = suggestions[index];
+          final isSelected = index == controller.selectedIndex;
+
+          return _SuggestionTile(
+            suggestion: suggestion,
+            isSelected: isSelected,
+            client: client,
+            onTap: () => controller.selectSuggestion(suggestion),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _SuggestionTile extends StatelessWidget {
+  const _SuggestionTile({
+    required this.suggestion,
+    required this.isSelected,
+    required this.client,
+    required this.onTap,
+  });
+
+  final EmojiSuggestion suggestion;
+  final bool isSelected;
+  final Client client;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    return Material(
+      color: isSelected
+          ? cs.primary.withValues(alpha: 0.12)
+          : Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Row(
+            children: [
+              SizedBox(
+                width: 24,
+                height: 24,
+                child: MxcImage(
+                  mxcUrl: suggestion.url.toString(),
+                  client: client,
+                  width: 24,
+                  height: 24,
+                  fallbackText: ':',
+                  fallbackStyle: tt.bodyMedium,
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  ':${suggestion.shortcode}:',
+                  style: tt.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w500,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/widgets/chat/emoji_autocomplete_controller_test.dart
+++ b/test/widgets/chat/emoji_autocomplete_controller_test.dart
@@ -1,0 +1,375 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/services/sticker_pack_service.dart';
+import 'package:kohera/features/chat/widgets/emoji_autocomplete_controller.dart';
+import 'package:matrix/matrix.dart';
+import 'package:matrix/src/utils/cached_stream_controller.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+@GenerateNiceMocks([
+  MockSpec<Client>(),
+  MockSpec<Room>(),
+])
+import 'emoji_autocomplete_controller_test.mocks.dart';
+
+// ── Helpers ──────────────────────────────────────────────────
+
+const _kRoomEmotesType = 'im.ponies.room_emotes';
+
+StrippedStateEvent _stateEvent(Map<String, Object?> content) =>
+    StrippedStateEvent(
+      type: _kRoomEmotesType,
+      senderId: '@bot:example.com',
+      stateKey: '',
+      content: content,
+    );
+
+Map<String, Object?> _emojiPackContent(List<String> shortcodes) => {
+      'pack': {
+        'display_name': 'Emoji Pack',
+        'usage': ['emoticon'],
+      },
+      'images': {
+        for (final s in shortcodes) s: {'url': 'mxc://example.com/$s'},
+      },
+    };
+
+void main() {
+  group('EmojiAutocompleteController', () {
+    late TextEditingController textCtrl;
+    late MockClient mockClient;
+    late CachedStreamController<SyncUpdate> syncCtl;
+    late StickerPackService stickerPacks;
+    late MockRoom mockRoom;
+
+    setUp(() {
+      textCtrl = TextEditingController();
+      mockClient = MockClient();
+      syncCtl = CachedStreamController<SyncUpdate>();
+      when(mockClient.onSync).thenReturn(syncCtl);
+      when(mockClient.accountData).thenReturn({});
+      when(mockClient.rooms).thenReturn([]);
+      stickerPacks = StickerPackService(client: mockClient);
+
+      mockRoom = MockRoom();
+      when(mockRoom.id).thenReturn('!room:example.com');
+      when(mockRoom.client).thenReturn(mockClient);
+      when(mockRoom.spaceParents).thenReturn([]);
+      when(mockRoom.getState(_kRoomEmotesType)).thenReturn(
+        _stateEvent(_emojiPackContent([
+          'partyblob',
+          'partywizard',
+          'thumbsup',
+          'heart',
+        ])),
+      );
+    });
+
+    tearDown(() {
+      textCtrl.dispose();
+      stickerPacks.dispose();
+    });
+
+    EmojiAutocompleteController makeController() => EmojiAutocompleteController(
+          textController: textCtrl,
+          room: mockRoom,
+          stickerPacks: stickerPacks,
+          debounceDuration: Duration.zero,
+        );
+
+    // ── Trigger detection ──────────────────────────────────
+
+    test('typing :par activates emoji autocomplete', () {
+      final ctrl = makeController();
+
+      textCtrl.value = const TextEditingValue(
+        text: ':par',
+        selection: TextSelection.collapsed(offset: 4),
+      );
+
+      expect(ctrl.isActive, isTrue);
+      expect(ctrl.query, 'par');
+
+      ctrl.dispose();
+    });
+
+    test(': after whitespace activates', () {
+      final ctrl = makeController();
+
+      textCtrl.value = const TextEditingValue(
+        text: 'hello :par',
+        selection: TextSelection.collapsed(offset: 10),
+      );
+
+      expect(ctrl.isActive, isTrue);
+
+      ctrl.dispose();
+    });
+
+    test('colon inside a word (http://) does not activate', () {
+      final ctrl = makeController();
+
+      textCtrl.value = const TextEditingValue(
+        text: 'http://example.com',
+        selection: TextSelection.collapsed(offset: 18),
+      );
+
+      expect(ctrl.isActive, isFalse);
+
+      ctrl.dispose();
+    });
+
+    test('single character query does not activate (min length 2)', () {
+      final ctrl = makeController();
+
+      textCtrl.value = const TextEditingValue(
+        text: ':p',
+        selection: TextSelection.collapsed(offset: 2),
+      );
+      expect(ctrl.isActive, isTrue);
+
+      textCtrl.value = const TextEditingValue(
+        text: ':',
+        selection: TextSelection.collapsed(offset: 1),
+      );
+      expect(ctrl.isActive, isFalse);
+
+      ctrl.dispose();
+    });
+
+    test('space in query dismisses autocomplete', () {
+      final ctrl = makeController();
+
+      textCtrl.value = const TextEditingValue(
+        text: ':par ty',
+        selection: TextSelection.collapsed(offset: 7),
+      );
+
+      expect(ctrl.isActive, isFalse);
+
+      ctrl.dispose();
+    });
+
+    test('completed shortcode with closing colon does not activate', () {
+      final ctrl = makeController();
+
+      textCtrl.value = const TextEditingValue(
+        text: ':party:',
+        selection: TextSelection.collapsed(offset: 7),
+      );
+
+      expect(ctrl.isActive, isFalse);
+
+      ctrl.dispose();
+    });
+
+    test('no trigger character means inactive', () {
+      final ctrl = makeController();
+
+      textCtrl.value = const TextEditingValue(
+        text: 'hello world',
+        selection: TextSelection.collapsed(offset: 11),
+      );
+
+      expect(ctrl.isActive, isFalse);
+
+      ctrl.dispose();
+    });
+
+    // ── Filtering ──────────────────────────────────────────
+
+    test('filters emoji by shortcode substring', () {
+      final ctrl = makeController();
+
+      textCtrl.value = const TextEditingValue(
+        text: ':party',
+        selection: TextSelection.collapsed(offset: 6),
+      );
+
+      expect(ctrl.suggestions.length, 2);
+      expect(
+        ctrl.suggestions.map((s) => s.shortcode),
+        containsAll(['partyblob', 'partywizard']),
+      );
+
+      ctrl.dispose();
+    });
+
+    test('filtering is case-insensitive', () {
+      final ctrl = makeController();
+
+      textCtrl.value = const TextEditingValue(
+        text: ':HEART',
+        selection: TextSelection.collapsed(offset: 6),
+      );
+
+      expect(ctrl.suggestions.length, 1);
+      expect(ctrl.suggestions.first.shortcode, 'heart');
+
+      ctrl.dispose();
+    });
+
+    test('non-matching query yields no suggestions', () {
+      final ctrl = makeController();
+
+      textCtrl.value = const TextEditingValue(
+        text: ':zzzznope',
+        selection: TextSelection.collapsed(offset: 9),
+      );
+
+      expect(ctrl.isActive, isTrue);
+      expect(ctrl.suggestions, isEmpty);
+      expect(ctrl.hasSuggestions, isFalse);
+
+      ctrl.dispose();
+    });
+
+    test('de-dupes emoji by shortcode (first wins)', () {
+      when(mockClient.accountData).thenReturn({
+        'im.ponies.user_emotes':
+            BasicEvent(type: 'im.ponies.user_emotes', content: {
+          'pack': {
+            'display_name': 'Account',
+            'usage': ['emoticon'],
+          },
+          'images': {
+            'heart': {'url': 'mxc://example.com/account_heart'},
+          },
+        }),
+      });
+
+      final ctrl = makeController();
+
+      textCtrl.value = const TextEditingValue(
+        text: ':heart',
+        selection: TextSelection.collapsed(offset: 6),
+      );
+
+      expect(ctrl.suggestions.length, 1);
+      // Account pack is aggregated first, so it wins.
+      expect(
+        ctrl.suggestions.first.url.toString(),
+        'mxc://example.com/account_heart',
+      );
+
+      ctrl.dispose();
+    });
+
+    // ── Selection ──────────────────────────────────────────
+
+    test('selectSuggestion inserts :shortcode: and a space', () {
+      final ctrl = makeController();
+
+      textCtrl.value = const TextEditingValue(
+        text: ':party',
+        selection: TextSelection.collapsed(offset: 6),
+      );
+
+      final suggestion = ctrl.suggestions
+          .firstWhere((s) => s.shortcode == 'partyblob');
+      ctrl.selectSuggestion(suggestion);
+
+      expect(textCtrl.text, ':partyblob: ');
+      expect(textCtrl.selection.baseOffset, ':partyblob: '.length);
+      expect(ctrl.isActive, isFalse);
+
+      ctrl.dispose();
+    });
+
+    test('selectSuggestion preserves text around the trigger', () {
+      final ctrl = makeController();
+
+      textCtrl.value = const TextEditingValue(
+        text: 'hey :heart thanks',
+        selection: TextSelection.collapsed(offset: 10),
+      );
+
+      expect(ctrl.suggestions.isNotEmpty, isTrue);
+      ctrl.selectSuggestion(ctrl.suggestions.first);
+
+      expect(textCtrl.text, 'hey :heart:  thanks');
+
+      ctrl.dispose();
+    });
+
+    // ── Keyboard navigation ────────────────────────────────
+
+    test('moveDown / moveUp adjust selectedIndex with clamping', () {
+      final ctrl = makeController();
+
+      textCtrl.value = const TextEditingValue(
+        text: ':party',
+        selection: TextSelection.collapsed(offset: 6),
+      );
+
+      expect(ctrl.selectedIndex, 0);
+      ctrl.moveDown();
+      expect(ctrl.selectedIndex, 1);
+      ctrl.moveDown();
+      expect(ctrl.selectedIndex, 1); // 2 suggestions, clamps at index 1.
+      ctrl.moveUp();
+      ctrl.moveUp();
+      expect(ctrl.selectedIndex, 0);
+
+      ctrl.dispose();
+    });
+
+    test('confirmSelection does nothing when suggestions empty', () {
+      final ctrl = makeController();
+
+      textCtrl.value = const TextEditingValue(
+        text: ':zzzznope',
+        selection: TextSelection.collapsed(offset: 9),
+      );
+
+      expect(ctrl.suggestions, isEmpty);
+      ctrl.confirmSelection(); // Should not throw.
+      expect(textCtrl.text, ':zzzznope');
+
+      ctrl.dispose();
+    });
+
+    // ── Dismissal ──────────────────────────────────────────
+
+    test('dismiss clears state', () {
+      final ctrl = makeController();
+
+      textCtrl.value = const TextEditingValue(
+        text: ':party',
+        selection: TextSelection.collapsed(offset: 6),
+      );
+
+      expect(ctrl.isActive, isTrue);
+      ctrl.dismiss();
+      expect(ctrl.isActive, isFalse);
+      expect(ctrl.suggestions, isEmpty);
+      expect(ctrl.selectedIndex, 0);
+
+      ctrl.dispose();
+    });
+
+    // ── hasSuggestions ──────────────────────────────────────
+
+    test('hasSuggestions is true only when active with suggestions', () {
+      final ctrl = makeController();
+
+      expect(ctrl.hasSuggestions, isFalse);
+
+      textCtrl.value = const TextEditingValue(
+        text: ':party',
+        selection: TextSelection.collapsed(offset: 6),
+      );
+      expect(ctrl.hasSuggestions, isTrue);
+
+      textCtrl.value = const TextEditingValue(
+        text: ':zzzznope',
+        selection: TextSelection.collapsed(offset: 9),
+      );
+      expect(ctrl.isActive, isTrue);
+      expect(ctrl.hasSuggestions, isFalse);
+
+      ctrl.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Closes #150. Discord/Slack-style custom-emoji autocomplete in the compose bar (insertion only).

- `EmojiAutocompleteController` (`emoji_autocomplete_controller.dart`) mirrors `MentionAutocompleteController`: walks back to the last `:`, requires it at start or after whitespace, query must be `^[\w-]*$` and ≥2 chars (so `http://`, lone `:`, and completed `:name:` don't trigger). Aggregates emoji from `StickerPackService.packsForRoom(room)`, de-dupes by shortcode (account pack wins), filters case-insensitively, caps at 30.
- `EmojiSuggestionList` (`emoji_suggestion_overlay.dart`) reuses the mention overlay's styling; each row shows a 24×24 `MxcImage` preview and the `:shortcode:` label, with selected-row highlight.
- `compose_bar.dart`: adds `_emojiController` (created in `initState` / re-created on room change), an overlay block, shared `_handleAutocompleteKey` for arrow/tab/escape across both controllers, emoji-confirm-before-send, and disposal. Selecting inserts `:shortcode: `.

Out of scope (not part of #150): sending/rendering shortcodes as inline images.

## Test plan
- [x] `test/widgets/chat/emoji_autocomplete_controller_test.dart`: trigger detection, filtering, de-dupe, insertion, nav clamping, dismissal.
- [ ] **CI must run `dart run build_runner build --delete-conflicting-outputs`** before `flutter test` (the test declares `@GenerateNiceMocks`), then `flutter analyze`. Toolchain was unavailable in the authoring environment — not compiled/run locally.
- [ ] Manual: in a room with an `im.ponies.*` emoji pack, type `:par`, confirm the popup filters, and selecting inserts the shortcode.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LK1kU4qCrjPLzfRFQCFvGQ)_