### PR TITLE
feat(#565): consolidate OpenMoji rendering, add perf and docs

### DIFF
--- a/agent_docs/openmoji.md
+++ b/agent_docs/openmoji.md
@@ -1,0 +1,73 @@
+# OpenMoji emoji rendering
+
+Kohera renders Unicode emoji as bundled [OpenMoji](https://openmoji.org) images
+rather than relying on each platform's emoji font, so emoji look identical on
+Linux, macOS, and web. Custom emoji (emoji.gg / sticker packs) are unrelated —
+they are image-based via `mxc://` and are not covered here.
+
+## Render path
+
+Everything funnels through one widget and one resolver:
+
+- `lib/core/utils/openmoji.dart` — `openMojiAssetFor(grapheme)` maps a Unicode
+  emoji to its bundled asset path, or `null` when none is bundled. It tries the
+  literal codepoint sequence first, then the form with variation selectors
+  (`U+FE0E`/`U+FE0F`) stripped, because OpenMoji keeps `FE0F` for keycaps
+  (`0023-FE0F-20E3`) but drops it elsewhere (`2764`). Codepoints are zero-padded
+  to four hex digits. Resolution is gated by the generated manifest
+  `lib/core/utils/openmoji_manifest.g.dart`.
+- `lib/shared/widgets/openmoji_image.dart` — `OpenMojiImage` is the single
+  shared render + fallback path. It shows the OpenMoji asset, and falls back to
+  system-font text (`emojiTextStyle`, `lib/core/utils/emoji_style.dart`) when no
+  asset is bundled or the asset fails to load. It decodes at `cacheWidth` for
+  the target size to bound memory.
+
+Consumers:
+
+- Inline message text — `buildEmojiSpans` (`lib/core/utils/emoji_spans.dart`)
+  splits text into spans, wrapping each emoji run in `OpenMojiImage` (and keeps
+  a plain `TextSpan` fallback for unbundled runs so text metrics are preserved).
+- Reactions — `reaction_chips.dart` (chips, reactors sheet, react button).
+- Quick-react bars — `hover_action_bar.dart`, `message_action_sheet.dart`. The
+  hot set `kQuickReactEmojis` is warmed via `precacheOpenMoji`.
+- Picker grid — `openmoji_picker.dart`, an in-house tabbed/searchable grid
+  driven by `OpenMojiCatalog` (`lib/core/utils/openmoji_catalog.dart`) reading
+  `assets/openmoji/metadata.json`.
+
+## Asset footprint
+
+- `assets/openmoji/*.png` — 4495 files, ~7 MB (72×72 color PNGs). These are the
+  dominant cost; on native they ship in the app binary, on web they are fetched
+  lazily per emoji.
+- `assets/openmoji/metadata.json` — ~168 KB (picker categories + search index).
+- `lib/core/utils/openmoji_manifest.g.dart` — ~93 KB generated source.
+
+Committed as plain git blobs (not Git LFS). ~7 MB is acceptable; if it ever
+needs trimming, subset the PNG set to the codepoints referenced by
+`metadata.json` plus the skin-tone variants.
+
+### Build/CI cost
+
+The dominant cost is **file count, not bytes**. Flutter bundles every asset
+into the build output (`build/unit_test_assets`, the app bundle) plus a
+per-asset `AssetManifest` entry. Measured locally (SSD), bundling the 4495 PNGs
+adds **~0.7–1.2 s per `flutter test`/`flutter build` invocation** (~3.9 s vs
+~2.8 s for a trivial test with the asset dir removed). This is paid once per
+job, so it lands on every CI test and build step; slower CI disks may see more.
+
+If this becomes a bottleneck, the fix targets file count:
+- **Subset** — `metadata.json` references ~1914 of the 4495 PNGs; trimming the
+  set toward referenced codepoints (plus skin-tone variants) roughly halves the
+  count. Cheap.
+- **Sprite atlas** — pack the PNGs into a few large images + an index and have
+  `openMojiAssetFor` return a sub-rect. Eliminates the file-count cost entirely;
+  larger change, good as a dedicated follow-up.
+
+Git LFS would help clone time but not bundling.
+
+## Updating the asset set
+
+1. Replace `assets/openmoji/*.png` from an OpenMoji `*-color` release.
+2. Regenerate the manifest: `tool/gen_openmoji_manifest.sh`.
+3. Regenerate the picker metadata from OpenMoji's `data/openmoji.json`:
+   `python3 tool/gen_openmoji_metadata.py path/to/openmoji.json`.

--- a/lib/core/utils/emoji_spans.dart
+++ b/lib/core/utils/emoji_spans.dart
@@ -1,17 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:kohera/core/utils/emoji_style.dart';
 import 'package:kohera/core/utils/openmoji.dart';
+import 'package:kohera/shared/widgets/openmoji_image.dart';
 
-/// Fallback font families for rendering color emoji on desktop platforms.
-const emojiFontFallback = [
-  'Noto Color Emoji',
-  'Apple Color Emoji',
-  'Segoe UI Emoji',
-];
-
-/// Text style for rendering emoji as text (the fallback when no OpenMoji asset
-/// is bundled). Applies [emojiFontFallback] so color emoji resolve on every
-/// platform.
-const emojiTextStyle = TextStyle(fontFamilyFallback: emojiFontFallback);
+export 'package:kohera/core/utils/emoji_style.dart';
 
 /// Regex matching common emoji characters and sequences (ZWJ, skin tones,
 /// variation selectors). Uses Unicode ranges rather than `\p{Emoji}` which
@@ -83,14 +75,7 @@ InlineSpan _emojiSpan(String run, TextStyle? style) {
   final size = fontSize * (style?.height ?? _defaultEmojiHeight);
   return WidgetSpan(
     alignment: PlaceholderAlignment.middle,
-    child: Image.asset(
-      asset,
-      width: size,
-      height: size,
-      fit: BoxFit.contain,
-      errorBuilder: (context, error, stackTrace) =>
-          Text.rich(_fallbackSpan(run, style)),
-    ),
+    child: OpenMojiImage(grapheme: run, size: size, fallbackStyle: style),
   );
 }
 

--- a/lib/core/utils/emoji_style.dart
+++ b/lib/core/utils/emoji_style.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/painting.dart';
+
+/// Fallback font families for rendering color emoji on desktop platforms.
+const emojiFontFallback = [
+  'Noto Color Emoji',
+  'Apple Color Emoji',
+  'Segoe UI Emoji',
+];
+
+/// Text style for rendering emoji as text (the fallback when no OpenMoji asset
+/// is bundled). Applies [emojiFontFallback] so color emoji resolve on every
+/// platform.
+const emojiTextStyle = TextStyle(fontFamilyFallback: emojiFontFallback);

--- a/lib/features/chat/widgets/hover_action_bar.dart
+++ b/lib/features/chat/widgets/hover_action_bar.dart
@@ -1,6 +1,19 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:kohera/core/utils/emoji_spans.dart';
 import 'package:kohera/features/chat/widgets/openmoji_picker.dart';
+import 'package:kohera/shared/widgets/openmoji_image.dart';
+
+/// Emoji offered in the quick-react bar, in display order.
+const kQuickReactEmojis = [
+  '\u{2764}\u{FE0F}', // ❤️
+  '\u{1F44D}', // 👍
+  '\u{1F44E}', // 👎
+  '\u{1F602}', // 😂
+  '\u{1F622}', // 😢
+  '\u{1F62E}', // 😮
+];
 
 // ── Hover action bar ────────────────────────────────────────
 
@@ -31,6 +44,16 @@ class _HoverActionBarState extends State<HoverActionBar> {
   final LayerLink _layerLink = LayerLink();
 
   bool _disposing = false;
+  bool _precached = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_precached && widget.onQuickReact != null) {
+      _precached = true;
+      unawaited(precacheOpenMoji(context, kQuickReactEmojis));
+    }
+  }
 
   @override
   void dispose() {
@@ -179,15 +202,6 @@ class _QuickReactOverlay extends StatefulWidget {
 class _QuickReactOverlayState extends State<_QuickReactOverlay> {
   bool _showPicker = false;
 
-  static const _quickEmojis = [
-    '\u{2764}\u{FE0F}', // ❤️
-    '\u{1F44D}', // 👍
-    '\u{1F44E}', // 👎
-    '\u{1F602}', // 😂
-    '\u{1F622}', // 😢
-    '\u{1F62E}', // 😮
-  ];
-
   @override
   Widget build(BuildContext context) {
     final cs = widget.cs;
@@ -240,7 +254,7 @@ class _QuickReactOverlayState extends State<_QuickReactOverlay> {
                     child: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        for (final emoji in _quickEmojis)
+                        for (final emoji in kQuickReactEmojis)
                           InkWell(
                             borderRadius: BorderRadius.circular(20),
                             onTap: () => widget.onEmojiSelected(emoji),

--- a/lib/features/chat/widgets/openmoji_picker.dart
+++ b/lib/features/chat/widgets/openmoji_picker.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:kohera/core/utils/emoji_spans.dart';
 import 'package:kohera/core/utils/openmoji_catalog.dart';
+import 'package:kohera/shared/widgets/openmoji_image.dart';
 
 // ── OpenMojiPicker ───────────────────────────────────────────
 
@@ -173,13 +173,7 @@ class _EmojiGrid extends StatelessWidget {
           onTap: () => onSelected(e.emoji),
           child: Padding(
             padding: const EdgeInsets.all(6),
-            child: Image.asset(
-              e.asset,
-              fit: BoxFit.contain,
-              errorBuilder: (context, error, stackTrace) => Center(
-                child: Text(e.emoji, style: emojiTextStyle),
-              ),
-            ),
+            child: OpenMojiImage(grapheme: e.emoji),
           ),
         );
       },

--- a/lib/shared/widgets/openmoji_image.dart
+++ b/lib/shared/widgets/openmoji_image.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:kohera/core/utils/emoji_style.dart';
+import 'package:kohera/core/utils/openmoji.dart';
+
+/// Renders a single emoji [grapheme] as its bundled OpenMoji image, falling
+/// back to system-font text when no asset is bundled or the asset fails to
+/// load. This is the single shared OpenMoji render+fallback path used by both
+/// inline message text ([buildEmojiSpans]) and the picker grid.
+class OpenMojiImage extends StatelessWidget {
+  const OpenMojiImage({
+    required this.grapheme,
+    super.key,
+    this.size,
+    this.fallbackStyle,
+  });
+
+  /// The Unicode emoji to render.
+  final String grapheme;
+
+  /// Square edge length. When null the image fills its parent's constraints
+  /// (used by the picker grid cells).
+  final double? size;
+
+  /// Style applied to the text fallback.
+  final TextStyle? fallbackStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    final asset = openMojiAssetFor(grapheme);
+    if (asset == null) return _fallback();
+
+    final s = size;
+    return Image.asset(
+      asset,
+      width: s,
+      height: s,
+      fit: BoxFit.contain,
+      cacheWidth: s == null
+          ? null
+          : (s * MediaQuery.devicePixelRatioOf(context)).round(),
+      errorBuilder: (context, error, stackTrace) => _fallback(),
+    );
+  }
+
+  Widget _fallback() => Text(
+        grapheme,
+        style: emojiTextStyle.merge(fallbackStyle),
+      );
+}
+
+/// Warms the image cache for [graphemes] (e.g. the quick-react set) so they
+/// render without a decode hitch the first time they appear.
+Future<void> precacheOpenMoji(
+  BuildContext context,
+  Iterable<String> graphemes,
+) async {
+  for (final g in graphemes) {
+    final asset = openMojiAssetFor(g);
+    if (asset != null) {
+      await precacheImage(AssetImage(asset), context);
+    }
+  }
+}

--- a/test/utils/emoji_spans_test.dart
+++ b/test/utils/emoji_spans_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:kohera/core/utils/emoji_spans.dart';
+import 'package:kohera/shared/widgets/openmoji_image.dart';
 
 void main() {
   const style = TextStyle(fontSize: 14);
@@ -25,17 +26,16 @@ void main() {
       expect(spans.first, isA<WidgetSpan>());
       final widgetSpan = spans.first as WidgetSpan;
       expect(widgetSpan.alignment, PlaceholderAlignment.middle);
-      expect(widgetSpan.child, isA<Image>());
-      final image = widgetSpan.child as Image;
-      expect(image.width, isNotNull);
-      expect(image.height, image.width);
+      expect(widgetSpan.child, isA<OpenMojiImage>());
+      final image = widgetSpan.child as OpenMojiImage;
+      expect(image.size, isNotNull);
     });
 
     test('emoji image is sized to the surrounding line height', () {
       const styled = TextStyle(fontSize: 20, height: 1.5);
       final spans = buildEmojiSpans('😀', styled);
-      final image = (spans.first as WidgetSpan).child as Image;
-      expect(image.width, 20 * 1.5);
+      final image = (spans.first as WidgetSpan).child as OpenMojiImage;
+      expect(image.size, 20 * 1.5);
     });
 
     test('unmapped emoji falls back to font rendering', () {

--- a/test/widgets/chat/hover_action_bar_test.dart
+++ b/test/widgets/chat/hover_action_bar_test.dart
@@ -1,18 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:kohera/core/utils/openmoji.dart';
 import 'package:kohera/features/chat/widgets/hover_action_bar.dart';
+import 'package:kohera/shared/widgets/openmoji_image.dart';
 
-/// Finds the OpenMoji [Image] rendered for [emoji].
-Finder _emojiImage(String emoji) {
-  final asset = openMojiAssetFor(emoji)!;
-  return find.byWidgetPredicate(
-    (w) =>
-        w is Image &&
-        w.image is AssetImage &&
-        (w.image as AssetImage).assetName == asset,
-  );
-}
+/// Finds the [OpenMojiImage] rendered for [emoji].
+Finder _emojiImage(String emoji) => find.byWidgetPredicate(
+      (w) => w is OpenMojiImage && w.grapheme == emoji,
+    );
 
 void main() {
   Widget buildTestWidget({

--- a/test/widgets/chat/message_action_sheet_test.dart
+++ b/test/widgets/chat/message_action_sheet_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/services/preferences_service.dart';
-import 'package:kohera/core/utils/openmoji.dart';
 import 'package:kohera/features/chat/widgets/message_action_sheet.dart';
+import 'package:kohera/shared/widgets/openmoji_image.dart';
 import 'package:matrix/matrix.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -19,16 +19,10 @@ import 'message_action_sheet_test.mocks.dart';
 
 late MockRoom _mockRoom;
 
-/// Finds the OpenMoji [Image] rendered for [emoji].
-Finder _emojiImage(String emoji) {
-  final asset = openMojiAssetFor(emoji)!;
-  return find.byWidgetPredicate(
-    (w) =>
-        w is Image &&
-        w.image is AssetImage &&
-        (w.image as AssetImage).assetName == asset,
-  );
-}
+/// Finds the [OpenMojiImage] rendered for [emoji].
+Finder _emojiImage(String emoji) => find.byWidgetPredicate(
+      (w) => w is OpenMojiImage && w.grapheme == emoji,
+    );
 
 MockEvent _makeEvent({
   required String eventId,

--- a/test/widgets/chat/openmoji_picker_test.dart
+++ b/test/widgets/chat/openmoji_picker_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/utils/openmoji_catalog.dart';
 import 'package:kohera/features/chat/widgets/openmoji_picker.dart';
+import 'package:kohera/shared/widgets/openmoji_image.dart';
 
 const _json = '''
 {"groups":[
@@ -27,11 +28,8 @@ class _FakeBundle extends CachingAssetBundle {
       ByteData.sublistView(Uint8List.fromList(utf8.encode(payload)));
 }
 
-Finder _cell(String assetName) => find.byWidgetPredicate(
-      (w) =>
-          w is Image &&
-          w.image is AssetImage &&
-          (w.image as AssetImage).assetName == 'assets/openmoji/$assetName.png',
+Finder _cell(String emoji) => find.byWidgetPredicate(
+      (w) => w is OpenMojiImage && w.grapheme == emoji,
     );
 
 Widget _wrap(void Function(String) onSelected) => MaterialApp(
@@ -54,8 +52,8 @@ void main() {
     await tester.pumpWidget(_wrap((_) {}));
     await tester.pump();
 
-    expect(_cell('1F600'), findsOneWidget);
-    expect(_cell('1F622'), findsOneWidget);
+    expect(_cell('😀'), findsOneWidget);
+    expect(_cell('😢'), findsOneWidget);
   });
 
   testWidgets('tapping an emoji selects its Unicode value', (tester) async {
@@ -63,7 +61,7 @@ void main() {
     await tester.pumpWidget(_wrap((e) => selected = e));
     await tester.pump();
 
-    await tester.tap(_cell('1F600'));
+    await tester.tap(_cell('😀'));
     expect(selected, '😀');
   });
 
@@ -74,7 +72,7 @@ void main() {
     await tester.enterText(find.byType(TextField), 'united');
     await tester.pump();
 
-    expect(_cell('1F1FA-1F1F8'), findsOneWidget);
-    expect(_cell('1F600'), findsNothing);
+    expect(_cell('🇺🇸'), findsOneWidget);
+    expect(_cell('😀'), findsNothing);
   });
 }

--- a/test/widgets/chat/reaction_chips_test.dart
+++ b/test/widgets/chat/reaction_chips_test.dart
@@ -1,7 +1,7 @@
 ﻿import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:kohera/core/utils/openmoji.dart';
 import 'package:kohera/features/chat/widgets/reaction_chips.dart';
+import 'package:kohera/shared/widgets/openmoji_image.dart';
 import 'package:matrix/matrix.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -23,16 +23,10 @@ Finder _richTextContaining(String text) => find.byWidgetPredicate(
       (w) => w is Text && (w.textSpan?.toPlainText().contains(text) ?? false),
     );
 
-/// Finds the OpenMoji [Image] rendered for [emoji].
-Finder _emojiImage(String emoji) {
-  final asset = openMojiAssetFor(emoji)!;
-  return find.byWidgetPredicate(
-    (w) =>
-        w is Image &&
-        w.image is AssetImage &&
-        (w.image as AssetImage).assetName == asset,
-  );
-}
+/// Finds the [OpenMojiImage] rendered for [emoji].
+Finder _emojiImage(String emoji) => find.byWidgetPredicate(
+      (w) => w is OpenMojiImage && w.grapheme == emoji,
+    );
 
 MockEvent _makeReactionEvent({
   required String senderId,

--- a/test/widgets/shared/openmoji_image_test.dart
+++ b/test/widgets/shared/openmoji_image_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/shared/widgets/openmoji_image.dart';
+
+Widget _wrap(Widget child) =>
+    MaterialApp(home: Scaffold(body: Center(child: child)));
+
+/// Asset name behind an [Image], unwrapping the [ResizeImage] that `cacheWidth`
+/// introduces.
+String _assetOf(Image image) {
+  final provider = image.image;
+  final asset =
+      provider is ResizeImage ? provider.imageProvider : provider;
+  return (asset as AssetImage).assetName;
+}
+
+void main() {
+  testWidgets('renders the OpenMoji asset for a bundled emoji', (tester) async {
+    await tester.pumpWidget(
+      _wrap(const OpenMojiImage(grapheme: '\u{1F44D}', size: 24)),
+    );
+
+    final image = tester.widget<Image>(find.byType(Image));
+    expect(_assetOf(image), 'assets/openmoji/1F44D.png');
+    expect(image.width, 24);
+    expect(image.height, 24);
+  });
+
+  testWidgets('strips FE0F to resolve the asset', (tester) async {
+    await tester.pumpWidget(
+      _wrap(const OpenMojiImage(grapheme: '❤️', size: 24)),
+    );
+
+    final image = tester.widget<Image>(find.byType(Image));
+    expect(_assetOf(image), 'assets/openmoji/2764.png');
+  });
+
+  testWidgets('falls back to text when no asset is bundled', (tester) async {
+    await tester.pumpWidget(
+      _wrap(const OpenMojiImage(grapheme: 'x', size: 24)),
+    );
+
+    expect(find.byType(Image), findsNothing);
+    expect(find.text('x'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary

Harden the OpenMoji rollout: a single shared render+fallback path, decode-memory and precache perf, a measured app-size/CI cost with mitigations, plus tests and docs.

## Changes

- **Single fallback path** — new `OpenMojiImage` (`lib/shared/widgets/openmoji_image.dart`) renders an emoji as its bundled asset and falls back to system-font text when unbundled or on load error. Now used by `buildEmojiSpans` (inline text), reactions, quick-react bars, and the picker grid — no duplicated fallback logic.
- Emoji font-style constants moved to `lib/core/utils/emoji_style.dart` (re-exported from `emoji_spans.dart`) to avoid an import cycle.
- **Performance** — `OpenMojiImage` decodes at `cacheWidth` to bound memory; `precacheOpenMoji` warms the quick-react set (`kQuickReactEmojis`).
- **Docs** — `agent_docs/openmoji.md`: render path, asset footprint, and the measured build/CI cost.

## App-size / CI cost (measured)

The cost is **file count, not bytes** (4495 PNGs, ~7 MB). Local SSD measurement of a trivial `flutter test` with vs without the asset dir:

| | bundled files | time |
|---|---|---|
| with OpenMoji | 4522 | ~3.9 s |
| without | 26 | ~2.8 s |

≈ **0.7–1.2 s of asset-bundling per `flutter test`/`flutter build` invocation**, paid once per CI job. Mitigations documented (subset toward referenced codepoints; sprite atlas) if it ever bites.

## Testing

- [x] `flutter analyze` clean
- [x] New `openmoji_image_test.dart` (asset + FE0F + fallback); updated emoji-span/reaction/hover/action-sheet/picker tests to match the shared widget
- [x] All emoji-related tests pass (60)
- Note: full suite has 37 **pre-existing** failures unrelated to this change (`room_members_section`, `chat_app_bar`, `room_tile`) — confirmed identical on clean `master`.

## Linked issues

Closes #565
Refs #566

## Checklist

- [x] Conventional Commits subject; issue refs in footer
- [x] Logs use `debugPrint('[Kohera] ...')` (none added)
- [x] No stray comments added
- [x] Tests added/updated to cover the change
- [x] Targets `master`

## Follow-ups (tracked)

- Skin-tone selection & recents (carryover on this issue's comment).
- #571 — OpenMoji as a built-in default emoji pack (alongside emoji.gg).
