### PR TITLE
feat(#539): responsive sticker/emoji picker grid layout

### DIFF
--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -94,8 +94,6 @@ class _ChatScreenState extends State<ChatScreen>
   String? _activeThreadEventId;
   bool _showThreadList = false;
 
-  // ── Sticker picker ─────────────────────────────────────
-  bool _showStickerPicker = false;
 
   // ── Web paste ───────────────────────────────────────────
   StreamSubscription<ClipboardImageData>? _webPasteSub;
@@ -330,11 +328,39 @@ class _ChatScreenState extends State<ChatScreen>
   // ── Sticker picker ────────────────────────────────────────
 
   void _toggleStickerPicker() {
-    setState(() => _showStickerPicker = !_showStickerPicker);
+    final matrix = context.read<MatrixService>();
+    final stickerService = context.read<StickerPackService>();
+    final room = matrix.client.getRoomById(widget.roomId);
+    if (room == null) return;
+    final sheetHeight = MediaQuery.sizeOf(context).height * 0.45;
+    unawaited(showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      useSafeArea: true,
+      builder: (sheetCtx) => SizedBox(
+        height: sheetHeight,
+        child: StickerPickerOverlay(
+          packs: stickerService.packsForRoom(room),
+          client: matrix.client,
+          onStickerTapped: (sticker) {
+            Navigator.of(sheetCtx).pop();
+            unawaited(_handleStickerSelected(sticker));
+          },
+          onEmojiTapped: (emoji) {
+            Navigator.of(sheetCtx).pop();
+            _handleEmojiSelected(emoji);
+          },
+          onManagePacks: () {
+            Navigator.of(sheetCtx).pop();
+            context.goNamed(Routes.settingsStickerPacks);
+          },
+        ),
+      ),
+    ),);
   }
 
   Future<void> _handleStickerSelected(PackImage sticker) async {
-    setState(() => _showStickerPicker = false);
     final room =
         context.read<MatrixService>().client.getRoomById(widget.roomId);
     if (room == null) return;
@@ -361,7 +387,6 @@ class _ChatScreenState extends State<ChatScreen>
   }
 
   void _handleEmojiSelected(PackImage emoji) {
-    setState(() => _showStickerPicker = false);
     final text = _msgCtrl.text;
     final sel = _msgCtrl.selection;
     final pos = sel.isValid ? sel.baseOffset : text.length;
@@ -485,35 +510,6 @@ class _ChatScreenState extends State<ChatScreen>
           myUserId: matrix.client.userID,
           syncStream: matrix.client.onSync.stream,
         ),
-        if (_showStickerPicker)
-          SizedBox(
-            height: 300,
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.surface,
-                border: Border(
-                  top: BorderSide(
-                    color: Theme.of(context)
-                        .colorScheme
-                        .outlineVariant
-                        .withValues(alpha: 0.3),
-                  ),
-                ),
-              ),
-              child: Consumer<StickerPackService>(
-                builder: (context, stickerService, _) => StickerPickerOverlay(
-                  packs: stickerService.packsForRoom(room),
-                  client: matrix.client,
-                  onStickerTapped: _handleStickerSelected,
-                  onEmojiTapped: _handleEmojiSelected,
-                  onManagePacks: () {
-                    setState(() => _showStickerPicker = false);
-                    context.goNamed(Routes.settingsStickerPacks);
-                  },
-                ),
-              ),
-            ),
-          ),
         ComposeBarSection(
           replyNotifier: _compose.replyNotifier,
           editNotifier: _compose.editNotifier,

--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -332,15 +332,16 @@ class _ChatScreenState extends State<ChatScreen>
     final stickerService = context.read<StickerPackService>();
     final room = matrix.client.getRoomById(widget.roomId);
     if (room == null) return;
-    final sheetHeight = MediaQuery.sizeOf(context).height * 0.45;
     unawaited(showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
-      showDragHandle: true,
       useSafeArea: true,
-      builder: (sheetCtx) => SizedBox(
-        height: sheetHeight,
-        child: StickerPickerOverlay(
+      builder: (sheetCtx) => DraggableScrollableSheet(
+        expand: false,
+        initialChildSize: 0.7,
+        minChildSize: 0.7,
+        maxChildSize: 0.9,
+        builder: (_, __) => StickerPickerOverlay(
           packs: stickerService.packsForRoom(room),
           client: matrix.client,
           onStickerTapped: (sticker) {

--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -486,16 +486,32 @@ class _ChatScreenState extends State<ChatScreen>
           syncStream: matrix.client.onSync.stream,
         ),
         if (_showStickerPicker)
-          Consumer<StickerPackService>(
-            builder: (context, stickerService, _) => StickerPickerOverlay(
-              packs: stickerService.packsForRoom(room),
-              client: matrix.client,
-              onStickerTapped: _handleStickerSelected,
-              onEmojiTapped: _handleEmojiSelected,
-              onManagePacks: () {
-                setState(() => _showStickerPicker = false);
-                context.goNamed(Routes.settingsStickerPacks);
-              },
+          SizedBox(
+            height: 300,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.surface,
+                border: Border(
+                  top: BorderSide(
+                    color: Theme.of(context)
+                        .colorScheme
+                        .outlineVariant
+                        .withValues(alpha: 0.3),
+                  ),
+                ),
+              ),
+              child: Consumer<StickerPackService>(
+                builder: (context, stickerService, _) => StickerPickerOverlay(
+                  packs: stickerService.packsForRoom(room),
+                  client: matrix.client,
+                  onStickerTapped: _handleStickerSelected,
+                  onEmojiTapped: _handleEmojiSelected,
+                  onManagePacks: () {
+                    setState(() => _showStickerPicker = false);
+                    context.goNamed(Routes.settingsStickerPacks);
+                  },
+                ),
+              ),
             ),
           ),
         ComposeBarSection(

--- a/lib/features/chat/widgets/sticker_picker_overlay.dart
+++ b/lib/features/chat/widgets/sticker_picker_overlay.dart
@@ -67,18 +67,7 @@ class _StickerPickerOverlayState extends State<StickerPickerOverlay>
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
-    return SizedBox(
-      height: 300,
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: cs.surface,
-          border: Border(
-            top: BorderSide(color: cs.outlineVariant.withValues(alpha: 0.3)),
-          ),
-        ),
-        child: widget.packs.isEmpty ? _buildEmptyState(cs) : _buildPicker(cs),
-      ),
-    );
+    return widget.packs.isEmpty ? _buildEmptyState(cs) : _buildPicker(cs);
   }
 
   Widget _buildEmptyState(ColorScheme cs) {
@@ -199,8 +188,9 @@ class _StickerPickerOverlayState extends State<StickerPickerOverlay>
           SliverToBoxAdapter(child: _sectionHeader('Stickers')),
           SliverGrid.builder(
             itemCount: pack.stickers.length,
-            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: 4,
+            gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+              maxCrossAxisExtent: 80,
+              mainAxisExtent: 80,
               mainAxisSpacing: 4,
               crossAxisSpacing: 4,
             ),
@@ -211,8 +201,9 @@ class _StickerPickerOverlayState extends State<StickerPickerOverlay>
           SliverToBoxAdapter(child: _sectionHeader('Emoji')),
           SliverGrid.builder(
             itemCount: pack.emoji.length,
-            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: 5,
+            gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+              maxCrossAxisExtent: 56,
+              mainAxisExtent: 56,
               mainAxisSpacing: 4,
               crossAxisSpacing: 4,
             ),
@@ -250,8 +241,9 @@ class _StickerPickerOverlayState extends State<StickerPickerOverlay>
           SliverToBoxAdapter(child: _sectionHeader('Stickers')),
           SliverGrid.builder(
             itemCount: matchingStickers.length,
-            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: 4,
+            gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+              maxCrossAxisExtent: 80,
+              mainAxisExtent: 80,
               mainAxisSpacing: 4,
               crossAxisSpacing: 4,
             ),
@@ -262,8 +254,9 @@ class _StickerPickerOverlayState extends State<StickerPickerOverlay>
           SliverToBoxAdapter(child: _sectionHeader('Emoji')),
           SliverGrid.builder(
             itemCount: matchingEmoji.length,
-            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: 5,
+            gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+              maxCrossAxisExtent: 56,
+              mainAxisExtent: 56,
               mainAxisSpacing: 4,
               crossAxisSpacing: 4,
             ),
@@ -298,6 +291,7 @@ class _StickerPickerOverlayState extends State<StickerPickerOverlay>
             client: widget.client,
             width: 64,
             height: 64,
+            fit: BoxFit.contain,
             fallbackText: sticker.altText,
             fallbackStyle: Theme.of(context).textTheme.bodySmall,
           ),
@@ -318,6 +312,7 @@ class _StickerPickerOverlayState extends State<StickerPickerOverlay>
             client: widget.client,
             width: 40,
             height: 40,
+            fit: BoxFit.contain,
             fallbackText: emoji.altText,
             fallbackStyle: Theme.of(context).textTheme.bodySmall,
           ),

--- a/lib/shared/widgets/mxc_image.dart
+++ b/lib/shared/widgets/mxc_image.dart
@@ -12,6 +12,7 @@ class MxcImage extends StatefulWidget {
     required this.fallbackStyle,
     this.width,
     this.height,
+    this.fit,
     super.key,
   });
 
@@ -19,6 +20,7 @@ class MxcImage extends StatefulWidget {
   final Client? client;
   final double? width;
   final double? height;
+  final BoxFit? fit;
   final String fallbackText;
   final TextStyle? fallbackStyle;
 
@@ -106,6 +108,7 @@ class _MxcImageState extends State<MxcImage> {
       _resolvedUrl!,
       width: widget.width,
       height: widget.height,
+      fit: widget.fit,
       headers: widget.client != null
           ? mediaAuthHeaders(widget.client!, _resolvedUrl!)
           : null,


### PR DESCRIPTION
## Summary

- Switches sticker/emoji grid delegates from \`SliverGridDelegateWithFixedCrossAxisCount\` to \`SliverGridDelegateWithMaxCrossAxisExtent\` (stickers: 80px, emoji: 56px) so the grid tiles adapt to available width instead of a hardcoded column count
- Adds optional \`BoxFit? fit\` to \`MxcImage\`; passes \`BoxFit.contain\` to sticker and emoji items to prevent image cropping within grid cells
- Moves the \`SizedBox\`/\`DecoratedBox\` sizing wrapper out of \`StickerPickerOverlay\` and into \`ChatScreen\`, making the widget layout-agnostic
- Replaces the inline fixed-height panel with \`showModalBottomSheet\` + \`DraggableScrollableSheet\` (initial/min 70%, max 90%) to match the GIF modal UX — same height, draggable to expand

Closes #539

## Test plan

- [ ] Open sticker picker — modal opens at same height as GIF modal
- [ ] Drag the sheet up — expands to 90% of screen height
- [ ] Sticker/emoji grid adapts as window is resized
- [ ] Images are not cropped within grid cells (contain, not cover)
- [ ] Hover over a sticker — tooltip shows alt text
- [ ] Tap a sticker — sheet dismisses and sticker sends
- [ ] Tap an emoji — sheet dismisses and shortcode is inserted in compose bar
- [ ] Tap manage packs — sheet dismisses and navigates to sticker packs settings
- [ ] Empty state (no packs configured) still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)