### PR TITLE
feat(#563): render OpenMoji images in reactions

### DIFF
--- a/lib/features/chat/widgets/reaction_chips.dart
+++ b/lib/features/chat/widgets/reaction_chips.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart'
     show DefaultEmojiTextStyle;
 import 'package:flutter/material.dart';
+import 'package:kohera/core/utils/emoji_spans.dart';
 import 'package:kohera/features/chat/widgets/long_press_wrapper.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
 import 'package:matrix/matrix.dart';
@@ -123,9 +124,13 @@ class _ReactionChipsState extends State<ReactionChips> {
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Text(
-                    emoji,
-                    style: DefaultEmojiTextStyle.copyWith(fontSize: 14),
+                  Text.rich(
+                    TextSpan(
+                      children: buildEmojiSpans(
+                        emoji,
+                        DefaultEmojiTextStyle.copyWith(fontSize: 14),
+                      ),
+                    ),
                   ),
                   if (events.length > 1) ...[
                     const SizedBox(width: 3),
@@ -173,9 +178,19 @@ void showReactorsSheet(
           children: [
             Padding(
               padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-              child: Text(
-                '$emoji ${reactionEvents.length}',
-                style: Theme.of(ctx).textTheme.titleMedium,
+              child: Text.rich(
+                TextSpan(
+                  children: [
+                    ...buildEmojiSpans(
+                      emoji,
+                      Theme.of(ctx).textTheme.titleMedium,
+                    ),
+                    TextSpan(
+                      text: ' ${reactionEvents.length}',
+                      style: Theme.of(ctx).textTheme.titleMedium,
+                    ),
+                  ],
+                ),
               ),
             ),
             const Divider(height: 1),
@@ -212,8 +227,13 @@ void showReactorsSheet(
                       Navigator.of(ctx).pop();
                       onToggle(emoji);
                     },
-                    child: Text(
-                      isMine ? 'Remove your $emoji' : 'React with $emoji',
+                    child: Text.rich(
+                      TextSpan(
+                        children: [
+                          TextSpan(text: isMine ? 'Remove your ' : 'React with '),
+                          ...buildEmojiSpans(emoji, null),
+                        ],
+                      ),
                     ),
                   ),
                 ),

--- a/test/widgets/chat/reaction_chips_test.dart
+++ b/test/widgets/chat/reaction_chips_test.dart
@@ -1,5 +1,6 @@
 ﻿import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/utils/openmoji.dart';
 import 'package:kohera/features/chat/widgets/reaction_chips.dart';
 import 'package:matrix/matrix.dart';
 import 'package:mockito/annotations.dart';
@@ -15,6 +16,23 @@ import 'package:mockito/mockito.dart';
 import 'reaction_chips_test.mocks.dart';
 
 // ── Helpers ──────────────────────────────────────────────────
+
+/// Finds a [Text.rich] whose plain text contains [text] (emoji spans render as
+/// the U+FFFC placeholder, so `find.text` does not match them).
+Finder _richTextContaining(String text) => find.byWidgetPredicate(
+      (w) => w is Text && (w.textSpan?.toPlainText().contains(text) ?? false),
+    );
+
+/// Finds the OpenMoji [Image] rendered for [emoji].
+Finder _emojiImage(String emoji) {
+  final asset = openMojiAssetFor(emoji)!;
+  return find.byWidgetPredicate(
+    (w) =>
+        w is Image &&
+        w.image is AssetImage &&
+        (w.image as AssetImage).assetName == asset,
+  );
+}
 
 MockEvent _makeReactionEvent({
   required String senderId,
@@ -113,10 +131,10 @@ void main() {
       client: mockClient,
     ),);
 
-    // Three different emojis → three chips (each with count 1, so just emoji)
-    expect(find.text('\u{1F44D}'), findsOneWidget);
-    expect(find.text('\u{2764}\u{FE0F}'), findsOneWidget);
-    expect(find.text('\u{1F602}'), findsOneWidget);
+    // Three different emojis → three OpenMoji chips (count 1, so just emoji).
+    expect(_emojiImage('\u{1F44D}'), findsOneWidget);
+    expect(_emojiImage('\u{2764}\u{FE0F}'), findsOneWidget);
+    expect(_emojiImage('\u{1F602}'), findsOneWidget);
   });
 
   testWidgets('shows correct count per emoji', (tester) async {
@@ -137,8 +155,8 @@ void main() {
       client: mockClient,
     ),);
 
-    // One emoji chip with count 3 (emoji and count are separate Text widgets)
-    expect(find.text('\u{1F44D}'), findsOneWidget);
+    // One emoji chip with count 3 (OpenMoji image + separate count Text).
+    expect(_emojiImage('\u{1F44D}'), findsOneWidget);
     expect(find.text('3'), findsOneWidget);
   });
 
@@ -224,7 +242,7 @@ void main() {
       onToggle: (emoji) => tappedEmoji = emoji,
     ),);
 
-    await tester.tap(find.text('\u{1F44D}'));
+    await tester.tap(_emojiImage('\u{1F44D}'));
     expect(tappedEmoji, '\u{1F44D}');
   });
 
@@ -253,12 +271,66 @@ void main() {
       client: mockClient,
     ),);
 
-    await tester.longPress(find.text('\u{1F44D}'));
+    await tester.longPress(_emojiImage('\u{1F44D}'));
     await tester.pumpAndSettle();
 
-    // Bottom sheet should show the emoji with count
-    expect(find.text('\u{1F44D} 1'), findsWidgets);
+    // Bottom sheet shows the emoji (chip + sheet header) and the count.
+    expect(_emojiImage('\u{1F44D}'), findsWidgets);
+    expect(_richTextContaining(' 1'), findsOneWidget);
     // Should show the reactor's name
     expect(find.text('Alice'), findsOneWidget);
+  });
+
+  testWidgets('non-emoji reaction key falls back to text', (tester) async {
+    final reactions = [
+      _makeReactionEvent(senderId: '@alice:example.com', emoji: ':custom:'),
+    ];
+
+    final event = _makeParentEvent(
+      timeline: mockTimeline,
+      reactions: reactions,
+    );
+
+    await tester.pumpWidget(_wrapChips(
+      event: event,
+      timeline: mockTimeline,
+      client: mockClient,
+    ),);
+
+    expect(find.text(':custom:'), findsOneWidget);
+  });
+
+  testWidgets('reactors sheet button renders OpenMoji', (tester) async {
+    final mockRoom = MockRoom();
+    final mockUser = MockUser();
+    when(mockUser.displayName).thenReturn('Alice');
+    when(mockUser.avatarUrl).thenReturn(null);
+    when(mockRoom.unsafeGetUserFromMemoryOrFallback('@alice:example.com'))
+        .thenReturn(mockUser);
+    when(mockRoom.client).thenReturn(mockClient);
+
+    final reactions = [
+      _makeReactionEvent(senderId: '@alice:example.com', emoji: '\u{1F44D}'),
+    ];
+
+    final event = _makeParentEvent(
+      timeline: mockTimeline,
+      reactions: reactions,
+      room: mockRoom,
+    );
+
+    await tester.pumpWidget(_wrapChips(
+      event: event,
+      timeline: mockTimeline,
+      client: mockClient,
+      onToggle: (_) {},
+    ),);
+
+    await tester.longPress(_emojiImage('\u{1F44D}'));
+    await tester.pumpAndSettle();
+
+    expect(_richTextContaining('React with '), findsOneWidget);
+    // Chip + sheet header + button all render the OpenMoji image.
+    expect(_emojiImage('\u{1F44D}'), findsNWidgets(3));
   });
 }


### PR DESCRIPTION
## Summary

Render emoji reactions with OpenMoji images instead of system-font text, reusing the `buildEmojiSpans` helper from #562. Part of the OpenMoji epic.

## Changes

- `lib/features/chat/widgets/reaction_chips.dart`:
  - Reaction chip emoji now renders via `buildEmojiSpans` (OpenMoji image with text fallback).
  - Reactors-sheet header renders the emoji as an image, keeping the count as text.
  - The add/remove button label renders the emoji as an image inline with its text.
- Non-emoji keys (custom shortcodes) and unbundled emoji fall back to text through the same helper — custom/`mxc://` reactions are untouched.
- `test/widgets/chat/reaction_chips_test.dart`: updated existing tests to find OpenMoji images instead of emoji text; added a non-emoji fallback test and a sheet-button render test.

## Testing

- [x] `flutter analyze` clean (changed files)
- [x] `flutter test test/widgets/chat/reaction_chips_test.dart` passes (9/9)

## Linked issues

Closes #563
Refs #566

## Checklist

- [x] Conventional Commits subject; issue refs in footer
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix (none added)
- [x] No stray comments added
- [x] Tests added/updated to cover the change
- [x] Targets `master`
