### PR TITLE
feat(#545): move GIF and sticker actions into attachment sheet on mobile

### DIFF
--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -246,10 +246,18 @@ class _ChatScreenState extends State<ChatScreen>
       return;
     }
 
-    final source = await showAttachmentSourceSheet(context);
+    final source = await showAttachmentSourceSheet(
+      context,
+      showGif: _giphyEnabled,
+      showSticker: true,
+    );
     if (source == null || !mounted) return;
 
     switch (source) {
+      case AttachmentSource.gif:
+        await _handleGifPressed();
+      case AttachmentSource.sticker:
+        _toggleStickerPicker();
       case AttachmentSource.file:
         final attachment = await pickFileAsAttachment();
         if (attachment != null && mounted) _addAttachment(attachment);
@@ -323,6 +331,31 @@ class _ChatScreenState extends State<ChatScreen>
   void _scrollToEvent(Event event, {bool closeSearch = true}) {
     if (closeSearch) _closeSearch();
     _messageListKey.currentState?.navigateToEvent(event);
+  }
+
+  // ── GIF ───────────────────────────────────────────────────
+
+  bool get _giphyEnabled =>
+      AppConfig.isInitialized && AppConfig.instance.giphyEnabled;
+
+  Future<void> _handleGifPressed() async {
+    final room =
+        context.read<MatrixService>().client.getRoomById(widget.roomId);
+    if (room == null) return;
+    final gif = await GiphyGet.getGif(
+      context: context,
+      apiKey: AppConfig.instance.giphyApiKey!,
+    );
+    if (gif == null || !mounted) return;
+    final url = gif.images?.downsized?.url ?? gif.images?.original?.url;
+    if (url == null) return;
+    await sendGifFromUrl(
+      scaffold: ScaffoldMessenger.of(context),
+      room: room,
+      url: url,
+      title: gif.title ?? 'giphy',
+      uploadNotifier: _compose.uploadNotifier,
+    );
   }
 
   // ── Sticker picker ────────────────────────────────────────
@@ -522,25 +555,7 @@ class _ChatScreenState extends State<ChatScreen>
           onAttach: _handleAttachPressed,
           onSticker: _toggleStickerPicker,
           stickerPackService: context.read<StickerPackService>(),
-          onGif: AppConfig.isInitialized && AppConfig.instance.giphyEnabled
-              ? () async {
-                  final gif = await GiphyGet.getGif(
-                    context: context,
-                    apiKey: AppConfig.instance.giphyApiKey!,
-                  );
-                  if (gif == null || !mounted) return;
-                  final url = gif.images?.downsized?.url ??
-                      gif.images?.original?.url;
-                  if (url == null) return;
-                  await sendGifFromUrl(
-                    scaffold: ScaffoldMessenger.of(context),
-                    room: room,
-                    url: url,
-                    title: gif.title ?? 'giphy',
-                    uploadNotifier: _compose.uploadNotifier,
-                  );
-                }
-              : null,
+          onGif: _giphyEnabled ? _handleGifPressed : null,
           onPasteImage: _isDesktop ? _handlePasteImage : null,
           uploadNotifier: _compose.uploadNotifier,
           room: room,

--- a/lib/features/chat/widgets/attachment_source_sheet.dart
+++ b/lib/features/chat/widgets/attachment_source_sheet.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
 
-enum AttachmentSource { gallery, camera, file }
+enum AttachmentSource { gallery, camera, file, gif, sticker }
 
-Future<AttachmentSource?> showAttachmentSourceSheet(BuildContext context) {
+Future<AttachmentSource?> showAttachmentSourceSheet(
+  BuildContext context, {
+  bool showGif = false,
+  bool showSticker = false,
+}) {
   return showModalBottomSheet<AttachmentSource>(
     context: context,
     showDragHandle: true,
@@ -26,6 +30,19 @@ Future<AttachmentSource?> showAttachmentSourceSheet(BuildContext context) {
               title: const Text('File'),
               onTap: () => Navigator.pop(sheetContext, AttachmentSource.file),
             ),
+            if (showGif)
+              ListTile(
+                leading: const Icon(Icons.gif_box_outlined),
+                title: const Text('GIF'),
+                onTap: () => Navigator.pop(sheetContext, AttachmentSource.gif),
+              ),
+            if (showSticker)
+              ListTile(
+                leading: const Icon(Icons.emoji_emotions_outlined),
+                title: const Text('Stickers & Emoji'),
+                onTap: () =>
+                    Navigator.pop(sheetContext, AttachmentSource.sticker),
+              ),
             const SizedBox(height: 8),
           ],
         ),

--- a/lib/features/chat/widgets/compose_bar.dart
+++ b/lib/features/chat/widgets/compose_bar.dart
@@ -7,6 +7,7 @@ import 'package:kohera/core/models/pending_attachment.dart';
 import 'package:kohera/core/models/upload_state.dart';
 import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/core/services/sticker_pack_service.dart';
+import 'package:kohera/core/utils/platform_info.dart';
 import 'package:kohera/features/chat/services/typing_controller.dart';
 import 'package:kohera/features/chat/services/voice_recording_controller.dart';
 import 'package:kohera/features/chat/widgets/attachment_preview_bar.dart';
@@ -428,8 +429,9 @@ class _ComposeBarState extends State<ComposeBar> {
       child: Row(
         children: [
           _buildAttachButton(cs),
-          if (widget.onGif != null) _buildGifButton(cs),
-          if (widget.onSticker != null) _buildStickerButton(cs),
+          if (!isTouchDevice && widget.onGif != null) _buildGifButton(cs),
+          if (!isTouchDevice && widget.onSticker != null)
+            _buildStickerButton(cs),
           Expanded(
             child: CallbackShortcuts(
               bindings: {

--- a/test/widgets/chat/attachment_source_sheet_test.dart
+++ b/test/widgets/chat/attachment_source_sheet_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/features/chat/widgets/attachment_source_sheet.dart';
+
+void main() {
+  Future<AttachmentSource?> openSheet(
+    WidgetTester tester, {
+    bool showGif = false,
+    bool showSticker = false,
+  }) async {
+    AttachmentSource? result;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () async {
+              result = await showAttachmentSourceSheet(
+                context,
+                showGif: showGif,
+                showSticker: showSticker,
+              );
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ),);
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    return result;
+  }
+
+  testWidgets('hides GIF and sticker options by default', (tester) async {
+    await openSheet(tester);
+
+    expect(find.text('Photo or Video'), findsOneWidget);
+    expect(find.text('GIF'), findsNothing);
+    expect(find.text('Stickers & Emoji'), findsNothing);
+  });
+
+  testWidgets('shows GIF and sticker options when enabled', (tester) async {
+    await openSheet(tester, showGif: true, showSticker: true);
+
+    expect(find.text('GIF'), findsOneWidget);
+    expect(find.text('Stickers & Emoji'), findsOneWidget);
+  });
+
+  testWidgets('returns gif source when GIF option tapped', (tester) async {
+    AttachmentSource? result;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) => ElevatedButton(
+            onPressed: () async {
+              result = await showAttachmentSourceSheet(context, showGif: true);
+            },
+            child: const Text('open'),
+          ),
+        ),
+      ),
+    ),);
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('GIF'));
+    await tester.pumpAndSettle();
+
+    expect(result, AttachmentSource.gif);
+  });
+}


### PR DESCRIPTION
Closes #545

## What
On touch devices (Android/iOS), the inline `GIF` and sticker buttons crowded the compose bar and shrank the text input. This moves both actions into the `+` attachment action sheet on mobile, keeping the text field as wide as possible. Desktop/web keep the inline buttons.

## Changes
- `attachment_source_sheet.dart` — add `gif` and `sticker` to `AttachmentSource`; new `showGif`/`showSticker` params render the extra `ListTile` options.
- `compose_bar.dart` — hide inline GIF/sticker buttons behind the existing `isTouchDevice` guard.
- `chat_screen.dart` — extract GIF send logic into `_handleGifPressed` + `_giphyEnabled` getter; the attach sheet passes the flags and handles the new `gif`/`sticker` cases.
- New test `attachment_source_sheet_test.dart` covering option visibility and the GIF tap result.

## Testing
- `flutter analyze` — clean
- `flutter test test/widgets/chat/attachment_source_sheet_test.dart` — pass (3)
- `flutter test test/widgets/chat/compose_bar_test.dart` — pass (22)

GIF option only shown when Giphy is enabled. Inline buttons hide only on real Android/iOS (Platform-based), so desktop and tests are unaffected.