### PR TITLE
feat(#530): browse and import emoji.gg sticker packs

### DIFF
--- a/lib/core/models/emoji_gg_pack.dart
+++ b/lib/core/models/emoji_gg_pack.dart
@@ -6,8 +6,8 @@ class EmojiGgEmoji {
 
   String get imageUrl => 'https://cdn3.emoji.gg/emojis/$slug.png';
 
-  /// Strips the numeric ID prefix: "4384_falco_stare" → "falco_stare".
-  String get shortcode => slug.replaceFirst(RegExp(r'^\d+_'), '');
+  /// Strips the numeric ID prefix: "4384_falco_stare" or "664414-name" → the name part.
+  String get shortcode => slug.replaceFirst(RegExp(r'^\d+[_-]'), '');
 }
 
 class EmojiGgPack {
@@ -36,8 +36,8 @@ class EmojiGgPack {
         (s) => EmojiGgEmoji(
           slug: s,
           title: s
-              .replaceFirst(RegExp(r'^\d+_'), '')
-              .replaceAll('_', ' '),
+              .replaceFirst(RegExp(r'^\d+[_-]'), '')
+              .replaceAll(RegExp('[_-]'), ' '),
         ),
       )
       .toList();

--- a/lib/core/models/emoji_gg_pack.dart
+++ b/lib/core/models/emoji_gg_pack.dart
@@ -1,0 +1,72 @@
+class EmojiGgEmoji {
+  const EmojiGgEmoji({required this.slug, required this.title});
+
+  final String slug;
+  final String title;
+
+  String get imageUrl => 'https://cdn3.emoji.gg/emojis/$slug.png';
+
+  /// Strips the numeric ID prefix: "4384_falco_stare" → "falco_stare".
+  String get shortcode => slug.replaceFirst(RegExp(r'^\d+_'), '');
+}
+
+class EmojiGgPack {
+  const EmojiGgPack({
+    required this.id,
+    required this.name,
+    required this.slug,
+    required this.description,
+    required this.amount,
+    required this.emojiSlugs,
+    this.category,
+  });
+
+  final int id;
+  final String name;
+  final String slug;
+  final String description;
+  final int amount;
+
+  /// Slugs parsed from the comma-separated `emojis` field.
+  final List<String> emojiSlugs;
+  final String? category;
+
+  List<EmojiGgEmoji> get emojis => emojiSlugs
+      .map(
+        (s) => EmojiGgEmoji(
+          slug: s,
+          title: s
+              .replaceFirst(RegExp(r'^\d+_'), '')
+              .replaceAll('_', ' '),
+        ),
+      )
+      .toList();
+
+  static EmojiGgPack? fromJson(Map<String, dynamic> json) {
+    try {
+      final id = json['id'];
+      if (id == null) return null;
+
+      final slugsRaw = (json['emojis'] as String?) ?? '';
+      final slugs = slugsRaw.isEmpty
+          ? <String>[]
+          : slugsRaw
+              .split(',')
+              .map((s) => s.trim().replaceAll(RegExp(r'\.png$'), ''))
+              .where((s) => s.isNotEmpty)
+              .toList();
+
+      return EmojiGgPack(
+        id: id as int,
+        name: (json['name'] as String?) ?? '',
+        slug: (json['slug'] as String?) ?? '',
+        description: (json['description'] as String?) ?? '',
+        amount: (json['amount'] as int?) ?? slugs.length,
+        emojiSlugs: slugs,
+        category: json['category'] as String?,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -23,6 +23,7 @@ import 'package:kohera/features/rooms/widgets/room_details_panel.dart';
 import 'package:kohera/features/rooms/widgets/room_list.dart';
 import 'package:kohera/features/settings/screens/appearance_screen.dart';
 import 'package:kohera/features/settings/screens/devices_screen.dart';
+import 'package:kohera/features/settings/screens/emoji_gg_browse_screen.dart';
 import 'package:kohera/features/settings/screens/notification_settings_screen.dart';
 import 'package:kohera/features/settings/screens/settings_screen.dart';
 import 'package:kohera/features/settings/screens/sticker_packs_screen.dart';
@@ -318,6 +319,12 @@ GoRouter buildRouter(ClientManager manager) {
                     name: Routes.settingsStickerPacks,
                     builder: (context, state) =>
                         const StickerPacksScreen(),
+                  ),
+                  GoRoute(
+                    path: 'emoji-gg-browse',
+                    name: Routes.settingsEmojiGgBrowse,
+                    builder: (context, state) =>
+                        const EmojiGgBrowseScreen(),
                   ),
                 ],
               ),

--- a/lib/core/routing/route_names.dart
+++ b/lib/core/routing/route_names.dart
@@ -16,6 +16,7 @@ abstract class Routes {
   static const settingsVoiceVideo = 'settings-voice-video';
   static const settingsRecoveryKey = 'settings-recovery-key';
   static const settingsStickerPacks = 'settings-sticker-packs';
+  static const settingsEmojiGgBrowse = 'settings-emoji-gg-browse';
   static const inbox = 'inbox';
   static const spaceDetails = 'space-details';
   static const call = 'call';

--- a/lib/core/services/emoji_gg_service.dart
+++ b/lib/core/services/emoji_gg_service.dart
@@ -1,0 +1,140 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import 'package:kohera/core/models/emoji_gg_pack.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+class EmojiGgService {
+  EmojiGgService({
+    http.Client? client,
+    Duration? cacheTtl,
+    Duration? requestTimeout,
+  })  : _client = client ?? http.Client(),
+        _cacheTtl = cacheTtl ?? const Duration(hours: 24),
+        _requestTimeout = requestTimeout ?? const Duration(seconds: 15);
+
+  static final Uri _packsEndpoint = Uri.parse('https://emoji.gg/api/packs');
+  static const _cacheFileName = 'emojigg_packs_cache.json';
+
+  final http.Client _client;
+  final Duration _cacheTtl;
+  final Duration _requestTimeout;
+
+  List<EmojiGgPack>? _memoryCache;
+  DateTime? _memoryCachedAt;
+  Future<List<EmojiGgPack>>? _inFlight;
+  bool _disposed = false;
+
+  void dispose() {
+    _disposed = true;
+    _client.close();
+  }
+
+  Future<List<EmojiGgPack>> fetchPacks({bool forceRefresh = false}) {
+    if (_disposed) return Future.value([]);
+    return _inFlight ??= _fetchPacks(forceRefresh: forceRefresh)
+        .whenComplete(() => _inFlight = null);
+  }
+
+  Future<Uint8List> downloadImage(String imageUrl) async {
+    final response = await _client
+        .get(Uri.parse(imageUrl))
+        .timeout(_requestTimeout);
+    if (response.statusCode != 200) {
+      throw Exception(
+        'emoji.gg image download failed (${response.statusCode}): $imageUrl',
+      );
+    }
+    return response.bodyBytes;
+  }
+
+  // ── Private ──────────────────────────────────────────────────
+
+  bool _isCacheFresh() =>
+      _memoryCachedAt != null &&
+      DateTime.now().difference(_memoryCachedAt!) < _cacheTtl;
+
+  Future<List<EmojiGgPack>> _fetchPacks({required bool forceRefresh}) async {
+    if (!forceRefresh && _memoryCache != null && _isCacheFresh()) {
+      return _memoryCache!;
+    }
+
+    if (!forceRefresh) {
+      final disk = await _readDiskCache();
+      if (disk != null) {
+        _memoryCache = disk;
+        _memoryCachedAt = DateTime.now();
+        return disk;
+      }
+    }
+
+    try {
+      final response = await _client
+          .get(_packsEndpoint, headers: {'Accept': 'application/json'})
+          .timeout(_requestTimeout);
+
+      if (response.statusCode == 200) {
+        final raw = jsonDecode(response.body) as List<dynamic>;
+        final packs = raw
+            .cast<Map<String, dynamic>>()
+            .map(EmojiGgPack.fromJson)
+            .whereType<EmojiGgPack>()
+            .where((pack) => pack.amount > 0)
+            .toList();
+
+        _memoryCache = packs;
+        _memoryCachedAt = DateTime.now();
+        unawaited(_writeDiskCache(raw));
+        return packs;
+      }
+
+      debugPrint('[Kohera] emoji.gg API returned ${response.statusCode}');
+      return _memoryCache ?? [];
+    } catch (e) {
+      debugPrint('[Kohera] emoji.gg fetch failed: $e');
+      return _memoryCache ?? [];
+    }
+  }
+
+  Future<File> _cacheFile() async {
+    final dir = await getApplicationSupportDirectory();
+    return File(p.join(dir.path, _cacheFileName));
+  }
+
+  Future<List<EmojiGgPack>?> _readDiskCache() async {
+    try {
+      final file = await _cacheFile();
+      if (!file.existsSync()) return null;
+
+      final age = DateTime.now().difference(file.statSync().modified);
+      if (age > _cacheTtl) return null;
+
+      final raw = jsonDecode(await file.readAsString()) as List<dynamic>;
+      return raw
+          .cast<Map<String, dynamic>>()
+          .map(EmojiGgPack.fromJson)
+          .whereType<EmojiGgPack>()
+          .where((pack) => pack.amount > 0)
+          .toList();
+    } catch (e) {
+      debugPrint('[Kohera] emoji.gg cache read failed: $e');
+      return null;
+    }
+  }
+
+  Future<void> _writeDiskCache(List<dynamic> raw) async {
+    try {
+      final file = await _cacheFile();
+      await file.parent.create(recursive: true);
+      await file.writeAsString(jsonEncode(raw));
+    } catch (e) {
+      debugPrint('[Kohera] emoji.gg cache write failed: $e');
+    }
+  }
+}
+
+// Dart 3 unawaited helper (mirrors dart:async behaviour).
+void unawaited(Future<void> future) => future.ignore();

--- a/lib/core/services/sticker_pack_service.dart
+++ b/lib/core/services/sticker_pack_service.dart
@@ -102,7 +102,7 @@ class StickerPackService extends ChangeNotifier {
           url: url,
           body: imageData['body'] as String?,
           isSticker: true,
-          isEmoji: true,
+          isEmoji: false,
         ),);
       }
 
@@ -112,7 +112,7 @@ class StickerPackService extends ChangeNotifier {
         id: id,
         displayName: displayName,
         stickers: stickers,
-        emoji: stickers,
+        emoji: const [],
       ),);
     }
 

--- a/lib/core/services/sticker_pack_service.dart
+++ b/lib/core/services/sticker_pack_service.dart
@@ -1,15 +1,28 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:kohera/core/models/emoji_gg_pack.dart';
 import 'package:kohera/core/models/sticker_pack.dart';
+import 'package:kohera/core/services/emoji_gg_service.dart';
 import 'package:matrix/matrix.dart';
+
+class ImportProgress {
+  const ImportProgress({required this.done, required this.total});
+  final int done;
+  final int total;
+  double get fraction => total == 0 ? 1.0 : done / total;
+  bool get isComplete => done >= total;
+}
 
 class StickerPackService extends ChangeNotifier {
   StickerPackService({required Client client}) : _client = client {
     _sub = client.onSync.stream.listen((sync) {
       final relevant =
           sync.accountData?.any(
-            (e) => e.type == _kUserEmotesType || e.type == _kSubscriptionsType,
+            (e) =>
+                e.type == _kUserEmotesType ||
+                e.type == _kSubscriptionsType ||
+                e.type == _kImportedPacksType,
           ) ??
           false;
       if (relevant) notifyListeners();
@@ -19,17 +32,20 @@ class StickerPackService extends ChangeNotifier {
   static const _kUserEmotesType = 'im.ponies.user_emotes';
   static const _kRoomEmotesType = 'im.ponies.room_emotes';
   static const _kSubscriptionsType = 'kohera.sticker_pack_subscriptions';
+  static const _kImportedPacksType = 'kohera.imported_packs';
 
   final Client _client;
   StreamSubscription<SyncUpdate>? _sub;
 
   @override
   void dispose() {
-    unawaited(_sub?.cancel());
+    unawaited(_sub?.cancel() ?? Future.value());
     super.dispose();
   }
 
-  /// The user's personal pack plus all subscribed room packs.
+  // ── Account packs ────────────────────────────────────────────
+
+  /// Personal pack + imported emoji.gg packs + subscribed room packs.
   List<StickerPack> get accountPacks {
     final packs = <StickerPack>[];
 
@@ -42,6 +58,8 @@ class StickerPackService extends ChangeNotifier {
       if (pack != null) packs.add(pack);
     }
 
+    packs.addAll(importedPacks);
+
     for (final roomId in _subscribedRoomIds) {
       final room = _client.getRoomById(roomId);
       if (room == null) continue;
@@ -51,6 +69,70 @@ class StickerPackService extends ChangeNotifier {
 
     return packs;
   }
+
+  /// Packs imported from emoji.gg, stored in account data.
+  List<StickerPack> get importedPacks {
+    final content = _client.accountData[_kImportedPacksType]?.content;
+    if (content == null) return [];
+
+    final rawPacks =
+        (content['packs'] as List?)?.cast<Map<String, Object?>>() ?? [];
+    final packs = <StickerPack>[];
+
+    for (final raw in rawPacks) {
+      final id = raw['id'] as String?;
+      final displayName = raw['display_name'] as String?;
+      final rawImages = raw['images'] as Map<String, Object?>?;
+
+      if (id == null || displayName == null || rawImages == null) continue;
+
+      final stickers = <PackImage>[];
+
+      for (final entry in rawImages.entries) {
+        final imageData = entry.value as Map<String, Object?>?;
+        if (imageData == null) continue;
+
+        final urlStr = imageData['url'] as String?;
+        if (urlStr == null) continue;
+        final url = Uri.tryParse(urlStr);
+        if (url == null) continue;
+
+        stickers.add(PackImage(
+          shortcode: entry.key,
+          url: url,
+          body: imageData['body'] as String?,
+          isSticker: true,
+          isEmoji: true,
+        ),);
+      }
+
+      if (stickers.isEmpty) continue;
+
+      packs.add(StickerPack(
+        id: id,
+        displayName: displayName,
+        stickers: stickers,
+        emoji: stickers,
+      ),);
+    }
+
+    return packs;
+  }
+
+  /// Slugs of emoji.gg packs already imported by the user.
+  Set<String> get importedEmojiGgSlugs {
+    final content = _client.accountData[_kImportedPacksType]?.content;
+    if (content == null) return {};
+
+    final rawPacks =
+        (content['packs'] as List?)?.cast<Map<String, Object?>>() ?? [];
+    return rawPacks
+        .map((p) => p['source_slug'] as String?)
+        .whereType<String>()
+        .toSet();
+  }
+
+  // ── Room packs ───────────────────────────────────────────────
 
   /// All packs visible in a room context: account packs + room pack + space packs.
   List<StickerPack> packsForRoom(Room room) {
@@ -76,7 +158,7 @@ class StickerPackService extends ChangeNotifier {
     return packs;
   }
 
-  /// Room/space packs from joined rooms that are not yet subscribed at account level.
+  /// Room/space packs from joined rooms not yet subscribed at account level.
   List<StickerPack> availableRoomPacks() {
     final subscribedIds = {_kUserEmotesType, ..._subscribedRoomIds};
     final packs = <StickerPack>[];
@@ -87,6 +169,8 @@ class StickerPackService extends ChangeNotifier {
     }
     return packs;
   }
+
+  // ── Subscriptions ─────────────────────────────────────────────
 
   Future<void> subscribeToRoomPack(String roomId) async {
     final ids = [..._subscribedRoomIds];
@@ -101,6 +185,59 @@ class StickerPackService extends ChangeNotifier {
 
   Future<void> reorderSubscriptions(List<String> orderedIds) async {
     await _writeSubscriptions(orderedIds);
+  }
+
+  // ── Emoji.gg import ───────────────────────────────────────────
+
+  /// Downloads each emoji from [pack] via [emojiGgService], uploads them to
+  /// the user's homeserver, and saves the pack to account data.
+  ///
+  /// Yields [ImportProgress] after each image. The final event has
+  /// [ImportProgress.isComplete] == true.
+  Stream<ImportProgress> importEmojiGgPack(
+    EmojiGgPack pack,
+    EmojiGgService emojiGgService,
+  ) async* {
+    final emojis = pack.emojis;
+    final total = emojis.length;
+    final images = <String, Object?>{};
+    var done = 0;
+
+    for (final emoji in emojis) {
+      try {
+        final bytes = await emojiGgService.downloadImage(emoji.imageUrl);
+        final mxcUri = await _client.uploadContent(
+          bytes,
+          filename: '${emoji.slug}.png',
+          contentType: 'image/png',
+        );
+        images[emoji.shortcode] = {
+          'url': mxcUri.toString(),
+          'body': emoji.title,
+        };
+      } catch (e) {
+        debugPrint('[Kohera] Failed to import ${emoji.slug}: $e');
+      }
+      done++;
+      yield ImportProgress(done: done, total: total);
+    }
+
+    if (images.isNotEmpty) {
+      await _writeImportedPack(pack, images);
+    }
+  }
+
+  Future<void> removeImportedPack(String packId) async {
+    final content =
+        _client.accountData[_kImportedPacksType]?.content ?? {};
+    final rawPacks =
+        (content['packs'] as List?)?.cast<Map<String, Object?>>() ?? [];
+    final updated = rawPacks.where((p) => p['id'] != packId).toList();
+    await _client.setAccountData(
+      _client.userID!,
+      _kImportedPacksType,
+      {'packs': updated},
+    );
   }
 
   // ── Private helpers ──────────────────────────────────────────
@@ -122,6 +259,35 @@ class StickerPackService extends ChangeNotifier {
       _client.userID!,
       _kSubscriptionsType,
       {'room_ids': roomIds},
+    );
+  }
+
+  Future<void> _writeImportedPack(
+    EmojiGgPack pack,
+    Map<String, Object?> images,
+  ) async {
+    final content =
+        _client.accountData[_kImportedPacksType]?.content ?? {};
+    final rawPacks =
+        (content['packs'] as List?)?.cast<Map<String, Object?>>() ?? [];
+
+    // Replace existing entry for the same source pack, if any.
+    final updated = rawPacks
+        .where((p) => p['source_id'] != pack.id)
+        .toList()
+      ..add({
+        'id': 'emojigg_${pack.id}',
+        'display_name': pack.name,
+        'source': 'emojigg',
+        'source_id': pack.id,
+        'source_slug': pack.slug,
+        'images': images,
+      });
+
+    await _client.setAccountData(
+      _client.userID!,
+      _kImportedPacksType,
+      {'packs': updated},
     );
   }
 }

--- a/lib/features/chat/widgets/sticker_picker_overlay.dart
+++ b/lib/features/chat/widgets/sticker_picker_overlay.dart
@@ -111,31 +111,43 @@ class _StickerPickerOverlayState extends State<StickerPickerOverlay>
       children: [
         _buildSearchField(cs),
         if (_query.isEmpty) ...[
-          TabBar(
-            controller: _tabController,
-            isScrollable: true,
-            tabAlignment: TabAlignment.start,
-            tabs: [
-              for (final pack in widget.packs)
-                Tab(
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      if (pack.avatarUrl != null) ...[
-                        MxcImage(
-                          mxcUrl: pack.avatarUrl!.toString(),
-                          client: widget.client,
-                          width: 18,
-                          height: 18,
-                          fallbackText: '',
-                          fallbackStyle: null,
+          Row(
+            children: [
+              Expanded(
+                child: TabBar(
+                  controller: _tabController,
+                  isScrollable: true,
+                  tabAlignment: TabAlignment.start,
+                  tabs: [
+                    for (final pack in widget.packs)
+                      Tab(
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            if (pack.avatarUrl != null) ...[
+                              MxcImage(
+                                mxcUrl: pack.avatarUrl!.toString(),
+                                client: widget.client,
+                                width: 18,
+                                height: 18,
+                                fallbackText: '',
+                                fallbackStyle: null,
+                              ),
+                              const SizedBox(width: 6),
+                            ],
+                            Text(pack.displayName),
+                          ],
                         ),
-                        const SizedBox(width: 6),
-                      ],
-                      Text(pack.displayName),
-                    ],
-                  ),
+                      ),
+                  ],
                 ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.add_rounded),
+                iconSize: 20,
+                tooltip: 'Manage packs',
+                onPressed: widget.onManagePacks,
+              ),
             ],
           ),
           Expanded(

--- a/lib/features/home/widgets/wide_layout.dart
+++ b/lib/features/home/widgets/wide_layout.dart
@@ -125,6 +125,7 @@ class _WideLayoutState extends State<WideLayout> {
         name == Routes.settingsVoiceVideo ||
         name == Routes.settingsRecoveryKey ||
         name == Routes.settingsStickerPacks ||
+        name == Routes.settingsEmojiGgBrowse ||
         name == Routes.spaces ||
         name == Routes.spaceDetails ||
         name == Routes.inbox ||

--- a/lib/features/settings/screens/emoji_gg_browse_screen.dart
+++ b/lib/features/settings/screens/emoji_gg_browse_screen.dart
@@ -1,0 +1,376 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:kohera/core/models/emoji_gg_pack.dart';
+import 'package:kohera/core/routing/nav_helper.dart';
+import 'package:kohera/core/routing/route_names.dart';
+import 'package:kohera/core/services/emoji_gg_service.dart';
+import 'package:kohera/core/services/sticker_pack_service.dart';
+import 'package:provider/provider.dart';
+
+class EmojiGgBrowseScreen extends StatefulWidget {
+  const EmojiGgBrowseScreen({super.key});
+
+  @override
+  State<EmojiGgBrowseScreen> createState() => _EmojiGgBrowseScreenState();
+}
+
+class _EmojiGgBrowseScreenState extends State<EmojiGgBrowseScreen> {
+  final _emojiGgService = EmojiGgService();
+  final _searchCtrl = TextEditingController();
+
+  List<EmojiGgPack>? _packs;
+  String _query = '';
+  bool _loadError = false;
+
+  // slug → 0.0–1.0 while importing; absent when idle or done
+  final Map<String, double> _importing = {};
+  Set<String> _importedSlugs = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _searchCtrl.addListener(
+      () => setState(() => _query = _searchCtrl.text.trim().toLowerCase()),
+    );
+    unawaited(_loadPacks());
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _importedSlugs =
+        context.read<StickerPackService>().importedEmojiGgSlugs;
+  }
+
+  @override
+  void dispose() {
+    _emojiGgService.dispose();
+    _searchCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadPacks({bool forceRefresh = false}) async {
+    setState(() {
+      _packs = null;
+      _loadError = false;
+    });
+    try {
+      final packs =
+          await _emojiGgService.fetchPacks(forceRefresh: forceRefresh);
+      if (mounted) setState(() => _packs = packs);
+    } catch (_) {
+      if (mounted) setState(() => _loadError = true);
+    }
+  }
+
+  Future<void> _importPack(EmojiGgPack pack) async {
+    if (pack.emojiSlugs.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Pack details not available — try again later')),
+      );
+      return;
+    }
+
+    setState(() => _importing[pack.slug] = 0.0);
+
+    final service = context.read<StickerPackService>();
+    var succeeded = 0;
+
+    await for (final progress
+        in service.importEmojiGgPack(pack, _emojiGgService)) {
+      if (!mounted) return;
+      setState(() => _importing[pack.slug] = progress.fraction);
+      if (progress.isComplete) succeeded = progress.done;
+    }
+
+    if (!mounted) return;
+    setState(() {
+      _importing.remove(pack.slug);
+      _importedSlugs = service.importedEmojiGgSlugs;
+    });
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          succeeded == 0
+              ? 'Import failed — no images could be uploaded'
+              : 'Imported $succeeded sticker${succeeded == 1 ? '' : 's'} from ${pack.name}',
+        ),
+      ),
+    );
+  }
+
+  List<EmojiGgPack> get _filtered {
+    final all = _packs ?? [];
+    if (_query.isEmpty) return all;
+    return all.where((p) {
+      return p.name.toLowerCase().contains(_query) ||
+          p.description.toLowerCase().contains(_query) ||
+          (p.category?.toLowerCase().contains(_query) ?? false);
+    }).toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.popOrGo(Routes.settingsStickerPacks),
+        ),
+        title: const Text('Browse emoji.gg'),
+        actions: [
+          if (_packs != null)
+            IconButton(
+              icon: const Icon(Icons.refresh),
+              tooltip: 'Refresh',
+              onPressed: () => _loadPacks(forceRefresh: true),
+            ),
+        ],
+      ),
+      body: Column(
+        children: [
+          _buildSearchField(cs),
+          Expanded(child: _buildBody(cs)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSearchField(ColorScheme cs) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+      child: TextField(
+        controller: _searchCtrl,
+        decoration: InputDecoration(
+          hintText: 'Search packs…',
+          prefixIcon: const Icon(Icons.search, size: 20),
+          suffixIcon: _query.isNotEmpty
+              ? IconButton(
+                  icon: const Icon(Icons.clear, size: 18),
+                  onPressed: _searchCtrl.clear,
+                )
+              : null,
+          isDense: true,
+          contentPadding:
+              const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(20),
+            borderSide: BorderSide.none,
+          ),
+          filled: true,
+          fillColor: cs.surfaceContainerHighest.withValues(alpha: 0.5),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBody(ColorScheme cs) {
+    if (_packs == null && !_loadError) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_loadError) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.cloud_off_rounded, size: 48, color: cs.outlineVariant),
+            const SizedBox(height: 12),
+            Text(
+              'Could not load packs',
+              style: TextStyle(color: cs.onSurfaceVariant),
+            ),
+            const SizedBox(height: 8),
+            TextButton(
+              onPressed: _loadPacks,
+              child: const Text('Try again'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final packs = _filtered;
+
+    if (packs.isEmpty) {
+      return Center(
+        child: Text(
+          'No packs found for "$_query"',
+          style: TextStyle(color: cs.onSurfaceVariant),
+        ),
+      );
+    }
+
+    return ListView.builder(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      itemCount: packs.length,
+      itemBuilder: (context, index) => _PackCard(
+        pack: packs[index],
+        isImported: _importedSlugs.contains(packs[index].slug),
+        importProgress: _importing[packs[index].slug],
+        onImport: () => _importPack(packs[index]),
+      ),
+    );
+  }
+}
+
+// ── Pack card ────────────────────────────────────────────────────
+
+class _PackCard extends StatelessWidget {
+  const _PackCard({
+    required this.pack,
+    required this.isImported,
+    required this.onImport,
+    this.importProgress,
+  });
+
+  final EmojiGgPack pack;
+  final bool isImported;
+  final double? importProgress; // null = idle
+  final VoidCallback onImport;
+
+  @override
+  Widget build(BuildContext context) {
+    final tt = Theme.of(context).textTheme;
+    final cs = Theme.of(context).colorScheme;
+    final isImporting = importProgress != null;
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 10),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Header row
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Preview thumbnail
+                _PackThumbnail(pack: pack),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(pack.name, style: tt.titleSmall),
+                      if (pack.category != null && pack.category!.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 2),
+                          child: Text(
+                            pack.category!,
+                            style: tt.labelSmall?.copyWith(
+                              color: cs.primary,
+                            ),
+                          ),
+                        ),
+                      Padding(
+                        padding: const EdgeInsets.only(top: 2),
+                        child: Text(
+                          '${pack.amount} emoji',
+                          style: tt.bodySmall?.copyWith(
+                            color: cs.onSurfaceVariant,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                // Action
+                if (isImported)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Icon(
+                      Icons.check_circle_rounded,
+                      color: cs.primary,
+                      size: 20,
+                    ),
+                  )
+                else if (isImporting)
+                  SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(
+                      value: importProgress,
+                      strokeWidth: 2,
+                    ),
+                  )
+                else
+                  TextButton(
+                    onPressed: pack.emojiSlugs.isEmpty ? null : onImport,
+                    style: TextButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                      minimumSize: Size.zero,
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                    child: const Text('Import'),
+                  ),
+              ],
+            ),
+            // Description
+            if (pack.description.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text(
+                pack.description,
+                style: tt.bodySmall?.copyWith(color: cs.onSurfaceVariant),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+            // Progress bar
+            if (isImporting) ...[
+              const SizedBox(height: 8),
+              LinearProgressIndicator(value: importProgress),
+              const SizedBox(height: 2),
+              Text(
+                'Uploading… ${((importProgress ?? 0) * 100).toInt()}%',
+                style: tt.labelSmall?.copyWith(color: cs.onSurfaceVariant),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Pack thumbnail — first emoji in the pack ─────────────────────
+
+class _PackThumbnail extends StatelessWidget {
+  const _PackThumbnail({required this.pack});
+  final EmojiGgPack pack;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final firstSlug = pack.emojiSlugs.isNotEmpty ? pack.emojiSlugs.first : null;
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(8),
+      child: Container(
+        width: 48,
+        height: 48,
+        color: cs.secondaryContainer,
+        child: firstSlug != null
+            ? Image.network(
+                'https://cdn3.emoji.gg/emojis/$firstSlug.png',
+                width: 48,
+                height: 48,
+                fit: BoxFit.contain,
+                errorBuilder: (_, __, ___) => Icon(
+                  Icons.emoji_emotions_outlined,
+                  color: cs.onSecondaryContainer,
+                ),
+              )
+            : Icon(
+                Icons.emoji_emotions_outlined,
+                color: cs.onSecondaryContainer,
+              ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/screens/emoji_gg_browse_screen.dart
+++ b/lib/features/settings/screens/emoji_gg_browse_screen.dart
@@ -321,6 +321,11 @@ class _PackCard extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
               ),
             ],
+            // Emoji preview strip
+            if (pack.emojiSlugs.length > 1) ...[
+              const SizedBox(height: 10),
+              _EmojiPreviewStrip(slugs: pack.emojiSlugs),
+            ],
             // Progress bar
             if (isImporting) ...[
               const SizedBox(height: 8),
@@ -332,6 +337,50 @@ class _PackCard extends StatelessWidget {
               ),
             ],
           ],
+        ),
+      ),
+    );
+  }
+}
+
+// ── Scrollable preview strip ─────────────────────────────────────
+
+class _EmojiPreviewStrip extends StatelessWidget {
+  const _EmojiPreviewStrip({required this.slugs});
+  final List<String> slugs;
+
+  static const _maxPreview = 12;
+  static const _size = 40.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final preview = slugs.take(_maxPreview).toList();
+    final cs = Theme.of(context).colorScheme;
+
+    return SizedBox(
+      height: _size,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        itemCount: preview.length,
+        separatorBuilder: (_, __) => const SizedBox(width: 4),
+        itemBuilder: (context, i) => ClipRRect(
+          borderRadius: BorderRadius.circular(6),
+          child: Image.network(
+            'https://cdn3.emoji.gg/emojis/${preview[i]}.png',
+            width: _size,
+            height: _size,
+            fit: BoxFit.contain,
+            errorBuilder: (_, __, ___) => Container(
+              width: _size,
+              height: _size,
+              color: cs.surfaceContainerHighest,
+              child: Icon(
+                Icons.broken_image_outlined,
+                size: 20,
+                color: cs.outlineVariant,
+              ),
+            ),
+          ),
         ),
       ),
     );

--- a/lib/features/settings/screens/sticker_packs_screen.dart
+++ b/lib/features/settings/screens/sticker_packs_screen.dart
@@ -35,8 +35,14 @@ class StickerPacksScreen extends StatelessWidget {
           final personalPack = accountPacks
               .where((p) => p.id == _kPersonalPackId)
               .firstOrNull;
+          final importedPacks = accountPacks
+              .where((p) => p.id.startsWith('emojigg_'))
+              .toList();
           final subscribedPacks = accountPacks
-              .where((p) => p.id != _kPersonalPackId)
+              .where(
+                (p) =>
+                    p.id != _kPersonalPackId && !p.id.startsWith('emojigg_'),
+              )
               .toList();
 
           return ListView(
@@ -79,16 +85,30 @@ class StickerPacksScreen extends StatelessWidget {
                             ),
                           ),
                         ),
-                        if (subscribedPacks.isNotEmpty)
-                          const Divider(height: 1, indent: 56),
                       ],
-                      if (subscribedPacks.isNotEmpty)
+                      for (var i = 0; i < importedPacks.length; i++) ...[
+                        const Divider(height: 1, indent: 56),
+                        _PackTile(
+                          pack: importedPacks[i],
+                          client: client,
+                          trailing: _RemoveButton(
+                            onTap: () => service.removeImportedPack(
+                              importedPacks[i].id,
+                            ),
+                          ),
+                        ),
+                      ],
+                      if (subscribedPacks.isNotEmpty) ...[
+                        if (personalPack != null || importedPacks.isNotEmpty)
+                          const Divider(height: 1, indent: 56),
                         _ReorderablePackList(
                           packs: subscribedPacks,
                           client: client,
                           service: service,
-                          personalPackPresent: personalPack != null,
+                          hasLeadingPack:
+                              personalPack != null || importedPacks.isNotEmpty,
                         ),
+                      ],
                     ],
                   ),
                 ),
@@ -125,6 +145,23 @@ class StickerPacksScreen extends StatelessWidget {
                   ),
                 ),
 
+              const SizedBox(height: 24),
+
+              // ── Browse online ─────────────────────────────────
+              const _SectionLabel(label: 'BROWSE ONLINE'),
+              Card(
+                child: ListTile(
+                  leading: const Icon(Icons.explore_outlined),
+                  title: const Text('Browse emoji.gg packs'),
+                  subtitle: const Text(
+                    'Import sticker packs from the emoji.gg library',
+                  ),
+                  trailing: const Icon(Icons.chevron_right),
+                  onTap: () =>
+                      context.pushOrGo(Routes.settingsEmojiGgBrowse),
+                ),
+              ),
+
               const SizedBox(height: 32),
             ],
           );
@@ -141,13 +178,13 @@ class _ReorderablePackList extends StatelessWidget {
     required this.packs,
     required this.client,
     required this.service,
-    required this.personalPackPresent,
+    required this.hasLeadingPack,
   });
 
   final List<StickerPack> packs;
   final Client client;
   final StickerPackService service;
-  final bool personalPackPresent;
+  final bool hasLeadingPack;
 
   @override
   Widget build(BuildContext context) {
@@ -168,7 +205,7 @@ class _ReorderablePackList extends StatelessWidget {
           key: ValueKey(pack.id),
           mainAxisSize: MainAxisSize.min,
           children: [
-            if (index > 0 || personalPackPresent)
+            if (index > 0 || hasLeadingPack)
               const Divider(height: 1, indent: 56),
             _PackTile(
               pack: pack,


### PR DESCRIPTION
## Summary

- Adds an **emoji.gg** API client (`EmojiGgService`) with 24-hour memory + disk caching
- Adds `EmojiGgPack` / `EmojiGgEmoji` models that parse the emoji.gg `/api/packs` response
- Extends `StickerPackService` with `importEmojiGgPack()` (streaming progress), `importedPacks`, `removeImportedPack()`, and `importedEmojiGgSlugs`; imported packs are stored under `kohera.imported_packs` account data — separate from MSC2545 subscriptions
- New **Browse emoji.gg** screen: searchable pack list, scrollable 12-emoji thumbnail preview strip per card, per-pack import progress bar, already-imported state
- **StickerPacksScreen** gains an imported-packs section in MY PACKS (removable) and a BROWSE ONLINE tile
- Sticker picker: `+` icon button in the tab bar keeps manage-packs reachable even after packs are added
- Imported packs are sticker-only (`isEmoji: false`) so they never leak into the emoji autocomplete or send as text

## Test plan

- [x] Browse emoji.gg screen loads and filters packs via search
- [ ] Import a pack — progress bar advances, snackbar confirms count
- [ ] Imported pack appears in MY PACKS with a remove button
- [ ] Imported pack appears in the sticker picker under Stickers (not Emoji)
- [ ] Tapping a sticker sends an `m.sticker` event (renders as image, not text)
- [ ] Remove imported pack from MY PACKS — disappears from picker
- [ ] `+` button in sticker picker tab bar opens pack management
- [ ] Pack list is cached; refresh button forces a new fetch
- [ ] Handles emoji.gg being unreachable gracefully (error state + retry)

## Notes

- Base branch is `feat/151-sticker-pack-settings` (depends on #529); will retarget to master once #529 merges
- Shortcode derivation strips numeric prefixes for both `_` and `-` separators (`664414-name` → `name`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)