### PR TITLE
fix: open registration in add-account flow instead of redirecting home

### DIFF
--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -113,6 +113,23 @@ GoRouter buildRouter(ClientManager manager) {
         },
         routes: [
           GoRoute(
+            path: 'register',
+            name: Routes.addAccountRegister,
+            builder: (context, state) {
+              final homeserver = state.extra as String? ??
+                  context.read<PreferencesService>().defaultHomeserver ??
+                  AppConfig.instance.defaultHomeserver;
+              final manager = context.read<ClientManager>();
+              return _AddAccountGuard(
+                manager: manager,
+                child: ChangeNotifierProvider<MatrixService>.value(
+                  value: manager.pendingService!,
+                  child: RegistrationScreen(initialHomeserver: homeserver),
+                ),
+              );
+            },
+          ),
+          GoRoute(
             path: ':homeserver',
             name: Routes.addAccountServer,
             builder: (context, state) {

--- a/lib/core/routing/route_names.dart
+++ b/lib/core/routing/route_names.dart
@@ -21,6 +21,7 @@ abstract class Routes {
   static const e2eeSetup = 'e2ee-setup';
   static const addAccount = 'add-account';
   static const addAccountServer = 'add-account-server';
+  static const addAccountRegister = 'add-account-register';
   static const whatsNew = 'whats-new';
   static const roomPermissions = 'room-permissions';
 }

--- a/lib/features/auth/screens/homeserver_screen.dart
+++ b/lib/features/auth/screens/homeserver_screen.dart
@@ -90,7 +90,7 @@ class _HomeserverScreenState extends State<HomeserverScreen>
   void _openRegistration() {
     if (!mounted) return;
     context.goNamed(
-      Routes.register,
+      widget.isAddAccount ? Routes.addAccountRegister : Routes.register,
       extra: _homeserverCtrl.text.trim(),
     );
   }

--- a/lib/features/auth/screens/registration_screen.dart
+++ b/lib/features/auth/screens/registration_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kohera/core/services/app_config.dart';
+import 'package:kohera/core/services/client_manager.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/features/auth/widgets/app_logo_header.dart';
 import 'package:kohera/features/auth/widgets/registration_controller.dart';
@@ -51,6 +52,7 @@ class _RegistrationScreenState extends State<RegistrationScreen>
 
     _controller = RegistrationController(
       matrixService: context.read<MatrixService>(),
+      clientManager: context.read<ClientManager>(),
       homeserver: _homeserverCtrl.text,
     );
     _controller.addListener(_onControllerChanged);

--- a/lib/features/auth/widgets/registration_controller.dart
+++ b/lib/features/auth/widgets/registration_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:kohera/core/services/client_manager.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/utils/network_error.dart';
 import 'package:kohera/features/auth/services/recaptcha_server.dart';
@@ -28,10 +29,12 @@ enum RegistrationState {
 class RegistrationController extends ChangeNotifier {
   RegistrationController({
     required this.matrixService,
+    required this.clientManager,
     required String homeserver,
   }) : _homeserver = homeserver;
 
   final MatrixService matrixService;
+  final ClientManager clientManager;
 
   String _homeserver;
   String get homeserver => _homeserver;
@@ -227,6 +230,9 @@ class RegistrationController extends ChangeNotifier {
       if (_isDisposed) return;
 
       await matrixService.completeRegistration(response, password: _password);
+      if (!clientManager.services.contains(matrixService)) {
+        clientManager.commitPendingService();
+      }
       _clearCredentials();
       _state = RegistrationState.done;
       _notify();

--- a/test/widgets/registration_controller_test.dart
+++ b/test/widgets/registration_controller_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/models/server_auth_capabilities.dart';
+import 'package:kohera/core/services/client_manager.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/auth_service.dart';
 import 'package:kohera/features/auth/widgets/registration_controller.dart';
@@ -17,15 +18,32 @@ import 'package:mockito/mockito.dart';
 ])
 import 'registration_controller_test.mocks.dart';
 
+/// Minimal [ClientManager] double. Hand-written rather than a generated mock
+/// so the controller test compiles without regenerating mocks.
+class _FakeClientManager extends ClientManager {
+  _FakeClientManager(this._registered);
+
+  final List<MatrixService> _registered;
+  bool committed = false;
+
+  @override
+  List<MatrixService> get services => _registered;
+
+  @override
+  void commitPendingService() => committed = true;
+}
+
 void main() {
   late MockClient mockClient;
   late MockMatrixService mockMatrixService;
   late MockAuthService mockAuthService;
+  late _FakeClientManager fakeClientManager;
 
   setUp(() {
     mockClient = MockClient();
     mockMatrixService = MockMatrixService();
     mockAuthService = MockAuthService();
+    fakeClientManager = _FakeClientManager([mockMatrixService]);
     when(mockMatrixService.client).thenReturn(mockClient);
     when(mockMatrixService.auth).thenReturn(mockAuthService);
     when(mockMatrixService.isLoggedIn).thenReturn(false);
@@ -34,6 +52,7 @@ void main() {
   RegistrationController createController({String homeserver = 'example.com'}) {
     return RegistrationController(
       matrixService: mockMatrixService,
+      clientManager: fakeClientManager,
       homeserver: homeserver,
     );
   }
@@ -428,6 +447,59 @@ void main() {
           any,
           password: anyNamed('password'),
         ),).called(1);
+        controller.dispose();
+      });
+
+      test('commits pending service when registering an additional account',
+          () async {
+        // The registering service is not yet in the account list (pending),
+        // mirroring the add-account flow.
+        fakeClientManager = _FakeClientManager([]);
+
+        when(mockClient.register(
+          username: anyNamed('username'),
+          password: anyNamed('password'),
+          initialDeviceDisplayName: anyNamed('initialDeviceDisplayName'),
+          auth: anyNamed('auth'),
+        ),).thenAnswer((_) async => RegisterResponse(
+              userId: '@user:example.com',
+              accessToken: 'tok',
+              deviceId: 'D1',
+            ),);
+        when(mockMatrixService.completeRegistration(any))
+            .thenAnswer((_) async {});
+
+        final controller = createController();
+        await controller.checkServer();
+        await controller.submitForm(
+            username: 'user', password: 'password123',);
+
+        expect(controller.state, RegistrationState.done);
+        expect(fakeClientManager.committed, isTrue);
+        controller.dispose();
+      });
+
+      test('does not commit when registering the first account', () async {
+        when(mockClient.register(
+          username: anyNamed('username'),
+          password: anyNamed('password'),
+          initialDeviceDisplayName: anyNamed('initialDeviceDisplayName'),
+          auth: anyNamed('auth'),
+        ),).thenAnswer((_) async => RegisterResponse(
+              userId: '@user:example.com',
+              accessToken: 'tok',
+              deviceId: 'D1',
+            ),);
+        when(mockMatrixService.completeRegistration(any))
+            .thenAnswer((_) async {});
+
+        final controller = createController();
+        await controller.checkServer();
+        await controller.submitForm(
+            username: 'user', password: 'password123',);
+
+        expect(controller.state, RegistrationState.done);
+        expect(fakeClientManager.committed, isFalse);
         controller.dispose();
       });
 


### PR DESCRIPTION
Tapping "Create account" from the add-account homeserver picker navigated
to /register, which the auth guard bounced back to / because the user was
already logged in. Add a dedicated /add-account/register route (covered by
the add-account guard prefix) and route the add-account picker to it.

RegistrationController now commits the pending service on success, mirroring
LoginController, so a newly registered additional account is added to the
account list and made active.

https://claude.ai/code/session_01XGBQ6xgWLoT3rSQUHCYevS