### PR TITLE
fix(#543): add reaction support to sticker messages

### DIFF
--- a/lib/features/chat/widgets/message_list_view.dart
+++ b/lib/features/chat/widgets/message_list_view.dart
@@ -9,7 +9,7 @@ import 'package:kohera/features/chat/widgets/call_event_tile.dart';
 import 'package:kohera/features/chat/widgets/chat_message_item.dart';
 import 'package:kohera/features/chat/widgets/read_receipts.dart';
 import 'package:kohera/features/chat/widgets/state_event_tile.dart';
-import 'package:kohera/features/chat/widgets/sticker_bubble.dart';
+import 'package:kohera/features/chat/widgets/sticker_message_item.dart';
 import 'package:kohera/features/chat/widgets/unread_divider.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
@@ -542,9 +542,19 @@ class MessageListViewState extends State<MessageListView> {
           } else if (_isStateEvent(event)) {
             tile = StateEventTile(event: event);
           } else if (event.type == EventTypes.Sticker) {
-            tile = StickerBubble(
+            final isMe = event.senderId == widget.matrix.client.userID;
+            tile = StickerMessageItem(
+              key: ValueKey(event.eventId),
               event: event,
-              isMe: event.senderId == widget.matrix.client.userID,
+              isMe: isMe,
+              isMobile: isMobile,
+              timeline: _timeline,
+              client: widget.matrix.client,
+              onToggleReaction: widget.onToggleReaction,
+              onReply: widget.onReply,
+              onPin: widget.onPin,
+              highlightedEventId: widget.highlightedEventId,
+              isPinned: event.room.pinnedEventIds.contains(event.eventId),
             );
           } else {
             final prevSender =

--- a/lib/features/chat/widgets/sticker_message_item.dart
+++ b/lib/features/chat/widgets/sticker_message_item.dart
@@ -1,0 +1,215 @@
+import 'dart:async';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:kohera/core/utils/platform_info.dart';
+import 'package:kohera/features/chat/widgets/emoji_picker_sheet.dart';
+import 'package:kohera/features/chat/widgets/long_press_wrapper.dart';
+import 'package:kohera/features/chat/widgets/message_action_sheet.dart';
+import 'package:kohera/features/chat/widgets/message_bubble_context_menu.dart';
+import 'package:kohera/features/chat/widgets/message_bubble_hover_bar_slot.dart';
+import 'package:kohera/features/chat/widgets/reaction_chips.dart';
+import 'package:kohera/features/chat/widgets/sticker_bubble.dart';
+import 'package:matrix/matrix.dart';
+
+class StickerMessageItem extends StatefulWidget {
+  const StickerMessageItem({
+    required this.event,
+    required this.isMe,
+    required this.isMobile,
+    required this.onToggleReaction,
+    this.timeline,
+    this.client,
+    this.onReply,
+    this.onPin,
+    this.isPinned = false,
+    this.highlightedEventId,
+    super.key,
+  });
+
+  final Event event;
+  final bool isMe;
+  final bool isMobile;
+  final Future<void> Function(Event event, String emoji) onToggleReaction;
+  final Timeline? timeline;
+  final Client? client;
+  final void Function(Event event)? onReply;
+  final Future<void> Function(Event event)? onPin;
+  final bool isPinned;
+  final String? highlightedEventId;
+
+  @override
+  State<StickerMessageItem> createState() => _StickerMessageItemState();
+}
+
+class _StickerMessageItemState extends State<StickerMessageItem> {
+  final ValueNotifier<bool> _hovering = ValueNotifier(false);
+  final ValueNotifier<bool> _quickReactOpen = ValueNotifier(false);
+
+  @override
+  void dispose() {
+    _hovering.dispose();
+    _quickReactOpen.dispose();
+    super.dispose();
+  }
+
+  void _openContextMenu(Offset position) {
+    unawaited(showMessageContextMenu(
+      context,
+      event: widget.event,
+      isMe: widget.isMe,
+      isPinned: widget.isPinned,
+      timeline: widget.timeline,
+      position: position,
+      onReply: () => widget.onReply?.call(widget.event),
+      onReact: () => showEmojiPickerSheet(
+        context,
+        (emoji) => widget.onToggleReaction(widget.event, emoji),
+      ),
+      onPin: widget.onPin != null
+          ? () => widget.onPin!.call(widget.event)
+          : null,
+    ),);
+  }
+
+  void _showMobileActions(Rect bubbleRect) {
+    final cs = Theme.of(context).colorScheme;
+    showMessageActionSheet(
+      context: context,
+      event: widget.event,
+      isMe: widget.isMe,
+      bubbleRect: bubbleRect,
+      timeline: widget.timeline,
+      onQuickReact: (emoji) => widget.onToggleReaction(widget.event, emoji),
+      actions: [
+        MessageAction(
+          label: 'Reply',
+          icon: Icons.reply_rounded,
+          onTap: () => widget.onReply?.call(widget.event),
+        ),
+        MessageAction(
+          label: 'React',
+          icon: Icons.add_reaction_outlined,
+          onTap: () => showEmojiPickerSheet(
+            context,
+            (emoji) => widget.onToggleReaction(widget.event, emoji),
+          ),
+        ),
+        if (widget.onPin != null)
+          MessageAction(
+            label: widget.isPinned ? 'Unpin' : 'Pin',
+            icon: widget.isPinned
+                ? Icons.push_pin_rounded
+                : Icons.push_pin_outlined,
+            onTap: () => widget.onPin!.call(widget.event),
+          ),
+        MessageAction(
+          label: 'Copy link',
+          icon: Icons.link_rounded,
+          onTap: () {
+            unawaited(Clipboard.setData(
+              ClipboardData(
+                text: widget.event.content.tryGet<String>('url') ?? '',
+              ),
+            ),);
+          },
+          color: cs.onSurface,
+        ),
+
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDesktop = !isTouchDevice;
+    final timeline = widget.timeline;
+    final client = widget.client;
+
+    final hasReactions = timeline != null &&
+        widget.event.hasAggregatedEvents(timeline, RelationshipTypes.reaction);
+
+    Widget sticker = Column(
+      crossAxisAlignment:
+          widget.isMe ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment:
+              widget.isMe ? MainAxisAlignment.end : MainAxisAlignment.start,
+          children: [
+            MessageBubbleHoverBarSlot(
+              enabled: isDesktop && widget.isMe,
+              hovering: _hovering,
+              onReact: () => showEmojiPickerSheet(
+                context,
+                (emoji) => widget.onToggleReaction(widget.event, emoji),
+              ),
+              onQuickReact: (emoji) =>
+                  widget.onToggleReaction(widget.event, emoji),
+              onReply: () => widget.onReply?.call(widget.event),
+              onMore: _openContextMenu,
+              onQuickReactOpenChanged: (open) => _quickReactOpen.value = open,
+            ),
+            StickerBubble(event: widget.event, isMe: widget.isMe),
+            MessageBubbleHoverBarSlot(
+              enabled: isDesktop && !widget.isMe,
+              hovering: _hovering,
+              onReact: () => showEmojiPickerSheet(
+                context,
+                (emoji) => widget.onToggleReaction(widget.event, emoji),
+              ),
+              onQuickReact: (emoji) =>
+                  widget.onToggleReaction(widget.event, emoji),
+              onReply: () => widget.onReply?.call(widget.event),
+              onMore: _openContextMenu,
+              onQuickReactOpenChanged: (open) => _quickReactOpen.value = open,
+            ),
+          ],
+        ),
+        if (hasReactions && client != null)
+          Padding(
+            padding: EdgeInsets.only(
+              left: widget.isMe ? 0 : 12,
+              right: widget.isMe ? 12 : 0,
+              bottom: 4,
+            ),
+            child: ReactionChips(
+              event: widget.event,
+              timeline: timeline,
+              client: client,
+              isMe: widget.isMe,
+              onToggle: (emoji) =>
+                  widget.onToggleReaction(widget.event, emoji),
+            ),
+          ),
+      ],
+    );
+
+    if (isDesktop) {
+      sticker = MouseRegion(
+        onEnter: (_) => _hovering.value = true,
+        onExit: (_) {
+          if (!_quickReactOpen.value) _hovering.value = false;
+        },
+        child: Listener(
+          onPointerDown: (event) {
+            if (event.buttons == kSecondaryMouseButton) {
+              _openContextMenu(event.position);
+            }
+          },
+          child: sticker,
+        ),
+      );
+    } else {
+      sticker = LongPressWrapper(
+        onLongPress: _showMobileActions,
+        child: sticker,
+      );
+    }
+
+    return sticker;
+  }
+}


### PR DESCRIPTION
## Summary

Sticker events (`m.sticker`) were rendered as bare `StickerBubble` widgets bypassing all of `ChatMessageItem`'s interaction scaffolding, making it impossible to react to stickers or see existing reactions.

Introduces `StickerMessageItem` which wraps `StickerBubble` with:
- `MessageBubbleHoverBarSlot` on desktop — react, reply, and more buttons appear on hover
- Right-click context menu on desktop
- `LongPressWrapper` + action sheet on mobile (React, Reply, Pin actions)
- `ReactionChips` shown below the sticker when reactions exist

`MessageListView` now renders sticker events via `StickerMessageItem` instead of the bare `StickerBubble`.

Closes #543

## Test plan

- [ ] Send a sticker — hover over it on desktop and confirm the react/reply/more bar appears
- [ ] React to a sticker via the hover bar emoji picker
- [ ] Right-click a sticker on desktop — confirm context menu shows React option
- [ ] Long-press a sticker on mobile — confirm action sheet shows React option
- [ ] React to a sticker — confirm reaction chip appears below it
- [ ] Tap an existing reaction chip — confirm it toggles correctly
- [ ] Confirm non-sticker messages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)