### PR TITLE
feat(#551): roll out presence indicators across UI surfaces

### DIFF
--- a/lib/features/chat/widgets/chat_app_bar.dart
+++ b/lib/features/chat/widgets/chat_app_bar.dart
@@ -4,10 +4,13 @@ import 'package:flutter/material.dart';
 import 'package:kohera/core/routing/nav_helper.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/call_service.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/core/services/sub_services/presence_service.dart';
 import 'package:kohera/features/calling/models/incoming_call_info.dart' as model;
 import 'package:kohera/features/calling/services/call_navigator.dart';
 import 'package:kohera/features/chat/widgets/pinned_messages_popup.dart';
 import 'package:kohera/features/home/screens/home_shell.dart';
+import 'package:kohera/shared/widgets/presence_dot.dart';
 import 'package:kohera/shared/widgets/room_avatar.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
@@ -40,6 +43,9 @@ class ChatAppBar extends StatelessWidget implements PreferredSizeWidget {
         MediaQuery.sizeOf(context).width < HomeShell.wideBreakpoint;
     final effectiveOnBack =
         onBack ?? (isNarrow ? () => context.popOrGo(Routes.home) : null);
+    final dmUserId = room.isDirectChat ? room.directChatMatrixID : null;
+    final presence =
+        dmUserId != null ? context.read<MatrixService>().presence : null;
 
     return AppBar(
       leading: effectiveOnBack != null
@@ -56,7 +62,12 @@ class ChatAppBar extends StatelessWidget implements PreferredSizeWidget {
           return Row(
             children: [
               if (showAvatar) ...[
-                RoomAvatarWidget(room: room, size: 34),
+                PresenceOverlay(
+                  size: 34,
+                  presence: presence,
+                  userId: dmUserId,
+                  child: RoomAvatarWidget(room: room, size: 34),
+                ),
                 const SizedBox(width: 12),
               ],
               Expanded(
@@ -69,8 +80,10 @@ class ChatAppBar extends StatelessWidget implements PreferredSizeWidget {
                       overflow: TextOverflow.ellipsis,
                       style: tt.titleMedium,
                     ),
-                    Text(
-                      _memberCountLabel(room),
+                    _HeaderSubtitle(
+                      room: room,
+                      presence: presence,
+                      userId: dmUserId,
                       style: tt.bodyMedium?.copyWith(fontSize: 11),
                     ),
                   ],
@@ -187,12 +200,77 @@ class ChatAppBar extends StatelessWidget implements PreferredSizeWidget {
     );
   }
 
-  static String _memberCountLabel(Room room) {
-    final count = room.summary.mJoinedMemberCount ?? 0;
-    if (count == 0) return '';
-    if (count == 1) return '1 member';
-    return '$count members';
+}
+
+/// App bar subtitle: the counterpart's presence for a DM, falling back to the
+/// member count when presence is unknown or the room is not a direct chat.
+class _HeaderSubtitle extends StatelessWidget {
+  const _HeaderSubtitle({
+    required this.room,
+    required this.style,
+    this.presence,
+    this.userId,
+  });
+
+  final Room room;
+  final TextStyle? style;
+  final PresenceService? presence;
+  final String? userId;
+
+  @override
+  Widget build(BuildContext context) {
+    final presence = this.presence;
+    final userId = this.userId;
+    if (presence == null || userId == null) {
+      return Text(_memberCountLabel(room), style: style);
+    }
+    return ListenableBuilder(
+      listenable: presence,
+      builder: (context, _) {
+        final label =
+            _presenceLabel(presence.presenceFor(userId)) ?? _memberCountLabel(room);
+        return Text(
+          label,
+          style: style,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        );
+      },
+    );
   }
+}
+
+String _memberCountLabel(Room room) {
+  final count = room.summary.mJoinedMemberCount ?? 0;
+  if (count == 0) return '';
+  if (count == 1) return '1 member';
+  return '$count members';
+}
+
+/// Human-readable presence line for a DM counterpart, or null when unknown.
+/// A "last seen" suffix is appended only when the server provided a timestamp.
+String? _presenceLabel(CachedPresence? presence) {
+  if (presence == null) return null;
+  final lastSeen = presence.lastActiveTimestamp;
+  switch (presence.presence) {
+    case PresenceType.online:
+      return 'Online';
+    case PresenceType.unavailable:
+      return lastSeen != null ? 'Away · last seen ${_ago(lastSeen)}' : 'Away';
+    case PresenceType.offline:
+      return lastSeen != null
+          ? 'Offline · last seen ${_ago(lastSeen)}'
+          : 'Offline';
+  }
+}
+
+String _ago(DateTime ts) {
+  final diff = DateTime.now().difference(ts);
+  if (diff.inMinutes < 1) return 'just now';
+  if (diff.inHours < 1) return '${diff.inMinutes}m ago';
+  if (diff.inDays < 1) return '${diff.inHours}h ago';
+  if (diff.inDays < 30) return '${diff.inDays}d ago';
+  return '${(diff.inDays / 30).floor()}mo ago';
 }
 
 class _CallButton extends StatefulWidget {

--- a/lib/features/rooms/widgets/room_members_section.dart
+++ b/lib/features/rooms/widgets/room_members_section.dart
@@ -5,10 +5,11 @@ import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/core/services/sub_services/presence_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
-import 'package:kohera/core/utils/sender_color.dart';
 import 'package:kohera/features/rooms/models/room_role.dart';
 import 'package:kohera/features/rooms/services/power_level_service.dart';
+import 'package:kohera/shared/widgets/user_avatar.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 
@@ -216,19 +217,12 @@ class _MemberTileState extends State<_MemberTile> {
 
     return ListTile(
       dense: true,
-      leading: CircleAvatar(
-        radius: 16,
-        backgroundColor: senderColor(widget.user.id, cs),
-        child: Text(
-          displayName.isNotEmpty ? displayName[0].toUpperCase() : '?',
-          style: TextStyle(
-            fontSize: 12,
-            fontWeight: FontWeight.w600,
-            color: ThemeData.estimateBrightnessForColor(senderColor(widget.user.id, cs)) == Brightness.dark
-                ? Colors.white
-                : Colors.black,
-          ),
-        ),
+      leading: UserAvatar(
+        client: widget.room.client,
+        userId: widget.user.id,
+        avatarUrl: widget.user.avatarUrl,
+        presence: context.read<MatrixService>().presence,
+        size: 32,
       ),
       title: Text(
         displayName,
@@ -285,6 +279,7 @@ class _MemberTileState extends State<_MemberTile> {
       builder: (ctx) => _MemberSheetDialog(
         user: widget.user,
         room: widget.room,
+        presence: matrix.presence,
         ownLevel: ownLevel,
         isMe: isMe,
         onStartDm: !isMe
@@ -330,6 +325,7 @@ class _MemberSheetDialog extends StatefulWidget {
   const _MemberSheetDialog({
     required this.user,
     required this.room,
+    required this.presence,
     required this.ownLevel,
     required this.isMe,
     this.onStartDm,
@@ -337,6 +333,7 @@ class _MemberSheetDialog extends StatefulWidget {
 
   final User user;
   final Room room;
+  final PresenceService presence;
   final int ownLevel;
   final bool isMe;
   final Future<void> Function()? onStartDm;
@@ -600,12 +597,6 @@ class _MemberSheetDialogState extends State<_MemberSheetDialog> {
     final displayName = user.displayName ?? user.id;
     final isBanned = user.membership == Membership.ban;
 
-    final avatarColor = senderColor(user.id, cs);
-    final avatarFg =
-        ThemeData.estimateBrightnessForColor(avatarColor) == Brightness.dark
-            ? Colors.white
-            : Colors.black;
-
     final canChangeRole = !widget.isMe &&
         room.canChangePowerLevel &&
         powerLevel < widget.ownLevel;
@@ -623,17 +614,12 @@ class _MemberSheetDialogState extends State<_MemberSheetDialog> {
       titlePadding: const EdgeInsets.fromLTRB(24, 24, 24, 12),
       title: Column(
         children: [
-          CircleAvatar(
-            radius: 32,
-            backgroundColor: avatarColor,
-            child: Text(
-              displayName.isNotEmpty ? displayName[0].toUpperCase() : '?',
-              style: TextStyle(
-                fontSize: 24,
-                fontWeight: FontWeight.w600,
-                color: avatarFg,
-              ),
-            ),
+          UserAvatar(
+            client: room.client,
+            userId: user.id,
+            avatarUrl: user.avatarUrl,
+            presence: widget.presence,
+            size: 64,
           ),
           const SizedBox(height: 12),
           Text(

--- a/lib/features/rooms/widgets/room_tile.dart
+++ b/lib/features/rooms/widgets/room_tile.dart
@@ -18,6 +18,7 @@ import 'package:kohera/features/calling/widgets/call_state_views.dart'
 import 'package:kohera/features/chat/widgets/typing_indicator.dart' show TypingIndicator;
 import 'package:kohera/features/rooms/widgets/room_context_menu.dart';
 import 'package:kohera/features/spaces/widgets/space_reparent_controller.dart';
+import 'package:kohera/shared/widgets/presence_dot.dart';
 import 'package:kohera/shared/widgets/room_avatar.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
 import 'package:matrix/matrix.dart';
@@ -94,6 +95,7 @@ class _RoomTileState extends State<RoomTile> {
     final unread = effectiveUnreadCount(room, prefs);
     final lastEvent = room.lastEvent;
     final hasMenu = widget.hasContextMenu;
+    final dmUserId = room.isDirectChat ? room.directChatMatrixID : null;
 
     final isUserInThisCall = callService.activeCallRoomId == room.id &&
         callService.callState == KoheraCallState.connected;
@@ -158,7 +160,14 @@ class _RoomTileState extends State<RoomTile> {
                 Row(
                   children: [
                     // Avatar
-                    RoomAvatarWidget(room: room, size: 48),
+                    PresenceOverlay(
+                      size: 48,
+                      presence: dmUserId != null
+                          ? context.read<MatrixService>().presence
+                          : null,
+                      userId: dmUserId,
+                      child: RoomAvatarWidget(room: room, size: 48),
+                    ),
 
                     const SizedBox(width: 12),
 

--- a/lib/features/settings/widgets/account_switcher.dart
+++ b/lib/features/settings/widgets/account_switcher.dart
@@ -29,6 +29,7 @@ class AccountSwitcher extends StatelessWidget {
                   leading: UserAvatar(
                     client: manager.services[i].client,
                     userId: manager.services[i].client.userID,
+                    presence: manager.services[i].presence,
                     size: 36,
                   ),
                   title: Text(

--- a/lib/shared/widgets/presence_dot.dart
+++ b/lib/shared/widgets/presence_dot.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:kohera/core/services/sub_services/presence_service.dart';
+import 'package:matrix/matrix.dart';
+
+/// A presence status dot. Rebuilds independently when [presence] changes and
+/// renders nothing (no layout shift) for unknown presence.
+///
+/// [size] is the diameter of the avatar it decorates; the dot is scaled
+/// relative to it. Colours come from the active [ColorScheme] (Material You).
+class PresenceDot extends StatelessWidget {
+  const PresenceDot({
+    required this.presence,
+    required this.userId,
+    required this.size,
+    super.key,
+  });
+
+  final PresenceService presence;
+  final String userId;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return ListenableBuilder(
+      listenable: presence,
+      builder: (context, _) {
+        final cached = presence.presenceFor(userId);
+        if (cached == null) return const SizedBox.shrink();
+        final (color, label) = _styleFor(cached.presence, cs);
+        final diameter = size * 0.3;
+        return Semantics(
+          label: label,
+          child: Container(
+            width: diameter,
+            height: diameter,
+            decoration: BoxDecoration(
+              color: color,
+              shape: BoxShape.circle,
+              border: Border.all(color: cs.surface, width: size * 0.05),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  static (Color, String) _styleFor(PresenceType type, ColorScheme cs) =>
+      switch (type) {
+        PresenceType.online => (cs.primary, 'Online'),
+        PresenceType.unavailable => (cs.tertiary, 'Away'),
+        PresenceType.offline => (cs.outline, 'Offline'),
+      };
+}
+
+/// Overlays a [PresenceDot] on the bottom-right of [child]. When [presence] or
+/// [userId] is null the child is returned unchanged (no dot, no layout shift).
+class PresenceOverlay extends StatelessWidget {
+  const PresenceOverlay({
+    required this.size,
+    required this.child,
+    this.presence,
+    this.userId,
+    super.key,
+  });
+
+  final double size;
+  final Widget child;
+  final PresenceService? presence;
+  final String? userId;
+
+  @override
+  Widget build(BuildContext context) {
+    final presence = this.presence;
+    final userId = this.userId;
+    if (presence == null || userId == null) return child;
+
+    return SizedBox(
+      width: size,
+      height: size,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          child,
+          Positioned(
+            right: 0,
+            bottom: 0,
+            child: PresenceDot(
+              presence: presence,
+              userId: userId,
+              size: size,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/user_avatar.dart
+++ b/lib/shared/widgets/user_avatar.dart
@@ -5,6 +5,7 @@ import 'package:cached_network_image_platform_interface/cached_network_image_pla
 import 'package:flutter/material.dart';
 import 'package:kohera/core/services/sub_services/presence_service.dart';
 import 'package:kohera/core/utils/media_auth.dart';
+import 'package:kohera/shared/widgets/presence_dot.dart';
 import 'package:matrix/matrix.dart';
 
 /// Displays a user's Matrix avatar with a colored-initial fallback.
@@ -101,28 +102,11 @@ class _UserAvatarState extends State<UserAvatar> {
       ),
     );
 
-    final presence = widget.presence;
-    final userId = widget.userId;
-    if (presence == null || userId == null) return avatar;
-
-    return SizedBox(
-      width: widget.size,
-      height: widget.size,
-      child: Stack(
-        clipBehavior: Clip.none,
-        children: [
-          avatar,
-          Positioned(
-            right: 0,
-            bottom: 0,
-            child: _PresenceDot(
-              presence: presence,
-              userId: userId,
-              size: widget.size,
-            ),
-          ),
-        ],
-      ),
+    return PresenceOverlay(
+      size: widget.size,
+      presence: widget.presence,
+      userId: widget.userId,
+      child: avatar,
     );
   }
 
@@ -146,53 +130,6 @@ class _UserAvatarState extends State<UserAvatar> {
     ];
     return palette[hash % palette.length];
   }
-}
-
-/// Status dot overlaid on [UserAvatar]. Rebuilds independently of the avatar
-/// when presence changes; renders nothing for unknown presence.
-class _PresenceDot extends StatelessWidget {
-  const _PresenceDot({
-    required this.presence,
-    required this.userId,
-    required this.size,
-  });
-
-  final PresenceService presence;
-  final String userId;
-  final double size;
-
-  @override
-  Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    return ListenableBuilder(
-      listenable: presence,
-      builder: (context, _) {
-        final cached = presence.presenceFor(userId);
-        if (cached == null) return const SizedBox.shrink();
-        final (color, label) = _styleFor(cached.presence, cs);
-        final diameter = size * 0.3;
-        return Semantics(
-          label: label,
-          child: Container(
-            width: diameter,
-            height: diameter,
-            decoration: BoxDecoration(
-              color: color,
-              shape: BoxShape.circle,
-              border: Border.all(color: cs.surface, width: size * 0.05),
-            ),
-          ),
-        );
-      },
-    );
-  }
-
-  static (Color, String) _styleFor(PresenceType type, ColorScheme cs) =>
-      switch (type) {
-        PresenceType.online => (cs.primary, 'Online'),
-        PresenceType.unavailable => (cs.tertiary, 'Away'),
-        PresenceType.offline => (cs.outline, 'Offline'),
-      };
 }
 
 class _Fallback extends StatelessWidget {

--- a/test/widgets/chat_app_bar_test.dart
+++ b/test/widgets/chat_app_bar_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/services/call_service.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/core/services/sub_services/presence_service.dart';
+import 'package:kohera/features/chat/widgets/chat_app_bar.dart';
+import 'package:matrix/matrix.dart';
+import 'package:matrix/src/utils/cached_stream_controller.dart';
+import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
+
+import 'room_tile_test.mocks.dart';
+
+void main() {
+  late MockMatrixService mockMatrix;
+  late MockRoom mockRoom;
+  late MockClient mockClient;
+  late MockCallService mockCallService;
+  late CachedStreamController<CachedPresence> presenceController;
+
+  setUp(() {
+    mockMatrix = MockMatrixService();
+    mockRoom = MockRoom();
+    mockClient = MockClient();
+    mockCallService = MockCallService();
+    presenceController = CachedStreamController<CachedPresence>();
+
+    when(mockMatrix.client).thenReturn(mockClient);
+    when(mockClient.onPresenceChanged).thenReturn(presenceController);
+    when(mockMatrix.presence).thenReturn(PresenceService(client: mockClient));
+
+    when(mockRoom.client).thenReturn(mockClient);
+    when(mockRoom.id).thenReturn('!room:example.com');
+    when(mockRoom.getLocalizedDisplayname()).thenReturn('Bob');
+    when(mockRoom.pinnedEventIds).thenReturn([]);
+    when(mockRoom.avatar).thenReturn(null);
+    when(mockRoom.summary).thenReturn(RoomSummary.fromJson({
+      'm.joined_member_count': 3,
+    }),);
+    when(mockRoom.isDirectChat).thenReturn(false);
+    when(mockRoom.directChatMatrixID).thenReturn(null);
+
+    when(mockCallService.isCallingAvailable).thenReturn(false);
+  });
+
+  Widget build() => MultiProvider(
+        providers: [
+          ChangeNotifierProvider<MatrixService>.value(value: mockMatrix),
+          ChangeNotifierProvider<CallService>.value(value: mockCallService),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            appBar: ChatAppBar(room: mockRoom, onSearch: () {}),
+          ),
+        ),
+      );
+
+  testWidgets('group room shows member count subtitle', (tester) async {
+    await tester.pumpWidget(build());
+    await tester.pumpAndSettle();
+
+    expect(find.text('3 members'), findsOneWidget);
+  });
+
+  testWidgets('DM shows counterpart presence as subtitle', (tester) async {
+    when(mockRoom.isDirectChat).thenReturn(true);
+    when(mockRoom.directChatMatrixID).thenReturn('@bob:example.com');
+
+    await tester.pumpWidget(build());
+    await tester.pumpAndSettle();
+
+    presenceController.add(
+      CachedPresence(PresenceType.online, null, null, true, '@bob:example.com'),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Online'), findsOneWidget);
+    expect(find.text('3 members'), findsNothing);
+  });
+
+  testWidgets('DM offline shows last-seen when timestamp provided',
+      (tester) async {
+    when(mockRoom.isDirectChat).thenReturn(true);
+    when(mockRoom.directChatMatrixID).thenReturn('@bob:example.com');
+
+    await tester.pumpWidget(build());
+    await tester.pumpAndSettle();
+
+    presenceController.add(
+      CachedPresence(PresenceType.offline, 7200000, null, false, '@bob:example.com'),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Offline · last seen'), findsOneWidget);
+  });
+
+  testWidgets('DM with unknown presence falls back to member count',
+      (tester) async {
+    when(mockRoom.isDirectChat).thenReturn(true);
+    when(mockRoom.directChatMatrixID).thenReturn('@bob:example.com');
+
+    await tester.pumpWidget(build());
+    await tester.pumpAndSettle();
+
+    expect(find.text('3 members'), findsOneWidget);
+  });
+}

--- a/test/widgets/room_members_section_test.dart
+++ b/test/widgets/room_members_section_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/core/services/sub_services/presence_service.dart';
 import 'package:kohera/features/rooms/models/room_role.dart';
 import 'package:kohera/features/rooms/widgets/room_members_section.dart';
 import 'package:matrix/matrix.dart';
@@ -41,6 +42,10 @@ void main() {
 
     when(mockMatrixService.client).thenReturn(mockClient);
     when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
+    when(mockClient.onPresenceChanged)
+        .thenReturn(CachedStreamController<CachedPresence>());
+    when(mockMatrixService.presence)
+        .thenReturn(PresenceService(client: mockClient));
     when(mockRoom.id).thenReturn('!room:example.com');
     when(mockRoom.client).thenReturn(mockClient);
     when(mockRoom.summary).thenReturn(RoomSummary.fromJson({

--- a/test/widgets/room_tile_test.dart
+++ b/test/widgets/room_tile_test.dart
@@ -5,8 +5,11 @@ import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/call_service.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/preferences_service.dart';
+import 'package:kohera/core/services/sub_services/presence_service.dart';
 import 'package:kohera/features/rooms/widgets/room_tile.dart';
+import 'package:kohera/shared/widgets/presence_dot.dart';
 import 'package:matrix/matrix.dart';
+import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
@@ -592,6 +595,64 @@ void main() {
       final tooltips = tester.widgetList<Tooltip>(find.byType(Tooltip))
           .where((t) => t.message == 'User 9');
       expect(tooltips.length, 1);
+    });
+  });
+
+  // ── Presence dot (DM only) ─────────────────────────────────
+
+  group('Presence dot', () {
+    late CachedStreamController<CachedPresence> presenceController;
+
+    void enablePresence() {
+      presenceController = CachedStreamController<CachedPresence>();
+      when(mockClient.onPresenceChanged).thenReturn(presenceController);
+      when(mockMatrix.presence)
+          .thenReturn(PresenceService(client: mockClient));
+    }
+
+    Finder dot() => find.descendant(
+          of: find.byType(PresenceDot),
+          matching: find.byType(Container),
+        );
+
+    testWidgets('shows counterpart dot for a direct chat', (tester) async {
+      enablePresence();
+      when(mockRoom.isDirectChat).thenReturn(true);
+      when(mockRoom.directChatMatrixID).thenReturn('@bob:example.com');
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      presenceController.add(
+        CachedPresence(PresenceType.online, null, null, true, '@bob:example.com'),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PresenceDot), findsOneWidget);
+      expect(dot(), findsOneWidget);
+    });
+
+    testWidgets('shows no presence overlay for a group room', (tester) async {
+      enablePresence();
+      when(mockRoom.isDirectChat).thenReturn(false);
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PresenceDot), findsNothing);
+    });
+
+    testWidgets('direct chat with unknown presence shows no dot',
+        (tester) async {
+      enablePresence();
+      when(mockRoom.isDirectChat).thenReturn(true);
+      when(mockRoom.directChatMatrixID).thenReturn('@bob:example.com');
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PresenceDot), findsOneWidget);
+      expect(dot(), findsNothing);
     });
   });
 }


### PR DESCRIPTION
Part of the presence epic #523. Closes #551. Builds on #549 (service layer) and #550 (UserAvatar dot).

Surfaces presence in the user-facing places listed in the epic. Since these call sites don't share one avatar widget, this slice includes a small refactor plus a reusable overlay.

## Reusable overlay
- Extracted the presence dot into a public `PresenceDot` (`lib/shared/widgets/presence_dot.dart`) plus a `PresenceOverlay` that stacks a dot on the bottom-right of **any** child avatar. This lets surfaces built on `RoomAvatarWidget` (DM tile, app bar) show presence without switching widgets. `UserAvatar` now delegates to `PresenceOverlay` (no behaviour change; #550 tests still green).

## Surfaces
- **Member list** (`room_members_section.dart`) — refactored the raw `CircleAvatar`s in `_MemberTile` (32px) and `_MemberSheetDialog` (64px) onto `UserAvatar` with a presence dot. Role badges, search, and expand/collapse preserved. The sheet receives the `PresenceService` from the tile (rather than reading it via context) so it works when shown from the root navigator.
- **DM room tiles** (`room_tile.dart`) — overlay the counterpart's dot via `room.directChatMatrixID`; group rooms get no overlay.
- **Chat app bar** (`chat_app_bar.dart`) — counterpart's dot on the header avatar, and the DM subtitle now reflects presence (`Online` / `Away` / `Offline`), appending `· last seen …` **only** when the server provided a timestamp, and falling back to the member count when presence is unknown. Group rooms keep the member count.
- **Account switcher** (`account_switcher.dart`) — each account shows its **own** presence via that account's independent `PresenceService`.

## Churn / thrash
Dots update live through `ListenableBuilder` on the `PresenceService` — only the small dot subtree repaints, and member lists are **not** reloaded on presence changes. So the large-room reload thrash the issue warns about is inherently avoided (the 300ms debounce still guards the membership reload it already governed).

## Tests
- `room_tile_test.dart` — DM renders a dot (online), group renders no overlay, DM with unknown presence renders the overlay but no dot.
- `chat_app_bar_test.dart` (new) — group shows member count; DM shows `Online`; DM offline shows `Offline · last seen …`; DM unknown falls back to member count.
- `room_members_section_test.dart` — stubbed presence; existing badge/search/expand/role/kick/ban tests pass through the `UserAvatar` refactor unchanged.
- Full suite green (1972 tests). `flutter analyze` clean.

Note: `*.mocks.dart` are regenerated by CI (`build_runner` runs before `flutter test`), so the regenerated mock churn from #549 adding `MatrixService.presence` is intentionally not committed here.

## Acceptance criteria
- [x] Other users' presence appears in member lists and DM tiles, updating live from sync.
- [x] DM chat app bar reflects the counterpart's presence; last-seen shown only when the server provides it, otherwise omitted.
- [x] Account switcher shows each account's own presence.
- [x] All surfaces degrade to no-indicator when presence is unknown/disabled — no errors, no layout shift.
- [x] Member-list refactor onto `UserAvatar` keeps existing behaviour (role badges, search, expand) intact; covered by tests.