### PR TITLE
fix(#540): clear link preview card on message send

### DIFF
--- a/lib/features/chat/widgets/compose_bar.dart
+++ b/lib/features/chat/widgets/compose_bar.dart
@@ -208,6 +208,10 @@ class _ComposeBarState extends State<ComposeBar> {
     final hasAttachments = widget.pendingAttachments.isNotEmpty;
     if (hasText || hasAttachments) {
       widget.typingController?.stop();
+      setState(() {
+        _previewUrl = null;
+        _dismissedUrl = null;
+      });
       widget.onSend();
       _focusNode.requestFocus();
     }


### PR DESCRIPTION
## Summary

- `_handleSend` was dismissing mention/emoji autocomplete overlays but never clearing `_previewUrl`, so the link preview card lingered in the compose area after the message was sent
- The debounced text-change listener would eventually clear it, but only after the controller text cleared — visually the card stayed up
- Fix: immediately reset `_previewUrl` and `_dismissedUrl` inside `setState` when a message is sent, so the card disappears at the same instant as the send

Closes #540

## Root cause

[compose_bar.dart:199-213](lib/features/chat/widgets/compose_bar.dart#L199) — `_handleSend` clears autocomplete state but not `_previewUrl`.

## Test plan

- [ ] Type a URL in compose bar — link preview card should appear
- [ ] Send the message — link preview card should disappear immediately
- [ ] Type the same URL again in the next message — preview should reappear (dismissedUrl is also reset on send)
- [ ] Dismiss the preview with the X button, then send — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)