### PR TITLE
fix(#535): replace permission-gated clipboard.read() with DOM paste event on web

### DIFF
--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart'
     show TargetPlatform, defaultTargetPlatform, kIsWeb;
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show Clipboard;
 import 'package:giphy_get/giphy_get.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kohera/core/models/pending_attachment.dart';
@@ -38,6 +37,7 @@ import 'package:kohera/features/chat/widgets/photo_send_handler.dart';
 import 'package:kohera/features/chat/widgets/search_results_body.dart';
 import 'package:kohera/features/chat/widgets/sticker_picker_overlay.dart';
 import 'package:kohera/features/chat/widgets/typing_indicator.dart';
+import 'package:kohera/features/chat/widgets/web_image_paste.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 
@@ -97,6 +97,9 @@ class _ChatScreenState extends State<ChatScreen>
   // ── Sticker picker ─────────────────────────────────────
   bool _showStickerPicker = false;
 
+  // ── Web paste ───────────────────────────────────────────
+  StreamSubscription<ClipboardImageData>? _webPasteSub;
+
   // ── Search ─────────────────────────────────────────────
   late ChatSearchController _search;
   final _searchCtrl = TextEditingController();
@@ -108,6 +111,10 @@ class _ChatScreenState extends State<ChatScreen>
     _actions = _createActions();
     _search = _createSearchController();
     _initControllers();
+    if (kIsWeb) {
+      initWebPasteListener();
+      _webPasteSub = webPasteImageStream.listen(_onWebPasteImage);
+    }
   }
 
   @override
@@ -271,13 +278,18 @@ class _ChatScreenState extends State<ChatScreen>
   }
 
   Future<void> _handlePasteImage() async {
-    if (kIsWeb) {
-      // On web, Clipboard.getData(kTextPlain) never triggers a permission popup.
-      // If text is present we let Flutter handle it as a normal text paste and bail.
-      if (clipboardHasText(await Clipboard.getData(Clipboard.kTextPlain))) return;
-    }
     final result = await _compose.handlePasteImage();
     if (mounted && result != null) _showAttachmentError(result);
+  }
+
+  void _onWebPasteImage(ClipboardImageData data) {
+    if (!mounted || !_composeFocusNode.hasFocus) return;
+    final name = generatePasteFilename(data.mimeType);
+    _showAttachmentError(
+      _compose.addAttachment(
+        PendingAttachment.fromBytes(bytes: data.bytes, name: name),
+      ),
+    );
   }
 
   void _showAttachmentError(AddAttachmentResult result) {
@@ -363,6 +375,7 @@ class _ChatScreenState extends State<ChatScreen>
 
   @override
   void dispose() {
+    unawaited(_webPasteSub?.cancel() ?? Future.value());
     _msgCtrl.dispose();
     _compose.dispose();
     _searchCtrl.dispose();
@@ -515,7 +528,7 @@ class _ChatScreenState extends State<ChatScreen>
                   );
                 }
               : null,
-          onPasteImage: (_isDesktop || kIsWeb) ? _handlePasteImage : null,
+          onPasteImage: _isDesktop ? _handlePasteImage : null,
           uploadNotifier: _compose.uploadNotifier,
           room: room,
           joinedRooms: context.read<SelectionService>().rooms,

--- a/lib/features/chat/widgets/web_image_paste.dart
+++ b/lib/features/chat/widgets/web_image_paste.dart
@@ -1,0 +1,2 @@
+export 'web_image_paste_native.dart'
+    if (dart.library.js_interop) 'web_image_paste_web.dart';

--- a/lib/features/chat/widgets/web_image_paste_native.dart
+++ b/lib/features/chat/widgets/web_image_paste_native.dart
@@ -1,0 +1,7 @@
+import 'dart:async';
+
+import 'package:kohera/features/chat/widgets/paste_image_handler.dart';
+
+Stream<ClipboardImageData> get webPasteImageStream => const Stream.empty();
+
+void initWebPasteListener() {}

--- a/lib/features/chat/widgets/web_image_paste_web.dart
+++ b/lib/features/chat/widgets/web_image_paste_web.dart
@@ -1,0 +1,49 @@
+import 'dart:async';
+import 'dart:js_interop';
+
+import 'package:kohera/features/chat/widgets/paste_image_handler.dart';
+import 'package:web/web.dart';
+
+final _controller = StreamController<ClipboardImageData>.broadcast();
+
+Stream<ClipboardImageData> get webPasteImageStream => _controller.stream;
+
+bool _initialized = false;
+
+void initWebPasteListener() {
+  if (_initialized) return;
+  _initialized = true;
+  document.addEventListener(
+    'paste',
+    (JSAny? event) {
+      if (event == null) return;
+      _handlePaste(event as ClipboardEvent);
+    }.toJS,
+  );
+}
+
+void _handlePaste(ClipboardEvent event) {
+  final items = event.clipboardData?.items;
+  if (items == null) return;
+
+  for (var i = 0; i < items.length; i++) {
+    final item = items[i];
+    if (item.kind != 'file') continue;
+    if (!item.type.startsWith('image/')) continue;
+
+    final file = item.getAsFile();
+    if (file == null) continue;
+
+    final mimeType = item.type;
+    unawaited(file.arrayBuffer().toDart.then((buffer) {
+      _controller.add(ClipboardImageData(
+        bytes: buffer.toDart.asUint8List(),
+        mimeType: mimeType,
+      ),);
+    }),);
+
+    // Prevent the browser from trying to handle the image paste itself.
+    event.preventDefault();
+    return;
+  }
+}


### PR DESCRIPTION
## Summary

- Replaces `Pasteboard.image` (which calls `navigator.clipboard.read()`) with a DOM `paste` event listener on `document`
- `ClipboardEvent.clipboardData.items` provides image bytes with **no browser permission prompt**, and works in all browsers including Firefox
- Native desktop paste (Windows/macOS/Linux) is unchanged — still goes through `Pasteboard.image` via the existing `onPasteImage` callback
- Removes the `Clipboard.getData` text-heuristic workaround that was added as a band-aid in `9978058`

## How it works

Three new files handle the platform split via conditional export:
- `web_image_paste.dart` — conditional export selector
- `web_image_paste_native.dart` — no-op stub for native targets
- `web_image_paste_web.dart` — registers a `document.addEventListener('paste', ...)` listener; when an image item is found in `clipboardData.items`, reads the bytes via `File.arrayBuffer()` and emits to a broadcast stream

`ChatScreen` subscribes to the stream in `initState` (web only) and calls `_onWebPasteImage` which adds the attachment to the compose state, guarded by `_composeFocusNode.hasFocus` so only the focused chat handles the event.

## Test plan

- [x] Copied an image and pasted with Ctrl+V on the deployed dev web app — image appeared in attachment preview with no permission popup
- [x] Text paste still inserts text normally (no image interception)
- [x] `dart analyze` — no issues

Closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)