### PR TITLE
feat(#149): sticker picker overlay in compose bar

### DIFF
--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -7,11 +7,13 @@ import 'package:flutter/services.dart' show Clipboard;
 import 'package:giphy_get/giphy_get.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kohera/core/models/pending_attachment.dart';
+import 'package:kohera/core/models/sticker_pack.dart';
 import 'package:kohera/core/models/upload_state.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/app_config.dart';
 import 'package:kohera/core/services/call_service.dart';
 import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/core/services/sticker_pack_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/core/utils/platform_info.dart';
 import 'package:kohera/features/chat/screens/thread_list_screen.dart';
@@ -34,6 +36,7 @@ import 'package:kohera/features/chat/widgets/message_list_view.dart';
 import 'package:kohera/features/chat/widgets/paste_image_handler.dart';
 import 'package:kohera/features/chat/widgets/photo_send_handler.dart';
 import 'package:kohera/features/chat/widgets/search_results_body.dart';
+import 'package:kohera/features/chat/widgets/sticker_picker_overlay.dart';
 import 'package:kohera/features/chat/widgets/typing_indicator.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
@@ -90,6 +93,9 @@ class _ChatScreenState extends State<ChatScreen>
   // ── Thread side pane (desktop) ─────────────────────────
   String? _activeThreadEventId;
   bool _showThreadList = false;
+
+  // ── Sticker picker ─────────────────────────────────────
+  bool _showStickerPicker = false;
 
   // ── Search ─────────────────────────────────────────────
   late ChatSearchController _search;
@@ -309,6 +315,52 @@ class _ChatScreenState extends State<ChatScreen>
     _messageListKey.currentState?.navigateToEvent(event);
   }
 
+  // ── Sticker picker ────────────────────────────────────────
+
+  void _toggleStickerPicker() {
+    setState(() => _showStickerPicker = !_showStickerPicker);
+  }
+
+  Future<void> _handleStickerSelected(PackImage sticker) async {
+    setState(() => _showStickerPicker = false);
+    final room =
+        context.read<MatrixService>().client.getRoomById(widget.roomId);
+    if (room == null) return;
+    try {
+      await room.sendEvent(
+        {
+          'body': sticker.altText,
+          'url': sticker.url.toString(),
+          'info': <String, Object?>{},
+        },
+        type: 'm.sticker',
+      );
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'Failed to send sticker: ${MatrixService.friendlyAuthError(e)}',
+            ),
+          ),
+        );
+      }
+    }
+  }
+
+  void _handleEmojiSelected(PackImage emoji) {
+    setState(() => _showStickerPicker = false);
+    final text = _msgCtrl.text;
+    final sel = _msgCtrl.selection;
+    final pos = sel.isValid ? sel.baseOffset : text.length;
+    final insertion = ':${emoji.shortcode}: ';
+    _msgCtrl.value = TextEditingValue(
+      text: text.substring(0, pos) + insertion + text.substring(pos),
+      selection: TextSelection.collapsed(offset: pos + insertion.length),
+    );
+    _composeFocusNode.requestFocus();
+  }
+
   @override
   void dispose() {
     _msgCtrl.dispose();
@@ -420,6 +472,19 @@ class _ChatScreenState extends State<ChatScreen>
           myUserId: matrix.client.userID,
           syncStream: matrix.client.onSync.stream,
         ),
+        if (_showStickerPicker)
+          Consumer<StickerPackService>(
+            builder: (context, stickerService, _) => StickerPickerOverlay(
+              packs: stickerService.packsForRoom(room),
+              client: matrix.client,
+              onStickerTapped: _handleStickerSelected,
+              onEmojiTapped: _handleEmojiSelected,
+              onManagePacks: () {
+                setState(() => _showStickerPicker = false);
+                context.goNamed(Routes.settings);
+              },
+            ),
+          ),
         ComposeBarSection(
           replyNotifier: _compose.replyNotifier,
           editNotifier: _compose.editNotifier,
@@ -429,6 +494,7 @@ class _ChatScreenState extends State<ChatScreen>
           onCancelReply: _compose.cancelReply,
           onCancelEdit: () => _compose.cancelEdit(_msgCtrl),
           onAttach: _handleAttachPressed,
+          onSticker: _toggleStickerPicker,
           onGif: AppConfig.isInitialized && AppConfig.instance.giphyEnabled
               ? () async {
                   final gif = await GiphyGet.getGif(

--- a/lib/features/chat/widgets/compose_bar.dart
+++ b/lib/features/chat/widgets/compose_bar.dart
@@ -32,6 +32,7 @@ class ComposeBar extends StatefulWidget {
     this.editEvent,
     this.onAttach,
     this.onGif,
+    this.onSticker,
     this.onPasteImage,
     this.uploadNotifier,
     this.room,
@@ -54,6 +55,7 @@ class ComposeBar extends StatefulWidget {
   final VoidCallback onCancelEdit;
   final VoidCallback? onAttach;
   final VoidCallback? onGif;
+  final VoidCallback? onSticker;
   final ValueNotifier<UploadState?>? uploadNotifier;
 
   /// The current room (needed to fetch members for @-mentions).
@@ -366,6 +368,7 @@ class _ComposeBarState extends State<ComposeBar> {
         children: [
           _buildAttachButton(cs),
           if (widget.onGif != null) _buildGifButton(cs),
+          if (widget.onSticker != null) _buildStickerButton(cs),
           Expanded(
             child: CallbackShortcuts(
               bindings: {
@@ -476,6 +479,14 @@ class _ComposeBarState extends State<ComposeBar> {
       ),
       onPressed: widget.onGif,
       tooltip: 'Send GIF',
+    );
+  }
+
+  Widget _buildStickerButton(ColorScheme cs) {
+    return IconButton(
+      icon: Icon(Icons.emoji_emotions_outlined, color: cs.onSurfaceVariant),
+      onPressed: widget.onSticker,
+      tooltip: 'Stickers & Emoji',
     );
   }
 }

--- a/lib/features/chat/widgets/compose_bar_section.dart
+++ b/lib/features/chat/widgets/compose_bar_section.dart
@@ -19,6 +19,7 @@ class ComposeBarSection extends StatelessWidget {
     required this.onClearAttachments,
     this.onAttach,
     this.onGif,
+    this.onSticker,
     this.onPasteImage,
     this.uploadNotifier,
     this.room,
@@ -41,6 +42,7 @@ class ComposeBarSection extends StatelessWidget {
   final VoidCallback onCancelEdit;
   final VoidCallback? onAttach;
   final VoidCallback? onGif;
+  final VoidCallback? onSticker;
   final Future<void> Function()? onPasteImage;
   final ValueNotifier<UploadState?>? uploadNotifier;
   final Room? room;
@@ -68,6 +70,7 @@ class ComposeBarSection extends StatelessWidget {
           onCancelEdit: onCancelEdit,
           onAttach: onAttach,
           onGif: onGif,
+          onSticker: onSticker,
           onPasteImage: onPasteImage,
           uploadNotifier: uploadNotifier,
           room: room,

--- a/lib/features/chat/widgets/sticker_picker_overlay.dart
+++ b/lib/features/chat/widgets/sticker_picker_overlay.dart
@@ -1,0 +1,316 @@
+import 'package:flutter/material.dart';
+import 'package:kohera/core/models/sticker_pack.dart';
+import 'package:kohera/shared/widgets/mxc_image.dart';
+import 'package:matrix/matrix.dart';
+
+class StickerPickerOverlay extends StatefulWidget {
+  const StickerPickerOverlay({
+    required this.packs,
+    required this.client,
+    required this.onStickerTapped,
+    required this.onEmojiTapped,
+    required this.onManagePacks,
+    super.key,
+  });
+
+  final List<StickerPack> packs;
+  final Client client;
+  final void Function(PackImage) onStickerTapped;
+  final void Function(PackImage) onEmojiTapped;
+  final VoidCallback onManagePacks;
+
+  @override
+  State<StickerPickerOverlay> createState() => _StickerPickerOverlayState();
+}
+
+class _StickerPickerOverlayState extends State<StickerPickerOverlay>
+    with SingleTickerProviderStateMixin {
+  final _searchCtrl = TextEditingController();
+  TabController? _tabController;
+  String _query = '';
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.packs.isNotEmpty) {
+      _tabController = TabController(length: widget.packs.length, vsync: this);
+    }
+    _searchCtrl.addListener(() {
+      setState(() => _query = _searchCtrl.text.trim().toLowerCase());
+    });
+  }
+
+  @override
+  void didUpdateWidget(StickerPickerOverlay old) {
+    super.didUpdateWidget(old);
+    if (old.packs.length != widget.packs.length) {
+      _tabController?.dispose();
+      _tabController = widget.packs.isEmpty
+          ? null
+          : TabController(length: widget.packs.length, vsync: this);
+    }
+  }
+
+  @override
+  void dispose() {
+    _tabController?.dispose();
+    _searchCtrl.dispose();
+    super.dispose();
+  }
+
+  bool _matches(PackImage img) {
+    if (_query.isEmpty) return true;
+    return img.shortcode.toLowerCase().contains(_query) ||
+        (img.body?.toLowerCase().contains(_query) ?? false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return SizedBox(
+      height: 300,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: cs.surface,
+          border: Border(
+            top: BorderSide(color: cs.outlineVariant.withValues(alpha: 0.3)),
+          ),
+        ),
+        child: widget.packs.isEmpty ? _buildEmptyState(cs) : _buildPicker(cs),
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(ColorScheme cs) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.sticky_note_2_outlined,
+            size: 48,
+            color: cs.onSurfaceVariant,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'No sticker packs configured',
+            style: TextStyle(color: cs.onSurfaceVariant),
+          ),
+          const SizedBox(height: 8),
+          TextButton(
+            onPressed: widget.onManagePacks,
+            child: const Text('Manage packs'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPicker(ColorScheme cs) {
+    return Column(
+      children: [
+        _buildSearchField(cs),
+        if (_query.isEmpty) ...[
+          TabBar(
+            controller: _tabController,
+            isScrollable: true,
+            tabAlignment: TabAlignment.start,
+            tabs: [
+              for (final pack in widget.packs)
+                Tab(
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (pack.avatarUrl != null) ...[
+                        MxcImage(
+                          mxcUrl: pack.avatarUrl!.toString(),
+                          client: widget.client,
+                          width: 18,
+                          height: 18,
+                          fallbackText: '',
+                          fallbackStyle: null,
+                        ),
+                        const SizedBox(width: 6),
+                      ],
+                      Text(pack.displayName),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+          Expanded(
+            child: TabBarView(
+              controller: _tabController,
+              children: [
+                for (final pack in widget.packs) _buildPackView(pack),
+              ],
+            ),
+          ),
+        ] else
+          Expanded(child: _buildSearchResults(cs)),
+      ],
+    );
+  }
+
+  Widget _buildSearchField(ColorScheme cs) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+      child: TextField(
+        controller: _searchCtrl,
+        decoration: InputDecoration(
+          hintText: 'Search stickers & emoji…',
+          prefixIcon: const Icon(Icons.search, size: 20),
+          suffixIcon: _query.isNotEmpty
+              ? IconButton(
+                  icon: const Icon(Icons.clear, size: 18),
+                  onPressed: _searchCtrl.clear,
+                )
+              : null,
+          isDense: true,
+          contentPadding:
+              const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(20),
+            borderSide: BorderSide.none,
+          ),
+          filled: true,
+          fillColor: cs.surfaceContainerHighest.withValues(alpha: 0.5),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPackView(StickerPack pack) {
+    return CustomScrollView(
+      slivers: [
+        if (pack.stickers.isNotEmpty) ...[
+          SliverToBoxAdapter(child: _sectionHeader('Stickers')),
+          SliverGrid.builder(
+            itemCount: pack.stickers.length,
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 4,
+              mainAxisSpacing: 4,
+              crossAxisSpacing: 4,
+            ),
+            itemBuilder: (ctx, i) => _stickerItem(pack.stickers[i]),
+          ),
+        ],
+        if (pack.emoji.isNotEmpty) ...[
+          SliverToBoxAdapter(child: _sectionHeader('Emoji')),
+          SliverGrid.builder(
+            itemCount: pack.emoji.length,
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 5,
+              mainAxisSpacing: 4,
+              crossAxisSpacing: 4,
+            ),
+            itemBuilder: (ctx, i) => _emojiItem(pack.emoji[i]),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildSearchResults(ColorScheme cs) {
+    final matchingStickers = [
+      for (final p in widget.packs)
+        for (final s in p.stickers)
+          if (_matches(s)) s,
+    ];
+    final matchingEmoji = [
+      for (final p in widget.packs)
+        for (final e in p.emoji)
+          if (_matches(e)) e,
+    ];
+
+    if (matchingStickers.isEmpty && matchingEmoji.isEmpty) {
+      return Center(
+        child: Text(
+          'No results for "$_query"',
+          style: TextStyle(color: cs.onSurfaceVariant),
+        ),
+      );
+    }
+
+    return CustomScrollView(
+      slivers: [
+        if (matchingStickers.isNotEmpty) ...[
+          SliverToBoxAdapter(child: _sectionHeader('Stickers')),
+          SliverGrid.builder(
+            itemCount: matchingStickers.length,
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 4,
+              mainAxisSpacing: 4,
+              crossAxisSpacing: 4,
+            ),
+            itemBuilder: (ctx, i) => _stickerItem(matchingStickers[i]),
+          ),
+        ],
+        if (matchingEmoji.isNotEmpty) ...[
+          SliverToBoxAdapter(child: _sectionHeader('Emoji')),
+          SliverGrid.builder(
+            itemCount: matchingEmoji.length,
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 5,
+              mainAxisSpacing: 4,
+              crossAxisSpacing: 4,
+            ),
+            itemBuilder: (ctx, i) => _emojiItem(matchingEmoji[i]),
+          ),
+        ],
+      ],
+    );
+  }
+
+  Widget _sectionHeader(String label) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 4),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.labelSmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+      ),
+    );
+  }
+
+  Widget _stickerItem(PackImage sticker) {
+    return Tooltip(
+      message: sticker.altText,
+      child: GestureDetector(
+        onTap: () => widget.onStickerTapped(sticker),
+        child: Padding(
+          padding: const EdgeInsets.all(4),
+          child: MxcImage(
+            mxcUrl: sticker.url.toString(),
+            client: widget.client,
+            width: 64,
+            height: 64,
+            fallbackText: sticker.altText,
+            fallbackStyle: Theme.of(context).textTheme.bodySmall,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _emojiItem(PackImage emoji) {
+    return Tooltip(
+      message: emoji.altText,
+      child: GestureDetector(
+        onTap: () => widget.onEmojiTapped(emoji),
+        child: Padding(
+          padding: const EdgeInsets.all(4),
+          child: MxcImage(
+            mxcUrl: emoji.url.toString(),
+            client: widget.client,
+            width: 40,
+            height: 40,
+            fallbackText: emoji.altText,
+            fallbackStyle: Theme.of(context).textTheme.bodySmall,
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a sticker/emoji picker overlay triggered by a new button (emoji icon) in the compose bar
- Overlay shows pack tabs along the top with avatar + name; each tab has separate Stickers (4-col grid) and Emoji (5-col grid) sections
- Global search field filters across all packs when active, switching to a flat cross-pack results view
- Tapping a sticker sends an `m.sticker` event to the room
- Tapping an emoji inserts its shortcode (`:shortcode: `) into the compose field
- Empty state shown when no packs are configured, with a "Manage packs" link to Settings

## Test plan
- [ ] Open a chat room and tap the emoji button in the compose bar — picker opens above the compose bar
- [ ] Switch between pack tabs; verify stickers and emoji render correctly
- [ ] Type in the search field; verify results filter across packs
- [ ] Tap a sticker; verify it sends as an `m.sticker` event visible in the timeline
- [ ] Tap an emoji; verify the shortcode is inserted at the cursor in the compose field
- [ ] Tap the button again to close the picker
- [ ] Open picker on an account with no sticker packs; verify empty state with "Manage packs" button

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)