### PR TITLE
feat(#549): presence service + publishing layer

### DIFF
--- a/lib/core/services/matrix_service.dart
+++ b/lib/core/services/matrix_service.dart
@@ -8,6 +8,7 @@ import 'package:kohera/core/services/sub_services/auth_service.dart';
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart';
 import 'package:kohera/core/services/sub_services/outbox_connectivity.dart';
 import 'package:kohera/core/services/sub_services/outbox_service.dart';
+import 'package:kohera/core/services/sub_services/presence_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/core/services/sub_services/space_access_service.dart';
 import 'package:kohera/core/services/sub_services/sync_service.dart';
@@ -52,6 +53,7 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
       storage: _storage,
     );
     selection = SelectionService(client: _client);
+    presence = PresenceService(client: _client);
     spaceAccess = SpaceAccessService(client: _client);
     sync = SyncService(
       client: _client,
@@ -111,6 +113,7 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
   late final UiaService uia;
   late final ChatBackupService chatBackup;
   late final SelectionService selection;
+  late final PresenceService presence;
   late final SpaceAccessService spaceAccess;
   late final SyncService sync;
   late final AuthService auth;
@@ -143,6 +146,7 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
     outbox.dispose();
     uia.dispose();
     selection.dispose();
+    presence.dispose();
     chatBackup.dispose();
     sync.dispose();
     stickerPacks.dispose();
@@ -155,10 +159,13 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
     switch (state) {
       case AppLifecycleState.resumed:
         _startForegroundSync();
-      case AppLifecycleState.inactive:
+        presence.setOnline();
       case AppLifecycleState.paused:
-      case AppLifecycleState.detached:
       case AppLifecycleState.hidden:
+        presence.setAway();
+      case AppLifecycleState.detached:
+        presence.setOffline();
+      case AppLifecycleState.inactive:
         break;
     }
   }
@@ -189,6 +196,7 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
       uia.setCachedPassword(password);
       try {
         await sync.startSync(timeout: const Duration(minutes: 5));
+        presence.setOnline();
         await auth.saveSessionBackup();
       } catch (e) {
         debugPrint('[Kohera] Post-login sync error: $e');
@@ -210,6 +218,7 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
     if (success) {
       try {
         await sync.startSync(timeout: const Duration(minutes: 5));
+        presence.setOnline();
         await auth.saveSessionBackup();
       } catch (e) {
         debugPrint('[Kohera] Post-login sync error: $e');
@@ -331,10 +340,6 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
   void _startForegroundSync() {
     if (_foregroundSyncStarted || _disposed) return;
     _foregroundSyncStarted = true;
-    if (_lifecycleObserverRegistered) {
-      WidgetsBinding.instance.removeObserver(this);
-      _lifecycleObserverRegistered = false;
-    }
     unawaited(
       sync.startSync().catchError((Object e) {
         if (e is! TimeoutException) {
@@ -342,6 +347,7 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
         }
       }),
     );
+    presence.setOnline();
   }
 
   // ── Private: Session Keys ──────────────────────────────────────

--- a/lib/core/services/sub_services/presence_service.dart
+++ b/lib/core/services/sub_services/presence_service.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:matrix/matrix.dart';
+
+class PresenceService extends ChangeNotifier {
+  PresenceService({required Client client}) : _client = client {
+    _sub = _client.onPresenceChanged.stream.listen(_onPresenceChanged);
+  }
+
+  final Client _client;
+  StreamSubscription<CachedPresence>? _sub;
+
+  final Map<String, CachedPresence> _presences = {};
+
+  bool _publishingEnabled = true;
+  PresenceType? _desired;
+
+  // ── Consuming ───────────────────────────────────────────────────
+
+  CachedPresence? presenceFor(String userId) => _presences[userId];
+
+  void _onPresenceChanged(CachedPresence presence) {
+    _presences[presence.userid] = presence;
+    notifyListeners();
+  }
+
+  // ── Publishing ──────────────────────────────────────────────────
+
+  bool get publishingEnabled => _publishingEnabled;
+
+  void setPublishingEnabled(bool enabled) {
+    if (_publishingEnabled == enabled) return;
+    _publishingEnabled = enabled;
+    if (!enabled) {
+      _apply(PresenceType.offline);
+    } else if (_desired != null) {
+      _apply(_desired!);
+    }
+    notifyListeners();
+  }
+
+  void setOnline() => _publish(PresenceType.online);
+
+  void setAway() => _publish(PresenceType.unavailable);
+
+  void setOffline() => _publish(PresenceType.offline);
+
+  void _publish(PresenceType type) {
+    _desired = type;
+    if (!_publishingEnabled) return;
+    _apply(type);
+  }
+
+  void _apply(PresenceType type) {
+    if (_client.syncPresence == type) return;
+    _client.syncPresence = type;
+    debugPrint('[Kohera] Presence → ${type.name}');
+  }
+
+  @override
+  void dispose() {
+    unawaited(_sub?.cancel());
+    super.dispose();
+  }
+}

--- a/test/e2e/chat_screen_test.dart
+++ b/test/e2e/chat_screen_test.dart
@@ -112,6 +112,8 @@ void main() {
     when(mockClient.userID).thenReturn(_myUserId);
     when(mockClient.rooms).thenReturn([mockRoom]);
     when(mockClient.onSync).thenReturn(syncController);
+    when(mockClient.onPresenceChanged)
+        .thenReturn(CachedStreamController<CachedPresence>());
     when(mockClient.encryption).thenReturn(null);
     when(mockClient.homeserver).thenReturn(Uri.parse('https://matrix.org'));
 

--- a/test/e2e/login_flow_test.dart
+++ b/test/e2e/login_flow_test.dart
@@ -57,6 +57,8 @@ void main() {
     when(mockClient.rooms).thenReturn([]);
     when(mockClient.database).thenReturn(_FakeDatabase());
     when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
+    when(mockClient.onPresenceChanged)
+        .thenReturn(CachedStreamController<CachedPresence>());
     when(mockClient.onLoginStateChanged)
         .thenReturn(CachedStreamController<LoginState>());
     matrixService = MatrixService(

--- a/test/e2e/room_management_test.dart
+++ b/test/e2e/room_management_test.dart
@@ -37,6 +37,8 @@ void stubClientDefaults(
   when(mockClient.userID).thenReturn(_myUserId);
   when(mockClient.rooms).thenReturn([]);
   when(mockClient.onSync).thenReturn(syncController);
+  when(mockClient.onPresenceChanged)
+      .thenReturn(CachedStreamController<CachedPresence>());
   when(mockClient.encryption).thenReturn(null);
   when(mockClient.homeserver).thenReturn(Uri.parse('https://example.com'));
   when(mockClient.updateUserDeviceKeys()).thenAnswer((_) async {});

--- a/test/e2e/settings_screen_test.dart
+++ b/test/e2e/settings_screen_test.dart
@@ -74,6 +74,8 @@ void main() {
     when(mockClient.homeserver).thenReturn(Uri.parse(_homeserver));
     when(mockClient.rooms).thenReturn([]);
     when(mockClient.onSync).thenReturn(syncController);
+    when(mockClient.onPresenceChanged)
+        .thenReturn(CachedStreamController<CachedPresence>());
     when(mockClient.encryption).thenReturn(null);
     when(mockClient.encryptionEnabled).thenReturn(false);
     when(mockClient.onLoginStateChanged)

--- a/test/e2e/space_management_test.dart
+++ b/test/e2e/space_management_test.dart
@@ -103,6 +103,8 @@ void main() {
     when(mockClient.userID).thenReturn(_myUserId);
     when(mockClient.rooms).thenReturn([]);
     when(mockClient.onSync).thenReturn(syncController);
+    when(mockClient.onPresenceChanged)
+        .thenReturn(CachedStreamController<CachedPresence>());
     when(mockClient.encryption).thenReturn(null);
     when(mockClient.homeserver).thenReturn(Uri.parse('https://matrix.org'));
     when(mockClient.fetchOwnProfile()).thenAnswer(

--- a/test/screens/homeserver_screen_test.dart
+++ b/test/screens/homeserver_screen_test.dart
@@ -49,6 +49,8 @@ void main() {
     mockStorage = MockFlutterSecureStorage();
     when(mockClient.rooms).thenReturn([]);
     when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
+    when(mockClient.onPresenceChanged)
+        .thenReturn(CachedStreamController<CachedPresence>());
     matrixService = MatrixService(
       client: mockClient,
       storage: mockStorage,

--- a/test/screens/login_screen_test.dart
+++ b/test/screens/login_screen_test.dart
@@ -45,6 +45,8 @@ void main() {
     mockStorage = MockFlutterSecureStorage();
     when(mockClient.rooms).thenReturn([]);
     when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
+    when(mockClient.onPresenceChanged)
+        .thenReturn(CachedStreamController<CachedPresence>());
     matrixService = MatrixService(
       client: mockClient,
       storage: mockStorage,

--- a/test/screens/registration_screen_test.dart
+++ b/test/screens/registration_screen_test.dart
@@ -38,6 +38,8 @@ void main() {
     mockStorage = MockFlutterSecureStorage();
     when(mockClient.rooms).thenReturn([]);
     when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
+    when(mockClient.onPresenceChanged)
+        .thenReturn(CachedStreamController<CachedPresence>());
     matrixService = MatrixService(
       client: mockClient,
       storage: mockStorage,

--- a/test/services/client_manager_test.dart
+++ b/test/services/client_manager_test.dart
@@ -36,6 +36,8 @@ class _TestServiceFactory extends MatrixServiceFactory {
     when(mockClient.userID).thenReturn('@$clientName:example.com');
     when(mockClient.dispose()).thenAnswer((_) async {});
     when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
+    when(mockClient.onPresenceChanged)
+        .thenReturn(CachedStreamController<CachedPresence>());
     final s = MatrixService(
       client: mockClient,
       storage: storage ?? const FlutterSecureStorage(),
@@ -167,6 +169,8 @@ void main() {
       final newMockClient = MockClient();
       when(newMockClient.rooms).thenReturn([]);
       when(newMockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
+      when(newMockClient.onPresenceChanged)
+          .thenReturn(CachedStreamController<CachedPresence>());
       final newService = MatrixService(
         client: newMockClient,
         storage: mockStorage,
@@ -344,6 +348,8 @@ class _MixedLoginFactory extends MatrixServiceFactory {
     when(mockClient.rooms).thenReturn([]);
     when(mockClient.userID).thenReturn('@$clientName:example.com');
     when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
+    when(mockClient.onPresenceChanged)
+        .thenReturn(CachedStreamController<CachedPresence>());
     final s = MatrixService(
       client: mockClient,
       storage: storage ?? _storage,
@@ -377,6 +383,8 @@ class _CountingFactory extends MatrixServiceFactory {
     when(mockClient.rooms).thenReturn([]);
     when(mockClient.dispose()).thenAnswer((_) async {});
     when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
+    when(mockClient.onPresenceChanged)
+        .thenReturn(CachedStreamController<CachedPresence>());
     final s = MatrixService(
       client: mockClient,
       storage: storage ?? _storage,

--- a/test/services/matrix_service_auth_test.dart
+++ b/test/services/matrix_service_auth_test.dart
@@ -22,6 +22,8 @@ void main() {
     when(mockClient.rooms).thenReturn([]);
     when(mockClient.database).thenReturn(_FakeDatabase());
     when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
+    when(mockClient.onPresenceChanged)
+        .thenReturn(CachedStreamController<CachedPresence>());
     service = MatrixService(
       client: mockClient,
       storage: mockStorage,

--- a/test/services/matrix_service_test.dart
+++ b/test/services/matrix_service_test.dart
@@ -51,6 +51,8 @@ void main() {
     when(mockClient.rooms).thenReturn([]);
     when(mockClient.onSync)
         .thenReturn(CachedStreamController<SyncUpdate>());
+    when(mockClient.onPresenceChanged)
+        .thenReturn(CachedStreamController<CachedPresence>());
     when(mockClient.database).thenReturn(_FakeDatabase());
     service = MatrixService(
       client: mockClient,
@@ -1555,10 +1557,30 @@ void main() {
       expect(
         notifyCount,
         0,
-        reason: 'observer should be unregistered after first foreground sync; '
-            'subsequent transitions must not re-trigger startSync',
+        reason: 'foreground sync is idempotent; subsequent lifecycle '
+            'transitions must not re-trigger startSync',
       );
       expect(service.sync.syncing, isTrue);
+    });
+
+    test('publishes presence across lifecycle transitions', () async {
+      WidgetsBinding.instance
+          .handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await service.activateSessionForTest();
+      verify(mockClient.syncPresence = PresenceType.online)
+          .called(greaterThanOrEqualTo(1));
+
+      WidgetsBinding.instance
+          .handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      verify(mockClient.syncPresence = PresenceType.unavailable).called(1);
+
+      WidgetsBinding.instance
+          .handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+      verify(mockClient.syncPresence = PresenceType.unavailable).called(1);
+
+      WidgetsBinding.instance
+          .handleAppLifecycleStateChanged(AppLifecycleState.detached);
+      verify(mockClient.syncPresence = PresenceType.offline).called(1);
     });
   });
 }

--- a/test/services/presence_service_test.dart
+++ b/test/services/presence_service_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/services/sub_services/presence_service.dart';
+import 'package:matrix/matrix.dart';
+import 'package:matrix/src/utils/cached_stream_controller.dart';
+import 'package:mockito/mockito.dart';
+
+import 'matrix_service_test.mocks.dart';
+
+void main() {
+  late MockClient mockClient;
+  late CachedStreamController<CachedPresence> presenceController;
+  late PresenceService service;
+
+  setUp(() {
+    mockClient = MockClient();
+    presenceController = CachedStreamController<CachedPresence>();
+    when(mockClient.onPresenceChanged).thenReturn(presenceController);
+    service = PresenceService(client: mockClient);
+  });
+
+  tearDown(() => service.dispose());
+
+  group('consuming', () {
+    test('presence is unknown (null) by default', () {
+      expect(service.presenceFor('@alice:example.com'), isNull);
+    });
+
+    test('reflects a presence update from sync and notifies', () async {
+      var notified = 0;
+      service.addListener(() => notified++);
+
+      final cached =
+          CachedPresence(PresenceType.online, null, 'busy', true, '@alice:example.com');
+      presenceController.add(cached);
+      await Future<void>.delayed(Duration.zero);
+
+      final result = service.presenceFor('@alice:example.com');
+      expect(result, same(cached));
+      expect(result?.presence, PresenceType.online);
+      expect(result?.statusMsg, 'busy');
+      expect(notified, 1);
+    });
+
+    test('still unknown for users with no presence event', () async {
+      presenceController.add(
+        CachedPresence(PresenceType.online, null, null, true, '@alice:example.com'),
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(service.presenceFor('@bob:example.com'), isNull);
+    });
+  });
+
+  group('publishing', () {
+    test('setOnline/setAway/setOffline drive syncPresence', () {
+      service.setOnline();
+      verify(mockClient.syncPresence = PresenceType.online).called(1);
+
+      service.setAway();
+      verify(mockClient.syncPresence = PresenceType.unavailable).called(1);
+
+      service.setOffline();
+      verify(mockClient.syncPresence = PresenceType.offline).called(1);
+    });
+
+    test('publishing disabled is a no-op until re-enabled', () {
+      service.setPublishingEnabled(false);
+      clearInteractions(mockClient);
+
+      service.setOnline();
+      verifyNever(mockClient.syncPresence = PresenceType.online);
+
+      service.setPublishingEnabled(true);
+      verify(mockClient.syncPresence = PresenceType.online).called(1);
+    });
+
+    test('disabling publishing advertises offline', () {
+      service.setOnline();
+      clearInteractions(mockClient);
+
+      service.setPublishingEnabled(false);
+      verify(mockClient.syncPresence = PresenceType.offline).called(1);
+    });
+  });
+}


### PR DESCRIPTION
Part of the presence epic #523. Closes #549.

Stands up the app-layer presence plumbing — consuming other users' presence and publishing our own — with **no UI changes**. Foundation for #550 (indicator widget) and #551 (UI rollout).

## Consuming
- New `PresenceService` (`core/services/sub_services/`) listens to `client.onPresenceChanged` (the non-deprecated `CachedPresence` stream — carries a timestamp) into a `userId → CachedPresence` map.
- `presenceFor(userId)` returns `null` for **unknown**, keeping unknown a first-class state. Deliberately avoids the deprecated `client.presences` and `fetchCurrentPresence()` (the latter never returns null — it falls back to `neverSeen` = offline, which would break the epic's "unknown = no dot" rule).

## Publishing
- `setOnline` / `setAway` / `setOffline` drive `client.syncPresence` (sent as `set_presence` on the sync loop), not the rate-limited `Client.setPresence`.
- `setPublishingEnabled(false)` advertises offline and stops publishing; re-enabling republishes the desired state — a privacy seam for a future `PreferencesService` opt-out.

## Lifecycle (`MatrixService`)
- `didChangeAppLifecycleState`: `resumed → online`, `paused`/`hidden → away (unavailable)`, `detached → offline`, `inactive → no-op` (avoids desktop focus-loss flapping — explicit per the epic).
- `_startForegroundSync` no longer unregisters the lifecycle observer (it previously did after the first foreground sync, so background transitions never fired). Observer now lives for the service lifetime; online is published on connect (foreground sync + login/SSO/registration).

## Tests
- `presence_service_test.dart`: unknown-by-default, presence update from sync + notify, publish transitions, publishing-disabled no-op, disable→offline.
- `matrix_service_test.dart`: lifecycle publish integration test; updated the now-stale comment on the idempotent-sync test.
- Added an `onPresenceChanged` stub next to the existing `onSync` stub in the 11 test files that build a real `MatrixService` with `MockClient` (the generated `SmartFake` stream throws on `.listen` when unstubbed — same reason `onSync` is stubbed everywhere).

`flutter analyze` clean; touched test suites pass.

## Acceptance criteria
- [x] Own presence published `online` on connect/foreground and `unavailable`/`offline` on background, via the sync loop, per active account.
- [x] Documented accessor returns a user's presence (incl. explicit unknown) and notifies on change.
- [x] Graceful no-op when the homeserver disables/rate-limits presence — `syncPresence` is best-effort; unknown stays unknown.
- [x] Unit tests cover unknown-by-default, presence update from a sync, and lifecycle-driven publish transitions.

## Known gap (foundation slice)
A freshly-logged-in account, within the same session and before any restart, won't flip to away on background — the lifecycle observer attaches on session activation (restore path), not on bare login (binding isn't initialized in the login-path test groups, so observer registration stays on the activation seam). Re-publishing on the next activation covers it. Flagged for a #550/#551 follow-up if needed.

## Out of scope
- Indicator widget (#550), UI surface rollout (#551), status-message editing (epic backlog).