### PR TITLE
chore: add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Report something that is broken or behaving incorrectly
+title: "Short summary of the bug"
+labels: bug
+---
+
+## What happened
+
+<!-- The incorrect behaviour you observed. -->
+
+## Expected behaviour
+
+<!-- What should have happened instead. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Environment
+
+- Platform: <!-- Linux / macOS / Windows / web / Android / iOS -->
+- App version / commit:
+- Homeserver (if relevant):
+
+## Logs / screenshots
+
+<!-- Paste relevant `[Kohera]` logs or attach screenshots. Redact tokens/IDs. -->
+
+## Notes
+
+<!-- Suspected cause, related code (file:line), or anything else useful. Optional. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,34 @@
+---
+name: Epic
+about: A large piece of work delivered as several dependent child issues
+title: "[Epic] Short summary"
+labels: epic
+---
+
+## Epic
+
+<!-- The end-to-end outcome and why it matters. Note whether this is app-layer
+     wiring or new protocol/infra work. -->
+
+## Child issues (in dependency order)
+
+<!-- List the slices, each shippable on its own, in the order they unblock. -->
+
+1. **#NNN — <slice name> (foundation)** — <one line>.
+2. **#NNN — <slice name>** — <one line>. Depends on #NNN.
+3. **#NNN — <slice name>** — <one line>. Depends on #NNN.
+
+## Key design decisions (apply to all slices)
+
+<!-- Cross-cutting choices, constraints, and SDK/API facts that every slice
+     must respect. -->
+
+-
+
+## Epic acceptance criteria
+
+- [ ]
+
+## Out of scope (backlog)
+
+-

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature / enhancement
+about: Propose a new capability or an improvement to an existing one
+title: "Short, action-oriented summary"
+labels: enhancement
+---
+
+## Goal
+
+<!-- What should exist after this is done, and why it matters. -->
+
+## Scope
+
+<!-- The concrete work. Cite files/areas (e.g. lib/features/...) and SDK APIs where known. -->
+
+-
+
+## Out of scope
+
+<!-- What this issue deliberately does NOT cover (link follow-ups). -->
+
+-
+
+## Acceptance criteria
+
+<!-- Testable, checkable outcomes. -->
+
+- [ ]
+
+## Notes
+
+<!-- Design decisions, constraints, links to docs/SDK. Optional. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+<!--
+  Title: use a Conventional Commits subject, e.g.
+    feat(#123): short description
+  Allowed types: feat, fix, perf, refactor, style, docs, test, chore, ci, build, revert
+-->
+
+## Summary
+
+<!-- What does this PR do and why? One or two sentences. -->
+
+## Changes
+
+<!-- The notable changes, as bullets. Reference files/areas where useful. -->
+
+-
+
+## Testing
+
+<!-- How was this verified? Name the suites/files run. -->
+
+- [ ] `flutter analyze` is clean
+- [ ] `flutter test` passes (run `dart run build_runner build --delete-conflicting-outputs` first if mocks changed)
+
+## Screenshots / recordings
+
+<!-- For UI changes, before/after. Delete this section if not applicable. -->
+
+## Linked issues
+
+<!-- Use "Closes #N" for the issue this completes, and "Refs #N" for the epic. -->
+
+Closes #
+
+## Checklist
+
+- [ ] Follows the conventions in `CLAUDE.md` (logging prefix, no stray comments, commit prefixes)
+- [ ] Targets `master` (not another feature branch, unless this is an explicitly requested stacked PR)
+- [ ] Updated/added tests for the change

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,6 +33,8 @@ Closes #
 
 ## Checklist
 
-- [ ] Follows the conventions in `CLAUDE.md` (logging prefix, no stray comments, commit prefixes)
-- [ ] Targets `master` (not another feature branch, unless this is an explicitly requested stacked PR)
-- [ ] Updated/added tests for the change
+- [ ] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
+- [ ] Logs use the `debugPrint('[Kohera] ...')` prefix
+- [ ] No stray comments added (only `// ── Section ──` markers)
+- [ ] Tests added or updated to cover the change
+- [ ] Targets `master` (not another feature branch, unless an explicitly requested stacked PR)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,14 @@ See `agent_docs/architecture.md` for detailed architecture, routing, responsive 
 
 ## Conventions
 
-- **Commits:** `feat:`, `fix:`, `refactor:`, `style:`, `docs:`, `test:`, `chore:`
+- **Commits:** `feat:`, `fix:`, `refactor:`, `style:`, `docs:`, `test:`, `chore:`, `perf:`, `ci:`, `build:`, `revert:`. A commitlint CI check enforces this. In the commit body, avoid lines that start with `Word:` or contain inline `#123` refs — the parser treats them as footer trailers and fails the `footer-leading-blank` rule. Put issue refs only in the trailing footer (`Refs #123`, `Closes #123`) after a blank line.
 - **Logging:** `debugPrint('[Kohera] ...')` prefix for all log messages
 - **No comments** -- code should be self-descriptive. Section markers (`// ── Section Name ──────`) are the exception.
+
+## Issues and pull requests
+
+Always use the repository templates when filing issues or opening pull requests.
+
+- **Issues:** pick the matching template under `.github/ISSUE_TEMPLATE/` — `epic.md` for multi-slice work, `feature_request.md` for a feature/enhancement, `bug_report.md` for defects. Blank issues are disabled. Fill every section; keep the epic's child-issue list in dependency order and give each issue testable acceptance criteria.
+- **Pull requests:** follow `.github/PULL_REQUEST_TEMPLATE.md` — Summary, Changes, Testing, linked issues (`Closes #N` for the issue, `Refs #N` for the epic), and the checklist. When creating a PR via `gh pr create`, pass a body that mirrors that template's sections.
+- **Base branch:** target `master` unless a stacked PR is explicitly requested.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing to Kohera
+
+Thanks for contributing! Kohera is a Flutter Matrix chat client. This guide
+covers how to get set up, the conventions we follow, and how to file issues and
+open pull requests.
+
+## Getting started
+
+```bash
+flutter pub get                                           # Install dependencies
+dart run build_runner build --delete-conflicting-outputs  # Generate mocks
+flutter analyze                                           # Lint
+flutter test                                              # Run all tests
+flutter run -d linux                                      # Run on Linux
+```
+
+Run `build_runner` before `flutter test` whenever a test's `@GenerateNiceMocks`
+annotations change, or when you touch a class that mocks reference. CI
+regenerates mocks before running tests, so generated `*.mocks.dart` files do not
+need to be committed.
+
+## Project layout
+
+Feature-based under `lib/`: `core/` (services, routing, theme, utils),
+`features/` (auth, calling, chat, e2ee, home, notifications, rooms, settings,
+spaces), and `shared/widgets/`. State is managed with Provider
+(`ChangeNotifier`s) wired at the root; `MatrixService` wraps the `matrix` SDK
+client, with sub-services under `core/services/sub_services/`.
+
+See `agent_docs/architecture.md` for the detailed architecture and
+`docs/e2ee-flow.md` for the E2EE state machine.
+
+## Conventions
+
+- **Commits:** Conventional Commits, enforced by a commitlint CI check. Allowed
+  types: `feat`, `fix`, `perf`, `refactor`, `style`, `docs`, `test`, `chore`,
+  `ci`, `build`, `revert`. Reference the issue in the subject scope when it
+  helps, e.g. `feat(#123): add presence dot`.
+  - In the commit **body**, avoid lines that start with `Word:` and avoid inline
+    `#123` references — the commitlint parser treats them as footer trailers and
+    fails the `footer-leading-blank` rule. Put issue references only in a footer
+    after a blank line: `Refs #123`, `Closes #123`.
+- **Logging:** prefix every log with `[Kohera]`, e.g.
+  `debugPrint('[Kohera] ...')`.
+- **Comments:** code should be self-descriptive; do not add explanatory
+  comments. Section markers (`// ── Section name ──────`) are the only
+  exception.
+- **Tests:** add or update tests for every behavioural change. Keep
+  `flutter analyze` clean.
+
+## Filing issues
+
+Issues use templates in `.github/ISSUE_TEMPLATE/` (blank issues are disabled):
+
+- **Epic** — large work split into dependent child issues. List the slices in
+  dependency order; each slice should be independently shippable.
+- **Feature / enhancement** — fill Goal, Scope, Out of scope, and testable
+  Acceptance criteria.
+- **Bug report** — what happened, expected behaviour, steps to reproduce,
+  environment, and `[Kohera]` logs (redact tokens/IDs).
+
+## Pull requests
+
+- Branch from and target `master`. Do not base a PR on another feature branch
+  unless a stacked PR is explicitly requested.
+- Use a branch name like `feat/123-short-description` or
+  `fix/123-short-description`.
+- Fill out the pull request template (`.github/PULL_REQUEST_TEMPLATE.md`):
+  summary, changes, testing, linked issues (`Closes #N` for the issue, `Refs #N`
+  for the epic), and the checklist.
+- Before pushing: `flutter analyze` is clean and `flutter test` passes (run
+  `build_runner` first if mocks changed).
+- Keep PRs focused on one slice; open follow-ups for out-of-scope work.
+
+## Code review
+
+Reviews look for correctness, adherence to the conventions above, and test
+coverage. Address review comments with follow-up commits on the same branch;
+keep the history readable.


### PR DESCRIPTION
## Summary

Add GitHub issue and pull request templates so issues and PRs follow a consistent, reviewable structure, and require them via CLAUDE.md.

## Changes

- `.github/ISSUE_TEMPLATE/epic.md` — multi-slice epic (epic description, child issues in dependency order, key design decisions, acceptance criteria, out of scope).
- `.github/ISSUE_TEMPLATE/feature_request.md` — Goal / Scope / Out of scope / Acceptance criteria / Notes (mirrors the shape already used in this repo's issues).
- `.github/ISSUE_TEMPLATE/bug_report.md` — what happened / expected / repro / environment / logs.
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues so a template is always chosen.
- `.github/PULL_REQUEST_TEMPLATE.md` — summary, changes, testing, screenshots, linked issues, conventions checklist.
- `CLAUDE.md` — new "Issues and pull requests" section requiring the templates and targeting `master`; expanded the commit-type list and documented the commitlint `footer-leading-blank` pitfall.

## Testing

- [x] Docs/templates only — no code changes.
- [x] `flutter analyze` unaffected.

## Linked issues

N/A — tooling/docs.

## Checklist

- [x] Targets `master`