### PR TITLE
fix: keep sticker & emoji pack routes full-screen on narrow layout

### DIFF
--- a/lib/features/home/widgets/narrow_layout.dart
+++ b/lib/features/home/widgets/narrow_layout.dart
@@ -61,6 +61,8 @@ class _NarrowLayoutState extends State<NarrowLayout> {
         name == Routes.settingsDevices ||
         name == Routes.settingsVoiceVideo ||
         name == Routes.settingsRecoveryKey ||
+        name == Routes.settingsStickerPacks ||
+        name == Routes.settingsEmojiGgBrowse ||
         name == Routes.spaceDetails ||
         name == Routes.whatsNew;
   }


### PR DESCRIPTION
Tapping the sticker & emoji packs tile in settings pushed the route but
NarrowLayout._isHideChromeRoute did not recognize it, so the layout fell
back to the bottom-nav IndexedStack and _tabForRoute defaulted the unknown
route to the chats tab, navigating the user to chat instead of the picker.

Add settingsStickerPacks and settingsEmojiGgBrowse to the hide-chrome route
list, matching how WideLayout already handles them.