### PR TITLE
fix(#544): tap reaction chip to see who reacted

### DIFF
--- a/lib/features/chat/widgets/long_press_wrapper.dart
+++ b/lib/features/chat/widgets/long_press_wrapper.dart
@@ -6,14 +6,33 @@ import 'package:kohera/features/chat/widgets/swipeable_message.dart' show Swipea
 /// Detects long press using raw pointer events so it does not participate in
 /// the gesture arena and therefore does not interfere with the horizontal drag
 /// recogniser in [SwipeableMessage].
+///
+/// Child widgets that need to handle their own long-press (e.g. reaction chips)
+/// can call [LongPressWrapper.claimOf] on pointer-down to prevent this wrapper
+/// from firing. Flutter dispatches [Listener] events innermost-first, so the
+/// claim is guaranteed to arrive before this wrapper processes the same event.
 class LongPressWrapper extends StatefulWidget {
   const LongPressWrapper({required this.onLongPress, required this.child, super.key});
 
   final void Function(Rect bubbleRect) onLongPress;
   final Widget child;
 
+  /// Suppresses the nearest enclosing [LongPressWrapper] for the current
+  /// gesture. No-op when called outside a [LongPressWrapper].
+  static void claimOf(BuildContext context) {
+    context.getInheritedWidgetOfExactType<_LongPressScope>()?.onClaim();
+  }
+
   @override
   State<LongPressWrapper> createState() => _LongPressWrapperState();
+}
+
+class _LongPressScope extends InheritedWidget {
+  const _LongPressScope({required this.onClaim, required super.child});
+  final VoidCallback onClaim;
+
+  @override
+  bool updateShouldNotify(_LongPressScope old) => onClaim != old.onClaim;
 }
 
 class _LongPressWrapperState extends State<LongPressWrapper> {
@@ -22,8 +41,21 @@ class _LongPressWrapperState extends State<LongPressWrapper> {
 
   Timer? _timer;
   Offset? _startPosition;
+  bool _claimed = false;
+
+  void _claim() {
+    _claimed = true;
+    _timer?.cancel();
+    _timer = null;
+  }
 
   void _onPointerDown(PointerDownEvent event) {
+    // An inner Listener (e.g. a reaction chip) may have already claimed this
+    // gesture — innermost callbacks fire before outer ones.
+    if (_claimed) {
+      _claimed = false;
+      return;
+    }
     _startPosition = event.position;
     _timer?.cancel();
     _timer = Timer(_longPressDuration, () {
@@ -64,12 +96,15 @@ class _LongPressWrapperState extends State<LongPressWrapper> {
 
   @override
   Widget build(BuildContext context) {
-    return Listener(
-      onPointerDown: _onPointerDown,
-      onPointerMove: _onPointerMove,
-      onPointerUp: _onPointerUp,
-      onPointerCancel: _onPointerCancel,
-      child: widget.child,
+    return _LongPressScope(
+      onClaim: _claim,
+      child: Listener(
+        onPointerDown: _onPointerDown,
+        onPointerMove: _onPointerMove,
+        onPointerUp: _onPointerUp,
+        onPointerCancel: _onPointerCancel,
+        child: widget.child,
+      ),
     );
   }
 }

--- a/lib/features/chat/widgets/reaction_chips.dart
+++ b/lib/features/chat/widgets/reaction_chips.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart'
     show DefaultEmojiTextStyle;
 import 'package:flutter/material.dart';
+import 'package:kohera/features/chat/widgets/long_press_wrapper.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
 import 'package:matrix/matrix.dart';
 
@@ -10,10 +11,11 @@ import 'package:matrix/matrix.dart';
 
 /// Displays aggregated emoji reaction chips below a message bubble.
 ///
-/// Each chip shows the emoji and its count. Chips where the current user
-/// has reacted are highlighted. Tapping a chip opens a sheet listing who
-/// reacted and allows toggling the current user's reaction.
-class ReactionChips extends StatelessWidget {
+/// Tapping a chip toggles the reaction. Long-pressing opens a sheet listing
+/// who reacted. Each chip claims the enclosing [LongPressWrapper] on
+/// pointer-down so only one action fires — the chip's own long-press wins
+/// and the message action sheet is not shown simultaneously.
+class ReactionChips extends StatefulWidget {
   const ReactionChips({
     required this.event,
     required this.timeline,
@@ -30,9 +32,36 @@ class ReactionChips extends StatelessWidget {
   final void Function(String emoji)? onToggle;
 
   @override
+  State<ReactionChips> createState() => _ReactionChipsState();
+}
+
+class _ReactionChipsState extends State<ReactionChips> {
+  final _pendingToggles = <String>{};
+  final _debounceTimers = <String, Timer>{};
+
+  @override
+  void dispose() {
+    for (final timer in _debounceTimers.values) {
+      timer.cancel();
+    }
+    super.dispose();
+  }
+
+  void _handleToggle(String emoji) {
+    if (_pendingToggles.contains(emoji)) return;
+    _pendingToggles.add(emoji);
+    widget.onToggle?.call(emoji);
+    _debounceTimers[emoji]?.cancel();
+    _debounceTimers[emoji] = Timer(const Duration(milliseconds: 600), () {
+      _pendingToggles.remove(emoji);
+      _debounceTimers.remove(emoji);
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     final reactionEvents =
-        event.aggregatedEvents(timeline, RelationshipTypes.reaction);
+        widget.event.aggregatedEvents(widget.timeline, RelationshipTypes.reaction);
     if (reactionEvents.isEmpty) return const SizedBox.shrink();
 
     final grouped = <String, List<Event>>{};
@@ -47,10 +76,10 @@ class ReactionChips extends StatelessWidget {
     if (grouped.isEmpty) return const SizedBox.shrink();
 
     final cs = Theme.of(context).colorScheme;
-    final myId = client.userID;
+    final myId = widget.client.userID;
 
     return Wrap(
-      alignment: isMe ? WrapAlignment.end : WrapAlignment.start,
+      alignment: widget.isMe ? WrapAlignment.end : WrapAlignment.start,
       spacing: 4,
       runSpacing: 4,
       children: grouped.entries.map((entry) {
@@ -58,54 +87,59 @@ class ReactionChips extends StatelessWidget {
         final events = entry.value;
         final isMine = events.any((e) => e.senderId == myId);
 
-        return GestureDetector(
-          onTap: () => showReactorsSheet(
-            context,
-            emoji: emoji,
-            reactionEvents: events,
-            room: event.room,
-            client: client,
-            onToggle: onToggle,
-          ),
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-            decoration: BoxDecoration(
-              color: isMine
-                  ? cs.primaryContainer
-                  : cs.surfaceContainerHighest,
-              borderRadius: BorderRadius.circular(10),
-              border: Border.all(
-                color: isMine
-                    ? cs.primary.withValues(alpha: 0.5)
-                    : cs.outlineVariant.withValues(alpha: 0.5),
-              ),
-              boxShadow: [
-                BoxShadow(
-                  color: cs.shadow.withValues(alpha: 0.08),
-                  blurRadius: 3,
-                  offset: const Offset(0, 1),
-                ),
-              ],
+        return Listener(
+          behavior: HitTestBehavior.translucent,
+          onPointerDown: (_) => LongPressWrapper.claimOf(context),
+          child: GestureDetector(
+            onTap: () => _handleToggle(emoji),
+            onLongPress: () => showReactorsSheet(
+              context,
+              emoji: emoji,
+              reactionEvents: events,
+              room: widget.event.room,
+              client: widget.client,
+              onToggle: widget.onToggle,
             ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  emoji,
-                  style: DefaultEmojiTextStyle.copyWith(fontSize: 14),
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: isMine
+                    ? cs.primaryContainer
+                    : cs.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(10),
+                border: Border.all(
+                  color: isMine
+                      ? cs.primary.withValues(alpha: 0.5)
+                      : cs.outlineVariant.withValues(alpha: 0.5),
                 ),
-                if (events.length > 1) ...[
-                  const SizedBox(width: 3),
-                  Text(
-                    '${events.length}',
-                    style: TextStyle(
-                      fontSize: 11,
-                      fontWeight: FontWeight.w500,
-                      color: isMine ? cs.primary : cs.onSurfaceVariant,
-                    ),
+                boxShadow: [
+                  BoxShadow(
+                    color: cs.shadow.withValues(alpha: 0.08),
+                    blurRadius: 3,
+                    offset: const Offset(0, 1),
                   ),
                 ],
-              ],
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    emoji,
+                    style: DefaultEmojiTextStyle.copyWith(fontSize: 14),
+                  ),
+                  if (events.length > 1) ...[
+                    const SizedBox(width: 3),
+                    Text(
+                      '${events.length}',
+                      style: TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w500,
+                        color: isMine ? cs.primary : cs.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
             ),
           ),
         );
@@ -116,8 +150,9 @@ class ReactionChips extends StatelessWidget {
 
 // ── Reactors bottom sheet ────────────────────────────────────
 
-/// Shows a modal bottom sheet listing all users who reacted with [emoji],
-/// with a button to add or remove the current user's own reaction.
+/// Shows a modal bottom sheet listing all users who reacted with [emoji].
+/// If [onToggle] is provided, a button lets the current user add or remove
+/// their own reaction directly from the sheet.
 void showReactorsSheet(
   BuildContext context, {
   required String emoji,
@@ -177,7 +212,9 @@ void showReactorsSheet(
                       Navigator.of(ctx).pop();
                       onToggle(emoji);
                     },
-                    child: Text(isMine ? 'Remove your $emoji' : 'React with $emoji'),
+                    child: Text(
+                      isMine ? 'Remove your $emoji' : 'React with $emoji',
+                    ),
                   ),
                 ),
               ),

--- a/lib/features/chat/widgets/reaction_chips.dart
+++ b/lib/features/chat/widgets/reaction_chips.dart
@@ -11,11 +11,15 @@ import 'package:matrix/matrix.dart';
 /// Displays aggregated emoji reaction chips below a message bubble.
 ///
 /// Each chip shows the emoji and its count. Chips where the current user
-/// has reacted are highlighted. Tapping toggles the reaction; long-pressing
-/// opens a bottom sheet listing who reacted.
-class ReactionChips extends StatefulWidget {
+/// has reacted are highlighted. Tapping a chip opens a sheet listing who
+/// reacted and allows toggling the current user's reaction.
+class ReactionChips extends StatelessWidget {
   const ReactionChips({
-    required this.event, required this.timeline, required this.client, required this.isMe, super.key,
+    required this.event,
+    required this.timeline,
+    required this.client,
+    required this.isMe,
+    super.key,
     this.onToggle,
   });
 
@@ -26,41 +30,11 @@ class ReactionChips extends StatefulWidget {
   final void Function(String emoji)? onToggle;
 
   @override
-  State<ReactionChips> createState() => _ReactionChipsState();
-}
-
-class _ReactionChipsState extends State<ReactionChips> {
-  /// Tracks emojis currently being toggled to prevent duplicate requests.
-  final _pendingToggles = <String>{};
-  final _debounceTimers = <String, Timer>{};
-
-  @override
-  void dispose() {
-    for (final timer in _debounceTimers.values) {
-      timer.cancel();
-    }
-    super.dispose();
-  }
-
-  void _handleToggle(String emoji) {
-    if (_pendingToggles.contains(emoji)) return;
-    _pendingToggles.add(emoji);
-    widget.onToggle?.call(emoji);
-    // Allow the same emoji to be toggled again after a short delay.
-    _debounceTimers[emoji]?.cancel();
-    _debounceTimers[emoji] = Timer(const Duration(milliseconds: 600), () {
-      _pendingToggles.remove(emoji);
-      _debounceTimers.remove(emoji);
-    });
-  }
-
-  @override
   Widget build(BuildContext context) {
     final reactionEvents =
-        widget.event.aggregatedEvents(widget.timeline, RelationshipTypes.reaction);
+        event.aggregatedEvents(timeline, RelationshipTypes.reaction);
     if (reactionEvents.isEmpty) return const SizedBox.shrink();
 
-    // Group by emoji key.
     final grouped = <String, List<Event>>{};
     for (final re in reactionEvents) {
       final key = re.content
@@ -73,10 +47,10 @@ class _ReactionChipsState extends State<ReactionChips> {
     if (grouped.isEmpty) return const SizedBox.shrink();
 
     final cs = Theme.of(context).colorScheme;
-    final myId = widget.client.userID;
+    final myId = client.userID;
 
     return Wrap(
-      alignment: widget.isMe ? WrapAlignment.end : WrapAlignment.start,
+      alignment: isMe ? WrapAlignment.end : WrapAlignment.start,
       spacing: 4,
       runSpacing: 4,
       children: grouped.entries.map((entry) {
@@ -85,16 +59,16 @@ class _ReactionChipsState extends State<ReactionChips> {
         final isMine = events.any((e) => e.senderId == myId);
 
         return GestureDetector(
-          onTap: () => _handleToggle(emoji),
-          onLongPress: () => showReactorsSheet(
+          onTap: () => showReactorsSheet(
             context,
-            emoji,
-            events,
-            widget.event.room,
+            emoji: emoji,
+            reactionEvents: events,
+            room: event.room,
+            client: client,
+            onToggle: onToggle,
           ),
           child: Container(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
             decoration: BoxDecoration(
               color: isMine
                   ? cs.primaryContainer
@@ -127,9 +101,7 @@ class _ReactionChipsState extends State<ReactionChips> {
                     style: TextStyle(
                       fontSize: 11,
                       fontWeight: FontWeight.w500,
-                      color: isMine
-                          ? cs.primary
-                          : cs.onSurfaceVariant,
+                      color: isMine ? cs.primary : cs.onSurfaceVariant,
                     ),
                   ),
                 ],
@@ -144,16 +116,22 @@ class _ReactionChipsState extends State<ReactionChips> {
 
 // ── Reactors bottom sheet ────────────────────────────────────
 
-/// Shows a modal bottom sheet listing all users who sent a given reaction.
+/// Shows a modal bottom sheet listing all users who reacted with [emoji],
+/// with a button to add or remove the current user's own reaction.
 void showReactorsSheet(
-  BuildContext context,
-  String emoji,
-  List<Event> reactionEvents,
-  Room room,
-) {
+  BuildContext context, {
+  required String emoji,
+  required List<Event> reactionEvents,
+  required Room room,
+  required Client client,
+  void Function(String emoji)? onToggle,
+}) {
   unawaited(showModalBottomSheet(
     context: context,
-    builder: (context) {
+    builder: (ctx) {
+      final myId = client.userID;
+      final isMine = reactionEvents.any((e) => e.senderId == myId);
+
       return SafeArea(
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -162,7 +140,7 @@ void showReactorsSheet(
               padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
               child: Text(
                 '$emoji ${reactionEvents.length}',
-                style: Theme.of(context).textTheme.titleMedium,
+                style: Theme.of(ctx).textTheme.titleMedium,
               ),
             ),
             const Divider(height: 1),
@@ -170,12 +148,11 @@ void showReactorsSheet(
               child: ListView.builder(
                 shrinkWrap: true,
                 itemCount: reactionEvents.length,
-                itemBuilder: (context, i) {
+                itemBuilder: (ctx, i) {
                   final re = reactionEvents[i];
                   final user =
                       room.unsafeGetUserFromMemoryOrFallback(re.senderId);
                   final name = user.displayName ?? re.senderId;
-
                   return ListTile(
                     leading: UserAvatar(
                       client: room.client,
@@ -189,6 +166,22 @@ void showReactorsSheet(
                 },
               ),
             ),
+            if (onToggle != null) ...[
+              const Divider(height: 1),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.tonal(
+                    onPressed: () {
+                      Navigator.of(ctx).pop();
+                      onToggle(emoji);
+                    },
+                    child: Text(isMine ? 'Remove your $emoji' : 'React with $emoji'),
+                  ),
+                ),
+              ),
+            ],
           ],
         ),
       );


### PR DESCRIPTION
## Summary

Long-pressing a reaction chip was broken on mobile: `LongPressWrapper` uses a raw `Listener` that fires outside the gesture arena, so it opened the message action sheet *simultaneously* with the chip's `GestureDetector.onLongPress` (two sheets at once). On desktop there was also no way to see reactors beyond a non-obvious mouse long-press.

## How it works

**Root cause:** Flutter delivers `Listener` callbacks innermost-first. `LongPressWrapper` starts a 500ms timer on `onPointerDown`, but since it's the *outer* widget, by the time the reaction chip's inner `Listener` fires, the timer is already running. Both timers expire and both sheets open.

**Fix — claim mechanism on `LongPressWrapper`:**
- `LongPressWrapper` now exposes `LongPressWrapper.claimOf(context)` via an `InheritedWidget` (`_LongPressScope`)
- Each reaction chip wraps itself in a `Listener` whose `onPointerDown` calls `claimOf`. Because innermost fires first, the claim is set *before* `LongPressWrapper._onPointerDown` runs
- `LongPressWrapper._onPointerDown` checks `_claimed`, skips starting the timer if set, then resets the flag

**Bonus:** `showReactorsSheet` now includes a **"React with X" / "Remove your X"** button so users can also toggle from the sheet after seeing who reacted.

## What is unchanged

| Interaction | Before | After |
|---|---|---|
| Tap chip | Toggle reaction ✓ | Toggle reaction ✓ |
| Long-press chip | Reactors sheet + action sheet (conflict) | Reactors sheet only ✓ |
| Long-press message body | Message action sheet ✓ | Message action sheet ✓ |
| Swipe to reply | Works ✓ | Works ✓ |
| Desktop hover bar | Works ✓ | Works ✓ |
| Desktop right-click | Works ✓ | Works ✓ |

Closes #544

## Test plan

- [ ] Tap a reaction chip — reaction toggles (same as before)
- [ ] Long-press a reaction chip on mobile — **only** the reactors sheet opens (no message action sheet)
- [ ] Long-press the message body (not on a chip) — message action sheet opens normally
- [ ] Reactors sheet shows "React with X" when not reacted — tap it, reaction added
- [ ] Reactors sheet shows "Remove your X" when already reacted — tap it, reaction removed
- [ ] Swipe-to-reply still works correctly
- [ ] Desktop hover react button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)