### PR TITLE
fix: prevent crash when switching accounts with a room open

### DIFF
--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -39,6 +39,7 @@ import 'package:provider/provider.dart';
 /// (which would reset the navigation stack and cause a visible flash).
 GoRouter buildRouter(ClientManager manager) {
   final refreshListenable = _ActiveMatrixListenable(manager);
+  final switchRedirector = AccountSwitchRedirector(manager.activeService);
   return GoRouter(
     refreshListenable: refreshListenable,
     initialLocation: '/',
@@ -50,6 +51,9 @@ GoRouter buildRouter(ClientManager manager) {
           loc.startsWith('/login') || loc.startsWith('/register');
       final onSetupRoute = loc == '/e2ee-setup';
       final onAddAccountRoute = loc.startsWith('/add-account');
+
+      final switchRedirect = switchRedirector.redirectFor(matrixService, loc);
+      if (switchRedirect != null) return switchRedirect;
 
       if (!loggedIn && !onAuthRoute) return '/login';
       if (loggedIn && onAuthRoute && !onAddAccountRoute) return '/';
@@ -377,6 +381,28 @@ class _ActiveMatrixListenable extends ChangeNotifier {
     _manager.removeListener(_onManagerChanged);
     _detach();
     super.dispose();
+  }
+}
+
+/// Detects active-account switches and falls back to the room list when a
+/// room route is still mounted.
+///
+/// Switching accounts swaps the per-account providers ([MatrixService] and
+/// friends) for different instances while the keyed `ChatScreen` subtree is
+/// still mounted and depends on them via `context.watch`. Reconciling the
+/// keyed subtree onto the swapped providers deactivates an `InheritedElement`
+/// before its dependent is released, tripping the framework's
+/// `_dependents.isEmpty` assertion. Redirecting `/rooms/...` to `/` tears the
+/// chat subtree down cleanly before the swap reconciles.
+class AccountSwitchRedirector {
+  AccountSwitchRedirector(this._active);
+
+  MatrixService _active;
+
+  String? redirectFor(MatrixService current, String location) {
+    if (identical(current, _active)) return null;
+    _active = current;
+    return location.startsWith('/rooms/') ? '/' : null;
   }
 }
 

--- a/lib/features/chat/widgets/audio_bubble.dart
+++ b/lib/features/chat/widgets/audio_bubble.dart
@@ -34,7 +34,7 @@ class _AudioBubbleState extends State<AudioBubble> {
   Duration _position = Duration.zero;
   Duration _duration = Duration.zero;
   late final List<double> _bars;
-  late final MediaPlaybackService _playbackService;
+  late MediaPlaybackService _playbackService;
   final List<StreamSubscription<dynamic>> _subs = [];
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,6 +46,7 @@ class _KoheraAppState extends State<KoheraApp> {
   PreferencesService? _preferencesService;
   GoRouter? _router;
   Object? _initError;
+  MatrixService? _displayedService;
   final _ringtoneService = RingtoneService();
 
   @override
@@ -73,9 +74,11 @@ class _KoheraAppState extends State<KoheraApp> {
       }
 
       if (!mounted) return;
+      clientManager.addListener(_onActiveServiceChanged);
       setState(() {
         _clientManager = clientManager;
         _preferencesService = prefs;
+        _displayedService = clientManager.activeService;
         _router = buildRouter(clientManager);
       });
     } catch (e) {
@@ -85,8 +88,21 @@ class _KoheraAppState extends State<KoheraApp> {
     }
   }
 
+  void _onActiveServiceChanged() {
+    final manager = _clientManager;
+    if (manager == null) return;
+    if (identical(manager.activeService, _displayedService)) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final current = _clientManager?.activeService;
+      if (current == null || identical(current, _displayedService)) return;
+      setState(() => _displayedService = current);
+    });
+  }
+
   @override
   void dispose() {
+    _clientManager?.removeListener(_onActiveServiceChanged);
     _router?.dispose();
     unawaited(_ringtoneService.dispose());
     super.dispose();
@@ -147,7 +163,7 @@ class _KoheraAppState extends State<KoheraApp> {
         builder: (lightDynamic, darkDynamic) {
           return Consumer2<ClientManager, PreferencesService>(
             builder: (context, manager, prefs, _) {
-              final matrix = manager.activeService;
+              final matrix = _displayedService ?? manager.activeService;
               final router = _router!;
 
               return MultiProvider(

--- a/test/core/account_switch_redirector_test.dart
+++ b/test/core/account_switch_redirector_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/routing/app_router.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:matrix/matrix.dart';
+import 'package:matrix/src/utils/cached_stream_controller.dart';
+import 'package:mockito/mockito.dart';
+
+import '../services/matrix_service_test.mocks.dart';
+
+MatrixService _makeService(String name) {
+  final mockClient = MockClient();
+  when(mockClient.rooms).thenReturn([]);
+  when(mockClient.userID).thenReturn('@$name:example.com');
+  when(mockClient.dispose()).thenAnswer((_) async {});
+  when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
+  when(mockClient.onPresenceChanged)
+      .thenReturn(CachedStreamController<CachedPresence>());
+  return MatrixService(client: mockClient, clientName: name);
+}
+
+void main() {
+  late MatrixService accountA;
+  late MatrixService accountB;
+
+  setUp(() {
+    accountA = _makeService('a');
+    accountB = _makeService('b');
+  });
+
+  group('AccountSwitchRedirector', () {
+    test('no redirect when the active account is unchanged', () {
+      final redirector = AccountSwitchRedirector(accountA);
+
+      expect(redirector.redirectFor(accountA, '/rooms/!x:server'), isNull);
+      expect(redirector.redirectFor(accountA, '/'), isNull);
+    });
+
+    test('falls back to room list when account switches on a room route', () {
+      final redirector = AccountSwitchRedirector(accountA);
+
+      expect(redirector.redirectFor(accountB, '/rooms/!x:server'), '/');
+    });
+
+    test('redirects from nested room sub-routes too', () {
+      final redirector = AccountSwitchRedirector(accountA);
+
+      expect(
+        redirector.redirectFor(accountB, '/rooms/!x:server/details'),
+        '/',
+      );
+    });
+
+    test('no redirect when account switches off a room route', () {
+      final redirector = AccountSwitchRedirector(accountA);
+
+      expect(redirector.redirectFor(accountB, '/settings'), isNull);
+    });
+
+    test('only redirects once per switch, not on every later evaluation', () {
+      final redirector = AccountSwitchRedirector(accountA);
+
+      expect(redirector.redirectFor(accountB, '/rooms/!x:server'), '/');
+      expect(redirector.redirectFor(accountB, '/rooms/!x:server'), isNull);
+    });
+  });
+}

--- a/test/widgets/chat/audio_bubble_test.dart
+++ b/test/widgets/chat/audio_bubble_test.dart
@@ -63,6 +63,29 @@ void main() {
       expect(find.byIcon(Icons.play_arrow_rounded), findsNothing);
     });
 
+    testWidgets('survives didChangeDependencies firing again', (tester) async {
+      final playback = MockMediaPlaybackService();
+      Widget build(Brightness brightness) => MaterialApp(
+            home: Theme(
+              data: ThemeData(brightness: brightness),
+              child: Scaffold(
+                body: ChangeNotifierProvider<MediaPlaybackService>.value(
+                  value: playback,
+                  child: AudioBubble(event: mockEvent, isMe: true),
+                ),
+              ),
+            ),
+          );
+
+      await tester.pumpWidget(build(Brightness.light));
+      // Changing an inherited dependency (theme) re-runs didChangeDependencies
+      // on the same State, mirroring the per-account provider swap on account
+      // switch. The playback service field must tolerate re-assignment.
+      await tester.pumpWidget(build(Brightness.dark));
+
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('play button is disabled when pending send', (tester) async {
       when(mockEvent.status).thenReturn(EventStatus.sending);
 


### PR DESCRIPTION
Fixes #558.

## Summary
Switching the active account while a `/rooms/...` route was open crashed the app with `'_dependents.isEmpty': is not true` (`InheritedElement.debugDeactivated()`), plus a collateral `LateInitializationError` in `AudioBubble`.

**Root cause:** the keyed `ChatScreen` subtree depends on the per-account providers (`MatrixService` & friends) via `context.watch`. On account switch `main.dart` swaps those providers for the other account's instances *in the same frame* that the route changes, so the still-mounted chat subtree gets reconciled onto the swapped providers — deactivating an `InheritedElement` before its dependent (a `GlobalKey`'d child) is released, and re-running `AudioBubble.didChangeDependencies`. Pre-existing, unrelated to the presence work (#551).

## Fix (three parts)
1. **Router redirect** (`AccountSwitchRedirector`): on active-service swap, redirect `/rooms/...` → `/` so the chat route falls back to the room list.
2. **Defer the provider swap** (`main.dart`): the per-account providers render off a lagged `_displayedService` that only adopts the new active account on a post-frame callback. The room subtree therefore unmounts cleanly *under the old account* (route already redirected) before the providers swap — they never coincide.
3. **Harden `AudioBubble`**: `_playbackService` is assigned in `didChangeDependencies` (which can fire more than once), so it must not be `late final`.

## Test plan
- [x] `test/core/account_switch_redirector_test.dart` — route fallback logic (5 cases); fails without the redirect.
- [x] `test/widgets/chat/audio_bubble_test.dart` — `survives didChangeDependencies firing again`; fails without the `final` drop, passes with it.
- [x] `flutter analyze` — no issues.
- [x] Manual: two accounts sharing a DM; open the DM on account A (wide/desktop layout), switch to B → lands on room list, no crash.