### PR TITLE
fix: only ring iOS push calls for 1:1 rooms

### DIFF
--- a/lib/features/notifications/services/call_push_rule_manager.dart
+++ b/lib/features/notifications/services/call_push_rule_manager.dart
@@ -5,9 +5,11 @@ import 'package:kohera/features/calling/services/rtc_membership_service.dart'
 import 'package:matrix/matrix.dart';
 
 // Ensures the homeserver notifies Kohera's VoIP pusher on inbound
-// m.call.member state events. Rule is written (or repaired) per-account on
-// login and on sync reconnect so it works on any homeserver without admin
-// config changes.
+// m.call.member state events for 1:1 rooms only. The room_member_count
+// condition restricts pushes to two-member (direct) rooms so that joins to
+// group calls never ring. Rule is written (or repaired) per-account on login
+// and on sync reconnect so it works on any homeserver without admin config
+// changes.
 
 class CallPushRuleManager {
   CallPushRuleManager({required Client client}) : _client = client;
@@ -22,7 +24,9 @@ class CallPushRuleManager {
           ?.where((r) => r.ruleId == kPushRuleCallMember)
           .firstOrNull;
 
-      if (existing != null && _actionsMatch(existing.actions)) {
+      if (existing != null &&
+          _actionsMatch(existing.actions) &&
+          _conditionsMatch(existing.conditions)) {
         return;
       }
 
@@ -30,13 +34,7 @@ class CallPushRuleManager {
         PushRuleKind.override,
         kPushRuleCallMember,
         _desiredActions(),
-        conditions: [
-          PushCondition(
-            kind: 'event_match',
-            key: 'type',
-            pattern: callMemberEventType,
-          ),
-        ],
+        conditions: _desiredConditions(),
       );
       debugPrint('[Kohera] Installed $kPushRuleCallMember push rule');
     } catch (e) {
@@ -44,11 +42,36 @@ class CallPushRuleManager {
     }
   }
 
+  List<PushCondition> _desiredConditions() => [
+        PushCondition(
+          kind: 'event_match',
+          key: 'type',
+          pattern: callMemberEventType,
+        ),
+        PushCondition(kind: 'room_member_count', is_: '2'),
+      ];
+
   List<Object?> _desiredActions() => [
         'notify',
         {'set_tweak': 'sound', 'value': 'ring'},
         {'set_tweak': 'highlight', 'value': false},
       ];
+
+  bool _conditionsMatch(List<PushCondition>? conditions) {
+    final desired = _desiredConditions();
+    if (conditions == null || conditions.length != desired.length) return false;
+    for (var i = 0; i < desired.length; i++) {
+      final a = conditions[i];
+      final b = desired[i];
+      if (a.kind != b.kind ||
+          a.key != b.key ||
+          a.pattern != b.pattern ||
+          a.is_ != b.is_) {
+        return false;
+      }
+    }
+    return true;
+  }
 
   bool _actionsMatch(List<Object?> actions) {
     if (actions.length != 3) return false;

--- a/lib/features/notifications/services/call_push_rule_manager.dart
+++ b/lib/features/notifications/services/call_push_rule_manager.dart
@@ -48,7 +48,7 @@ class CallPushRuleManager {
           key: 'type',
           pattern: callMemberEventType,
         ),
-        PushCondition(kind: 'room_member_count', is_: '2'),
+        PushCondition(kind: 'room_member_count', is$: '2'),
       ];
 
   List<Object?> _desiredActions() => [
@@ -66,7 +66,7 @@ class CallPushRuleManager {
       if (a.kind != b.kind ||
           a.key != b.key ||
           a.pattern != b.pattern ||
-          a.is_ != b.is_) {
+          a.is$ != b.is$) {
         return false;
       }
     }

--- a/lib/features/notifications/services/ios_voip_push_service.dart
+++ b/lib/features/notifications/services/ios_voip_push_service.dart
@@ -137,7 +137,7 @@ class IosVoipPushService {
         return;
       }
 
-      _maybeEndCallIfCallerGone(roomId);
+      _maybeEndRingAfterSync(roomId);
     } catch (e) {
       debugPrint('[Kohera] VoIP push message processing error: $e');
     }
@@ -220,11 +220,23 @@ class IosVoipPushService {
     debugPrint('[Kohera] VoIP pusher unregistered from homeserver');
   }
 
-  // ── Cancel check (caller removed m.call.member before answer) ───
+  // ── Cancel checks (run after the post-push sync) ───
+  // Only 1:1 calls should ring. iOS requires every VoIP push to present a
+  // CallKit ring immediately, so a group-call push (e.g. from a homeserver
+  // whose push rule predates the room_member_count restriction) is dismissed
+  // here once room state is known. Also cancels if the caller removed their
+  // m.call.member membership before we answered.
 
-  void _maybeEndCallIfCallerGone(String roomId) {
+  void _maybeEndRingAfterSync(String roomId) {
     if (_disposed) return;
     if (callService.callState != KoheraCallState.ringingIncoming) return;
+
+    final room = matrixService.client.getRoomById(roomId);
+    if (room != null && !room.isDirectChat) {
+      debugPrint('[Kohera] VoIP post-sync: not a 1:1 room, ending CallKit ring');
+      callService.endCallFromPushKit();
+      return;
+    }
 
     final stillRinging = RtcMembershipService.roomHasRemoteActiveCall(
       matrixService.client,

--- a/test/services/call_push_rule_manager_test.dart
+++ b/test/services/call_push_rule_manager_test.dart
@@ -27,6 +27,7 @@ void main() {
             key: 'type',
             pattern: 'org.matrix.msc3401.call.member',
           ),
+          PushCondition(kind: 'room_member_count', is_: '2'),
         ],
         actions: [
           'notify',
@@ -35,7 +36,7 @@ void main() {
         ],
       );
 
-  test('writes rule when missing', () async {
+  test('writes rule restricted to 1:1 rooms when missing', () async {
     when(mockClient.getPushRules())
         .thenAnswer((_) async => PushRuleSet(override: []));
     when(
@@ -52,14 +53,27 @@ void main() {
 
     await manager.ensureRule();
 
-    verify(
+    final captured = verify(
       mockClient.setPushRule(
         PushRuleKind.override,
         'io.kohera.call_member',
         any,
-        conditions: anyNamed('conditions'),
+        conditions: captureAnyNamed('conditions'),
       ),
-    ).called(1);
+    ).captured;
+    final conditions = captured.single as List<PushCondition>;
+    expect(
+      conditions.any(
+        (c) => c.kind == 'event_match' &&
+            c.key == 'type' &&
+            c.pattern == 'org.matrix.msc3401.call.member',
+      ),
+      isTrue,
+    );
+    expect(
+      conditions.any((c) => c.kind == 'room_member_count' && c.is_ == '2'),
+      isTrue,
+    );
   });
 
   test('no write when rule already present with matching actions', () async {
@@ -112,6 +126,56 @@ void main() {
         conditions: anyNamed('conditions'),
       ),
     ).called(1);
+  });
+
+  test('rewrites legacy rule that lacks the room_member_count condition',
+      () async {
+    final legacy = PushRule(
+      ruleId: 'io.kohera.call_member',
+      default$: false,
+      enabled: true,
+      conditions: [
+        PushCondition(
+          kind: 'event_match',
+          key: 'type',
+          pattern: 'org.matrix.msc3401.call.member',
+        ),
+      ],
+      actions: [
+        'notify',
+        {'set_tweak': 'sound', 'value': 'ring'},
+        {'set_tweak': 'highlight', 'value': false},
+      ],
+    );
+    when(mockClient.getPushRules())
+        .thenAnswer((_) async => PushRuleSet(override: [legacy]));
+    when(
+      mockClient.setPushRule(
+        any,
+        any,
+        any,
+        before: anyNamed('before'),
+        after: anyNamed('after'),
+        conditions: anyNamed('conditions'),
+        pattern: anyNamed('pattern'),
+      ),
+    ).thenAnswer((_) async {});
+
+    await manager.ensureRule();
+
+    final captured = verify(
+      mockClient.setPushRule(
+        PushRuleKind.override,
+        'io.kohera.call_member',
+        any,
+        conditions: captureAnyNamed('conditions'),
+      ),
+    ).captured;
+    final conditions = captured.single as List<PushCondition>;
+    expect(
+      conditions.any((c) => c.kind == 'room_member_count' && c.is_ == '2'),
+      isTrue,
+    );
   });
 
   test('no-op when userID missing', () async {

--- a/test/services/call_push_rule_manager_test.dart
+++ b/test/services/call_push_rule_manager_test.dart
@@ -27,7 +27,7 @@ void main() {
             key: 'type',
             pattern: 'org.matrix.msc3401.call.member',
           ),
-          PushCondition(kind: 'room_member_count', is_: '2'),
+          PushCondition(kind: 'room_member_count', is$: '2'),
         ],
         actions: [
           'notify',
@@ -71,7 +71,7 @@ void main() {
       isTrue,
     );
     expect(
-      conditions.any((c) => c.kind == 'room_member_count' && c.is_ == '2'),
+      conditions.any((c) => c.kind == 'room_member_count' && c.is$ == '2'),
       isTrue,
     );
   });
@@ -173,7 +173,7 @@ void main() {
     ).captured;
     final conditions = captured.single as List<PushCondition>;
     expect(
-      conditions.any((c) => c.kind == 'room_member_count' && c.is_ == '2'),
+      conditions.any((c) => c.kind == 'room_member_count' && c.is$ == '2'),
       isTrue,
     );
   });

--- a/test/services/ios_voip_push_service_test.dart
+++ b/test/services/ios_voip_push_service_test.dart
@@ -348,7 +348,23 @@ void main() {
       final mockRoom = MockRoom();
       when(mockClient.getRoomById('!room:example.com')).thenReturn(mockRoom);
       when(mockClient.userID).thenReturn('@alice:example.com');
+      when(mockRoom.isDirectChat).thenReturn(true);
       when(mockRoom.states).thenReturn({});
+      when(mockCallService.callState)
+          .thenReturn(KoheraCallState.ringingIncoming);
+
+      await service.onVoipMessage(validPayload());
+
+      verify(mockCallService.endCallFromPushKit()).called(1);
+    });
+
+    test('ends CallKit when post-sync shows room is not 1:1', () async {
+      when(mockClient.oneShotSync(timeout: anyNamed('timeout')))
+          .thenAnswer((_) async {});
+
+      final mockRoom = MockRoom();
+      when(mockClient.getRoomById('!room:example.com')).thenReturn(mockRoom);
+      when(mockRoom.isDirectChat).thenReturn(false);
       when(mockCallService.callState)
           .thenReturn(KoheraCallState.ringingIncoming);
 


### PR DESCRIPTION
## Problem

On iOS, users received a push/CallKit ring **every time someone joined a room voice call**, not just when a call started.

## Root cause

The homeserver override push rule `io.kohera.call_member` (`call_push_rule_manager.dart`) matched purely on event **type** — every `org.matrix.msc3401.call.member` state event, in any room, from any sender. In the MSC3401 model each participant who joins writes their own `m.call.member` state event (and renews it every ~5 min), so the homeserver pushed a VoIP ring on **every join and every renewal**. Nothing in the push path distinguished a new call from an additional participant joining.

## Fix — only 1:1 (direct) rooms ring

1. **`call_push_rule_manager.dart`** — added a `room_member_count == 2` condition so the homeserver only pushes for two-member (direct) rooms; group-call joins never ring. Also fixed `ensureRule`, which previously compared only *actions* — it now also checks *conditions*, so existing installs with the old single-condition rule get repaired on next login/sync reconnect.

2. **`ios_voip_push_service.dart`** — defense-in-depth. iOS requires every VoIP push to present CallKit immediately, so for any homeserver whose rule hasn't been repaired yet, the post-push sync now dismisses the ring when the room is not a 1:1 chat (`!room.isDirectChat`), alongside the existing caller-gone check (`_maybeEndCallIfCallerGone` → `_maybeEndRingAfterSync`).

## Tests

Updated `call_push_rule_manager_test.dart` and `ios_voip_push_service_test.dart`:
- rule is written with the `room_member_count` condition,
- a legacy rule lacking it gets rewritten,
- a non-1:1 room post-sync cancels the ring.

Uses existing generated mocks (no `build_runner` regeneration needed).

## Note on "1:1" mapping

"1:1" maps to a 2-member room: `room_member_count == 2` server-side (matching Matrix's standard `.m.rule.room_one_to_one`) and `isDirectChat` client-side (matching the app's in-call foreground logic).

https://claude.ai/code/session_01KQ3ifr1x3cg2JQL1jhVsE8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQ3ifr1x3cg2JQL1jhVsE8)_