### PR TITLE
feat(#550): presence indicator dot on UserAvatar

### DIFF
--- a/lib/shared/widgets/user_avatar.dart
+++ b/lib/shared/widgets/user_avatar.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart';
 import 'package:flutter/material.dart';
+import 'package:kohera/core/services/sub_services/presence_service.dart';
 import 'package:kohera/core/utils/media_auth.dart';
 import 'package:matrix/matrix.dart';
 
@@ -10,18 +11,23 @@ import 'package:matrix/matrix.dart';
 ///
 /// Resolves the mxc:// [avatarUrl] asynchronously via [getThumbnailUri]
 /// and passes auth headers for authenticated media endpoints.
+///
+/// When [presence] and [userId] are both supplied, an opt-in status dot is
+/// overlaid on the bottom-right. Unknown presence renders no dot.
 class UserAvatar extends StatefulWidget {
   const UserAvatar({
     required this.client, super.key,
     this.avatarUrl,
     this.userId,
     this.size = 44,
+    this.presence,
   });
 
   final Client client;
   final Uri? avatarUrl;
   final String? userId;
   final double size;
+  final PresenceService? presence;
 
   @override
   State<UserAvatar> createState() => _UserAvatarState();
@@ -66,7 +72,7 @@ class _UserAvatarState extends State<UserAvatar> {
     final initial = _userInitial(widget.userId);
     final bgColor = _colorFromString(widget.userId ?? '', cs);
 
-    return ClipOval(
+    final avatar = ClipOval(
       child: SizedBox(
         width: widget.size,
         height: widget.size,
@@ -94,6 +100,30 @@ class _UserAvatarState extends State<UserAvatar> {
               ),
       ),
     );
+
+    final presence = widget.presence;
+    final userId = widget.userId;
+    if (presence == null || userId == null) return avatar;
+
+    return SizedBox(
+      width: widget.size,
+      height: widget.size,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          avatar,
+          Positioned(
+            right: 0,
+            bottom: 0,
+            child: _PresenceDot(
+              presence: presence,
+              userId: userId,
+              size: widget.size,
+            ),
+          ),
+        ],
+      ),
+    );
   }
 
   static String _userInitial(String? userId) {
@@ -116,6 +146,53 @@ class _UserAvatarState extends State<UserAvatar> {
     ];
     return palette[hash % palette.length];
   }
+}
+
+/// Status dot overlaid on [UserAvatar]. Rebuilds independently of the avatar
+/// when presence changes; renders nothing for unknown presence.
+class _PresenceDot extends StatelessWidget {
+  const _PresenceDot({
+    required this.presence,
+    required this.userId,
+    required this.size,
+  });
+
+  final PresenceService presence;
+  final String userId;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return ListenableBuilder(
+      listenable: presence,
+      builder: (context, _) {
+        final cached = presence.presenceFor(userId);
+        if (cached == null) return const SizedBox.shrink();
+        final (color, label) = _styleFor(cached.presence, cs);
+        final diameter = size * 0.3;
+        return Semantics(
+          label: label,
+          child: Container(
+            width: diameter,
+            height: diameter,
+            decoration: BoxDecoration(
+              color: color,
+              shape: BoxShape.circle,
+              border: Border.all(color: cs.surface, width: size * 0.05),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  static (Color, String) _styleFor(PresenceType type, ColorScheme cs) =>
+      switch (type) {
+        PresenceType.online => (cs.primary, 'Online'),
+        PresenceType.unavailable => (cs.tertiary, 'Away'),
+        PresenceType.offline => (cs.outline, 'Offline'),
+      };
 }
 
 class _Fallback extends StatelessWidget {

--- a/test/widgets/user_avatar_test.dart
+++ b/test/widgets/user_avatar_test.dart
@@ -1,8 +1,11 @@
 ﻿import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/services/sub_services/presence_service.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
 import 'package:matrix/matrix.dart';
+import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
 
 @GenerateNiceMocks([
   MockSpec<Client>(),
@@ -112,6 +115,134 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(ClipOval), findsOneWidget);
+    });
+  });
+
+  group('UserAvatar presence dot', () {
+    late CachedStreamController<CachedPresence> presenceController;
+    late PresenceService presenceService;
+
+    setUp(() {
+      presenceController = CachedStreamController<CachedPresence>();
+      when(mockClient.onPresenceChanged).thenReturn(presenceController);
+      presenceService = PresenceService(client: mockClient);
+    });
+
+    tearDown(() => presenceService.dispose());
+
+    Widget buildWithPresence(
+      String userId, {
+      ThemeData? theme,
+      double size = 44,
+    }) {
+      return MaterialApp(
+        theme: theme ?? ThemeData(splashFactory: InkRipple.splashFactory),
+        home: Scaffold(
+          body: UserAvatar(
+            client: mockClient,
+            userId: userId,
+            presence: presenceService,
+            size: size,
+          ),
+        ),
+      );
+    }
+
+    void emit(String userId, PresenceType type) =>
+        presenceController.add(CachedPresence(type, null, null, true, userId));
+
+    ThemeData seeded({Brightness brightness = Brightness.light}) => ThemeData(
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: Colors.indigo,
+            brightness: brightness,
+          ),
+        );
+
+    Container dotFor(WidgetTester tester, String label) =>
+        tester.widget<Container>(
+          find.descendant(
+            of: find.bySemanticsLabel(label),
+            matching: find.byType(Container),
+          ),
+        );
+
+    testWidgets('unknown presence renders no dot and no layout shift',
+        (tester) async {
+      await tester.pumpWidget(buildWithPresence('@alice:example.com'));
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsLabel('Online'), findsNothing);
+      expect(find.bySemanticsLabel('Away'), findsNothing);
+      expect(find.bySemanticsLabel('Offline'), findsNothing);
+      expect(tester.getSize(find.byType(UserAvatar)), const Size(44, 44));
+    });
+
+    testWidgets('online renders dot labelled Online with primary color',
+        (tester) async {
+      final theme = seeded();
+      emit('@alice:example.com', PresenceType.online);
+      await tester.pumpWidget(
+        buildWithPresence('@alice:example.com', theme: theme),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsLabel('Online'), findsOneWidget);
+      expect(
+        (dotFor(tester, 'Online').decoration! as BoxDecoration).color,
+        theme.colorScheme.primary,
+      );
+    });
+
+    testWidgets('away maps to tertiary and offline to outline, live',
+        (tester) async {
+      final theme = seeded();
+      emit('@bob:example.com', PresenceType.unavailable);
+      await tester.pumpWidget(
+        buildWithPresence('@bob:example.com', theme: theme),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsLabel('Away'), findsOneWidget);
+      expect(
+        (dotFor(tester, 'Away').decoration! as BoxDecoration).color,
+        theme.colorScheme.tertiary,
+      );
+
+      emit('@bob:example.com', PresenceType.offline);
+      await tester.pumpAndSettle();
+
+      expect(find.bySemanticsLabel('Offline'), findsOneWidget);
+      expect(
+        (dotFor(tester, 'Offline').decoration! as BoxDecoration).color,
+        theme.colorScheme.outline,
+      );
+    });
+
+    testWidgets('dot is sized relative to avatar size', (tester) async {
+      emit('@alice:example.com', PresenceType.online);
+      await tester.pumpWidget(buildWithPresence('@alice:example.com', size: 80));
+      await tester.pumpAndSettle();
+
+      final dotFinder = find.descendant(
+        of: find.bySemanticsLabel('Online'),
+        matching: find.byType(Container),
+      );
+      expect(tester.getSize(dotFinder).width, closeTo(80 * 0.3, 0.5));
+    });
+
+    testWidgets('colors come from the active scheme in dark theme',
+        (tester) async {
+      final dark = seeded(brightness: Brightness.dark);
+      emit('@alice:example.com', PresenceType.online);
+      await tester.pumpWidget(
+        buildWithPresence('@alice:example.com', theme: dark),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        (dotFor(tester, 'Online').decoration! as BoxDecoration).color,
+        dark.colorScheme.primary,
+      );
     });
   });
 }


### PR DESCRIPTION
Part of the presence epic #523. Closes #550. Builds on #549 (service layer).

Adds a reusable presence indicator (status dot) to the shared `UserAvatar`, with a clean "unknown = no dot" default. No feature surfaces are wired up here — that's #551.

## What
- Opt-in `PresenceService? presence` parameter. When `presence` **and** `userId` are both supplied, a status dot is overlaid bottom-right. All existing call sites are unaffected (param defaults to null → identical render/structure).
- `_PresenceDot` reads `PresenceService.presenceFor(userId)` inside a `ListenableBuilder`, so presence updates repaint **only the dot subtree** — never the avatar (its async thumbnail resolution stays put).
- **Unknown → renders nothing.** No dot, no layout shift (the dot is `Positioned` in a `Stack` and collapses to `SizedBox.shrink`; the outer box stays `size×size`). Unknown is the common case on cold start, so it must look intentional.
- States map to **ColorScheme tokens** (Material You, theme-adaptive), not hard-coded colors:
  - online → `primary`
  - away (`unavailable`) → `tertiary`
  - offline → `outline`
  - ring/border → `surface`
- Dot diameter is `size * 0.3`; carries a `Semantics(label: ...)` for accessibility.

## Tests
`test/widgets/user_avatar_test.dart` adds a `presence dot` group:
- unknown → no dot, no layout shift
- online → dot labelled "Online", color = `colorScheme.primary`
- live transition away (`tertiary`) → offline (`outline`)
- dot sized relative to avatar size
- colors come from the active scheme in dark theme

`flutter analyze` clean; full avatar suite (12 tests) passes.

## Acceptance criteria
- [x] `UserAvatar` renders a correctly positioned, scaled status dot for online/away/offline.
- [x] Unknown presence renders no dot and no layout shift.
- [x] Colors come from the active `ColorScheme`; verified in light and dark themes.
- [x] Widget test covers each state including unknown, and the semantic label.

## Out of scope
- Wiring into member lists / tiles / app bar / switcher (#551).
- `last-seen` text rendering (belongs with the surfaces that show it, #551).