### PR TITLE
fix(#574): keep session on transient token-refresh failure in soft logout

### DIFF
--- a/lib/core/services/matrix_service.dart
+++ b/lib/core/services/matrix_service.dart
@@ -261,8 +261,14 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
       debugPrint('[Kohera] Token refreshed successfully');
     } catch (e) {
       debugPrint('[Kohera] Token refresh failed: $e');
-      await auth.logout();
-      await chatBackup.deleteStoredRecoveryKey();
+      final cause = _unwrapInitException(e);
+      if (auth.isPermanentAuthFailure(cause)) {
+        await auth.logout();
+        await chatBackup.deleteStoredRecoveryKey();
+      } else {
+        debugPrint('[Kohera] Transient refresh failure, keeping session '
+            'for next sync/refresh retry');
+      }
     }
   }
 

--- a/test/services/matrix_service_auth_test.dart
+++ b/test/services/matrix_service_auth_test.dart
@@ -263,6 +263,72 @@ void main() {
     });
   });
 
+  group('handleSoftLogout', () {
+    setUp(() {
+      when(mockClient.userID).thenReturn('@user:example.com');
+      when(mockClient.homeserver)
+          .thenReturn(Uri.parse('https://example.com'));
+      service.isLoggedInForTest = true;
+    });
+
+    test('keeps session on transient refresh failure', () async {
+      when(mockClient.refreshAccessToken())
+          .thenThrow(Exception('connection timed out'));
+
+      await service.handleSoftLogout();
+
+      expect(service.isLoggedIn, isTrue);
+      verifyNever(mockStorage.delete(key: 'kohera_test_access_token'));
+      verifyNever(mockStorage.delete(key: 'ssss_recovery_key_@user:example.com'));
+    });
+
+    test('keeps session on transient MatrixException (limit exceeded)',
+        () async {
+      when(mockClient.refreshAccessToken()).thenThrow(
+        MatrixException.fromJson({
+          'errcode': 'M_LIMIT_EXCEEDED',
+          'error': 'Too many requests',
+        }),
+      );
+
+      await service.handleSoftLogout();
+
+      expect(service.isLoggedIn, isTrue);
+      verifyNever(mockStorage.delete(key: 'kohera_test_access_token'));
+    });
+
+    test('signs out on permanent auth failure (unknown token)', () async {
+      when(mockClient.accessToken).thenReturn('tok');
+      when(mockClient.logout()).thenAnswer((_) async {});
+      when(mockClient.refreshAccessToken()).thenThrow(
+        MatrixException.fromJson({
+          'errcode': 'M_UNKNOWN_TOKEN',
+          'error': 'Invalid refresh token',
+        }),
+      );
+
+      await service.handleSoftLogout();
+
+      expect(service.isLoggedIn, isFalse);
+      verify(mockStorage.delete(key: 'kohera_test_access_token')).called(1);
+      verify(mockStorage.delete(key: 'ssss_recovery_key_@user:example.com'))
+          .called(1);
+    });
+
+    test('persists credentials on successful refresh', () async {
+      when(mockClient.accessToken).thenReturn('new_tok');
+      when(mockClient.deviceID).thenReturn('DEV');
+      when(mockClient.refreshAccessToken()).thenAnswer((_) async {});
+
+      await service.handleSoftLogout();
+
+      expect(service.isLoggedIn, isTrue);
+      verify(mockStorage.write(
+              key: 'kohera_test_access_token', value: 'new_tok',),)
+          .called(1);
+    });
+  });
+
   group('completeSsoLogin', () {
     late CachedStreamController<SyncUpdate> syncController;
 


### PR DESCRIPTION
## Summary

`MatrixService.handleSoftLogout()` signed the user out on **any** exception thrown during `refreshAccessToken()`. Since access-token expiry (the soft-logout trigger) is routine and frequent, a transient network blip or server error coinciding with a refresh permanently ejected an otherwise-valid session. This gates the destructive branch on `auth.isPermanentAuthFailure()` so only a genuinely rejected refresh token signs the user out.

## Changes

- `lib/core/services/matrix_service.dart`: in `handleSoftLogout`, unwrap the caught error and gate `auth.logout()` + `chatBackup.deleteStoredRecoveryKey()` on `auth.isPermanentAuthFailure(cause)`. Transient failures now keep the session for the next sync/refresh to retry, mirroring the database-restore (`:438`) and keychain-restore (`:504`) paths.
- `test/services/matrix_service_auth_test.dart`: added a `handleSoftLogout` group covering transient `Exception`, transient `M_LIMIT_EXCEEDED`, permanent `M_UNKNOWN_TOKEN`, and successful-refresh cases.

## Testing

- [ ] `flutter analyze` is clean
- [ ] `flutter test` passes (run `dart run build_runner build --delete-conflicting-outputs` first if mocks changed)

> Note: the Flutter SDK is not installed in the remote execution environment used for this change, so `flutter analyze` / `flutter test` could not be run here. The new tests follow the existing mocking patterns in the same file and should be confirmed in CI.

## Linked issues

Closes #574

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master` (not another feature branch, unless an explicitly requested stacked PR)


