### PR TITLE
feat(#575): add retry/backoff and reconnecting state to auth lifecycle

### DIFF
--- a/lib/core/services/matrix_service.dart
+++ b/lib/core/services/matrix_service.dart
@@ -14,6 +14,7 @@ import 'package:kohera/core/services/sub_services/space_access_service.dart';
 import 'package:kohera/core/services/sub_services/sync_service.dart';
 import 'package:kohera/core/services/sub_services/uia_service.dart';
 import 'package:kohera/core/utils/network_error.dart';
+import 'package:kohera/core/utils/retry.dart';
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart';
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart';
 import 'package:matrix/matrix.dart';
@@ -35,7 +36,9 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
     required Client client,
     FlutterSecureStorage? storage,
     this.clientName = 'default',
+    SleepFn? backoff,
   })  : _client = client,
+        _backoff = backoff ?? Future<void>.delayed,
         _storage = storage ??
             const FlutterSecureStorage(
               iOptions: IOSOptions(
@@ -57,6 +60,7 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
     spaceAccess = SpaceAccessService(client: _client);
     sync = SyncService(
       client: _client,
+      sleep: _backoff,
       onPostSyncBackup: () async {
         await chatBackup.tryAutoUnlockBackup();
       },
@@ -84,11 +88,16 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
 
   final FlutterSecureStorage _storage;
   final String clientName;
+  final SleepFn _backoff;
 
   final Client _client;
   Client get client => _client;
 
   bool get isLoggedIn => auth.isLoggedIn;
+
+  /// Authenticated but the SDK is temporarily unreachable and the lifecycle is
+  /// retrying. The router keeps the user in the app while this is true.
+  bool get isReconnecting => auth.isReconnecting;
 
   @visibleForTesting
   set isLoggedInForTest(bool value) {
@@ -124,6 +133,7 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
 
   bool _foregroundSyncStarted = false;
   bool _lifecycleObserverRegistered = false;
+  bool _lastAuthLoggedIn = false;
 
   bool _hasSkippedSetup = false;
   bool get hasSkippedSetup => _hasSkippedSetup;
@@ -255,54 +265,78 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
   Future<void> handleSoftLogout() async {
     debugPrint('[Kohera] Soft logout detected, attempting token refresh...');
     try {
-      await _client.refreshAccessToken();
-      await auth.persistCredentials();
-      await auth.saveSessionBackup();
-      debugPrint('[Kohera] Token refreshed successfully');
+      await retryWithBackoff(
+        _client.refreshAccessToken,
+        retryIf: auth.isTransientAuthFailure,
+        sleep: _backoff,
+        onRetry: (e, delay, attempt) {
+          auth.enterReconnecting();
+          debugPrint('[Kohera] Token refresh failed (attempt $attempt), '
+              'retrying in ${delay.inSeconds}s: $e');
+        },
+      );
     } catch (e) {
-      debugPrint('[Kohera] Token refresh failed: $e');
-      final cause = _unwrapInitException(e);
-      if (auth.isPermanentAuthFailure(cause)) {
+      if (auth.isPermanentAuthFailure(_unwrapInitException(e))) {
+        debugPrint('[Kohera] Token refresh failed permanently, logging out: $e');
         await auth.logout();
         await chatBackup.deleteStoredRecoveryKey();
       } else {
-        debugPrint('[Kohera] Transient refresh failure, keeping session '
-            'for next sync/refresh retry');
+        debugPrint('[Kohera] Token refresh failed transiently after retries; '
+            'keeping session in reconnecting state: $e');
+        auth.enterReconnecting();
       }
+      return;
     }
+
+    try {
+      await auth.persistCredentials();
+      await auth.saveSessionBackup();
+    } catch (e) {
+      debugPrint('[Kohera] Persisting refreshed credentials failed '
+          '(non-fatal): $e');
+    }
+    auth.exitReconnecting();
+    debugPrint('[Kohera] Token refreshed successfully');
   }
 
   // ── Private: Auth Observer ──────────────────────────────────────
 
   void _onAuthChanged() {
-    if (auth.isLoggedIn) {
-      uia.listenForUia();
-      _listenForLoginState();
-      unawaited(callPushRuleManager.ensureRule());
-      unawaited(
-        keyMirror.start().catchError((Object e) {
-          debugPrint('[Kohera] Key mirror start failed: $e');
-        }),
-      );
-      unawaited(
-        outbox.start().catchError((Object e) {
-          debugPrint('[Kohera] Outbox start failed: $e');
-        }),
-      );
-    } else {
-      unawaited(_loginStateSub?.cancel());
-      _loginStateSub = null;
-      sync.cancelSyncSub();
-      unawaited(keyMirror.dispose());
-      uia.clearCachedPassword();
-      uia.cancelUiaSub();
-      selection.resetSelection();
-      chatBackup.resetChatBackupState();
-      _hasSkippedSetup = false;
-      _foregroundSyncStarted = false;
-      if (_lifecycleObserverRegistered) {
-        WidgetsBinding.instance.removeObserver(this);
-        _lifecycleObserverRegistered = false;
+    // Only run startup/teardown on an actual signed-in/out transition. The
+    // reconnecting flag also notifies through here, but must not re-run the
+    // logged-in startup.
+    final loggedIn = auth.isLoggedIn;
+    if (loggedIn != _lastAuthLoggedIn) {
+      _lastAuthLoggedIn = loggedIn;
+      if (loggedIn) {
+        uia.listenForUia();
+        _listenForLoginState();
+        unawaited(callPushRuleManager.ensureRule());
+        unawaited(
+          keyMirror.start().catchError((Object e) {
+            debugPrint('[Kohera] Key mirror start failed: $e');
+          }),
+        );
+        unawaited(
+          outbox.start().catchError((Object e) {
+            debugPrint('[Kohera] Outbox start failed: $e');
+          }),
+        );
+      } else {
+        unawaited(_loginStateSub?.cancel());
+        _loginStateSub = null;
+        sync.cancelSyncSub();
+        unawaited(keyMirror.dispose());
+        uia.clearCachedPassword();
+        uia.cancelUiaSub();
+        selection.resetSelection();
+        chatBackup.resetChatBackupState();
+        _hasSkippedSetup = false;
+        _foregroundSyncStarted = false;
+        if (_lifecycleObserverRegistered) {
+          WidgetsBinding.instance.removeObserver(this);
+          _lifecycleObserverRegistered = false;
+        }
       }
     }
     notifyListeners();
@@ -347,10 +381,19 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
     if (_foregroundSyncStarted || _disposed) return;
     _foregroundSyncStarted = true;
     unawaited(
-      sync.startSync().catchError((Object e) {
+      sync
+          .startSync(
+            retrySchedule: kAuthBackoffSchedule,
+            onRetry: (e, delay, attempt) => auth.enterReconnecting(),
+          )
+          .then((_) => auth.exitReconnecting())
+          .catchError((Object e) {
         if (e is! TimeoutException) {
           debugPrint('[Kohera] Background sync error: $e');
         }
+        // First sync never landed after retries: stay authenticated but
+        // reconnecting rather than tearing the session down.
+        auth.enterReconnecting();
       }),
     );
     presence.setOnline();
@@ -417,7 +460,18 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
   Future<void> _restoreFromDatabase() async {
     debugPrint('[Kohera] Restoring session from database for $clientName');
     try {
-      await _client.init();
+      await retryWithBackoff(
+        () async {
+          if (_client.isLogged()) return;
+          await _client.init();
+        },
+        retryIf: auth.isTransientAuthFailure,
+        sleep: _backoff,
+        onRetry: (e, delay, attempt) => debugPrint(
+          '[Kohera] Database restore failed (attempt $attempt), '
+          'retrying in ${delay.inSeconds}s: $e',
+        ),
+      );
       if (!_client.isLogged()) {
         debugPrint('[Kohera] Database restore produced no logged-in session');
         auth.isLoggedIn = false;
@@ -443,6 +497,11 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
       auth.isLoggedIn = false;
       if (auth.isPermanentAuthFailure(cause)) {
         await _clearSessionAndBackup();
+      } else if (_client.isLogged()) {
+        debugPrint('[Kohera] Restore failed transiently but session data is '
+            'present; activating in reconnecting state');
+        await _activateSession();
+        auth.enterReconnecting();
       }
     }
   }
@@ -479,14 +538,25 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
     try {
       final homeserverUri = Uri.parse(keys.homeserver!);
       _client.homeserver = homeserverUri;
-      await _client.init(
-        newToken: keys.token,
-        newRefreshToken: keys.refreshToken ?? backup?.refreshToken,
-        newUserID: keys.userId,
-        newDeviceID: keys.deviceId,
-        newHomeserver: homeserverUri,
-        newDeviceName: 'Kohera Flutter',
-        newOlmAccount: backup?.olmAccount,
+      await retryWithBackoff(
+        () async {
+          if (_client.isLogged()) return;
+          await _client.init(
+            newToken: keys.token,
+            newRefreshToken: keys.refreshToken ?? backup?.refreshToken,
+            newUserID: keys.userId,
+            newDeviceID: keys.deviceId,
+            newHomeserver: homeserverUri,
+            newDeviceName: 'Kohera Flutter',
+            newOlmAccount: backup?.olmAccount,
+          );
+        },
+        retryIf: auth.isTransientAuthFailure,
+        sleep: _backoff,
+        onRetry: (e, delay, attempt) => debugPrint(
+          '[Kohera] Keychain restore failed (attempt $attempt), '
+          'retrying in ${delay.inSeconds}s: $e',
+        ),
       );
       debugPrint('[Kohera] Session restored from keychain – '
           'encryption=${_client.encryption != null ? "available" : "null"}, '
@@ -509,6 +579,11 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
       auth.isLoggedIn = false;
       if (auth.isPermanentAuthFailure(cause)) {
         await _clearSessionAndBackup();
+      } else if (_client.isLogged()) {
+        debugPrint('[Kohera] Restore failed transiently but session data is '
+            'present; activating in reconnecting state');
+        await _activateSession();
+        auth.enterReconnecting();
       }
     }
   }

--- a/lib/core/services/sub_services/auth_service.dart
+++ b/lib/core/services/sub_services/auth_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:kohera/core/models/server_auth_capabilities.dart';
 import 'package:kohera/core/services/matrix_service.dart' show koheraKey;
 import 'package:kohera/core/services/session_backup.dart';
+import 'package:kohera/core/utils/network_error.dart';
 import 'package:matrix/matrix.dart';
 // ignore: implementation_imports, no public API for ClientInitException
 import 'package:matrix/src/utils/client_init_exception.dart';
@@ -24,6 +25,24 @@ class AuthService extends ChangeNotifier {
 
   // ── Auth state ────────────────────────────────────────────────
   bool isLoggedIn = false;
+
+  // The session is authenticated but the SDK is temporarily unreachable; the
+  // lifecycle is retrying rather than tearing the session down. Distinct from
+  // `isLoggedIn = false` so the router keeps the user in the app.
+  bool _reconnecting = false;
+  bool get isReconnecting => _reconnecting;
+
+  void enterReconnecting() {
+    if (!isLoggedIn || _reconnecting) return;
+    _reconnecting = true;
+    notifyListeners();
+  }
+
+  void exitReconnecting() {
+    if (!_reconnecting) return;
+    _reconnecting = false;
+    notifyListeners();
+  }
 
   String? _loginError;
   String? get loginError => _loginError;
@@ -171,6 +190,7 @@ class AuthService extends ChangeNotifier {
 
   void activateRestoredSession() {
     isLoggedIn = true;
+    _reconnecting = false;
     notifyListeners();
   }
 
@@ -178,6 +198,7 @@ class AuthService extends ChangeNotifier {
 
   Future<void> logout() async {
     isLoggedIn = false;
+    _reconnecting = false;
     notifyListeners();
 
     try {
@@ -193,6 +214,7 @@ class AuthService extends ChangeNotifier {
 
   Future<void> handleServerLogout() async {
     isLoggedIn = false;
+    _reconnecting = false;
     notifyListeners();
 
     await clearSessionKeys();
@@ -327,6 +349,22 @@ class AuthService extends ChangeNotifier {
           e.errcode == 'M_FORBIDDEN' ||
           e.errcode == 'M_USER_DEACTIVATED';
     }
+    return false;
+  }
+
+  /// Whether [error] is a transient failure worth retrying — i.e. the session
+  /// is likely still valid and the server is merely unreachable. Restore and
+  /// soft-logout share this so they classify the same errcodes identically:
+  /// network/timeout failures, rate-limiting, and 5xx/other non-permanent
+  /// `MatrixException`s are transient; only [isPermanentAuthFailure] errcodes
+  /// are not.
+  bool isTransientAuthFailure(Object error) {
+    final e =
+        error is ClientInitException ? error.originalException : error;
+    if (isPermanentAuthFailure(e)) return false;
+    if (isNetworkError(e)) return true;
+    if (e is TimeoutException) return true;
+    if (e is MatrixException) return true;
     return false;
   }
 

--- a/lib/core/services/sub_services/sync_service.dart
+++ b/lib/core/services/sub_services/sync_service.dart
@@ -1,17 +1,21 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:kohera/core/utils/retry.dart';
 import 'package:matrix/matrix.dart';
 
 class SyncService extends ChangeNotifier {
   SyncService({
     required Client client,
     required Future<void> Function() onPostSyncBackup,
+    SleepFn? sleep,
   })  : _client = client,
-        _onPostSyncBackup = onPostSyncBackup;
+        _onPostSyncBackup = onPostSyncBackup,
+        _sleep = sleep ?? Future<void>.delayed;
 
   final Client _client;
   final Future<void> Function() _onPostSyncBackup;
+  final SleepFn _sleep;
 
   // ── Sync ─────────────────────────────────────────────────────
   bool _syncing = false;
@@ -29,7 +33,11 @@ class SyncService extends ChangeNotifier {
     super.dispose();
   }
 
-  Future<void> startSync({Duration? timeout = const Duration(seconds: 30)}) async {
+  Future<void> startSync({
+    Duration? timeout = const Duration(seconds: 30),
+    List<Duration> retrySchedule = const <Duration>[],
+    RetryCallback? onRetry,
+  }) async {
     if (_syncing) return;
     _syncing = true;
     notifyListeners();
@@ -50,16 +58,33 @@ class SyncService extends ChangeNotifier {
       notifyListeners();
     },),);
 
-    if (timeout != null) {
-      await firstSync.future.timeout(
-        timeout,
-        onTimeout: () {
-          debugPrint('[Kohera] First sync timed out after ${timeout.inSeconds}s');
-          throw TimeoutException('Initial sync timed out. Check your connection.');
-        },
-      );
-    } else {
+    if (timeout == null) {
       await firstSync.future;
+      return;
+    }
+
+    // The subscription stays live across attempts, so a late first sync still
+    // resolves and triggers the post-sync backup. Each attempt re-waits the
+    // same future with a fresh timeout, backing off between tries.
+    var attempt = 0;
+    while (true) {
+      try {
+        await firstSync.future.timeout(timeout);
+        return;
+      } on TimeoutException catch (e) {
+        if (_disposed) return;
+        if (attempt >= retrySchedule.length) {
+          debugPrint('[Kohera] First sync timed out after '
+              '${timeout.inSeconds}s and $attempt retries');
+          throw TimeoutException('Initial sync timed out. Check your connection.');
+        }
+        final delay = retrySchedule[attempt];
+        attempt++;
+        onRetry?.call(e, delay, attempt);
+        debugPrint('[Kohera] First sync timed out (attempt $attempt), '
+            'retrying in ${delay.inSeconds}s');
+        await _sleep(delay);
+      }
     }
   }
 

--- a/lib/core/utils/retry.dart
+++ b/lib/core/utils/retry.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+
+/// Bounded exponential backoff schedule shared by the auth lifecycle, matching
+/// the repository's network-op convention (2s/4s/8s/16s).
+const List<Duration> kAuthBackoffSchedule = [
+  Duration(seconds: 2),
+  Duration(seconds: 4),
+  Duration(seconds: 8),
+  Duration(seconds: 16),
+];
+
+typedef RetryPredicate = bool Function(Object error);
+typedef RetryCallback = void Function(
+  Object error,
+  Duration delay,
+  int attempt,
+);
+typedef SleepFn = Future<void> Function(Duration delay);
+
+Future<void> _defaultSleep(Duration delay) => Future<void>.delayed(delay);
+
+/// Runs [action], retrying on failure while [retryIf] accepts the error and the
+/// [schedule] still has delays left. Waits [schedule]`[attempt]` between tries
+/// before re-running. The last error is rethrown once retries are exhausted or
+/// [retryIf] rejects it.
+///
+/// [sleep] is injectable so tests can advance without real delays.
+Future<T> retryWithBackoff<T>(
+  Future<T> Function() action, {
+  required RetryPredicate retryIf,
+  List<Duration> schedule = kAuthBackoffSchedule,
+  RetryCallback? onRetry,
+  SleepFn sleep = _defaultSleep,
+}) async {
+  var attempt = 0;
+  while (true) {
+    try {
+      return await action();
+    } catch (error) {
+      if (attempt >= schedule.length || !retryIf(error)) rethrow;
+      final delay = schedule[attempt];
+      attempt++;
+      onRetry?.call(error, delay, attempt);
+      await sleep(delay);
+    }
+  }
+}

--- a/lib/features/home/screens/home_shell.dart
+++ b/lib/features/home/screens/home_shell.dart
@@ -6,6 +6,7 @@ import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/calling/widgets/voice_banner.dart';
 import 'package:kohera/features/e2ee/widgets/key_backup_banner.dart';
 import 'package:kohera/features/home/widgets/narrow_layout.dart';
+import 'package:kohera/features/home/widgets/reconnecting_banner.dart';
 import 'package:kohera/features/home/widgets/wide_layout.dart';
 import 'package:kohera/features/spaces/widgets/space_reparent_controller.dart';
 import 'package:provider/provider.dart';
@@ -115,6 +116,7 @@ class _HomeShellState extends State<HomeShell> {
           autofocus: true,
           child: Column(
             children: [
+              const ReconnectingBanner(),
               VoiceBanner(currentViewingRoomId: _routeRoomId),
               const KeyBackupBanner(),
               Expanded(child: child),

--- a/lib/features/home/widgets/reconnecting_banner.dart
+++ b/lib/features/home/widgets/reconnecting_banner.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:provider/provider.dart';
+
+class ReconnectingBanner extends StatelessWidget {
+  const ReconnectingBanner({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final reconnecting = context.select<MatrixService, bool>(
+      (s) => s.isReconnecting,
+    );
+
+    return AnimatedSize(
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeInOut,
+      alignment: Alignment.topCenter,
+      child: reconnecting
+          ? const _ReconnectingBannerContent()
+          : const SizedBox.shrink(),
+    );
+  }
+}
+
+class _ReconnectingBannerContent extends StatelessWidget {
+  const _ReconnectingBannerContent();
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+
+    return Material(
+      color: Colors.transparent,
+      child: Semantics(
+        liveRegion: true,
+        label: 'Reconnecting to server',
+        child: Container(
+          constraints: const BoxConstraints(minHeight: 36),
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          decoration: BoxDecoration(
+            border: Border(
+              left: BorderSide(color: cs.onSecondaryContainer, width: 3),
+            ),
+            color: cs.secondaryContainer,
+          ),
+          child: Row(
+            children: [
+              SizedBox(
+                width: 14,
+                height: 14,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  color: cs.onSecondaryContainer,
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  'Reconnecting…',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: tt.bodyMedium?.copyWith(
+                    color: cs.onSecondaryContainer,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/core/utils/retry_test.dart
+++ b/test/core/utils/retry_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/utils/retry.dart';
+
+void main() {
+  group('retryWithBackoff', () {
+    test('returns immediately on first success without sleeping', () async {
+      var calls = 0;
+      var slept = 0;
+
+      final result = await retryWithBackoff(
+        () async {
+          calls++;
+          return 'ok';
+        },
+        retryIf: (_) => true,
+        sleep: (_) async => slept++,
+      );
+
+      expect(result, 'ok');
+      expect(calls, 1);
+      expect(slept, 0);
+    });
+
+    test('retries until success and backs off between attempts', () async {
+      var calls = 0;
+      final delays = <Duration>[];
+
+      final result = await retryWithBackoff(
+        () async {
+          calls++;
+          if (calls < 3) throw Exception('transient');
+          return calls;
+        },
+        retryIf: (_) => true,
+        schedule: const [
+          Duration(seconds: 2),
+          Duration(seconds: 4),
+          Duration(seconds: 8),
+        ],
+        sleep: (d) async => delays.add(d),
+      );
+
+      expect(result, 3);
+      expect(calls, 3);
+      expect(delays, const [Duration(seconds: 2), Duration(seconds: 4)]);
+    });
+
+    test('rethrows immediately when retryIf rejects the error', () async {
+      var calls = 0;
+
+      await expectLater(
+        retryWithBackoff(
+          () async {
+            calls++;
+            throw StateError('permanent');
+          },
+          retryIf: (_) => false,
+          sleep: (_) async {},
+        ),
+        throwsA(isA<StateError>()),
+      );
+      expect(calls, 1);
+    });
+
+    test('rethrows the last error after exhausting the schedule', () async {
+      var calls = 0;
+      var slept = 0;
+
+      await expectLater(
+        retryWithBackoff(
+          () async {
+            calls++;
+            throw Exception('always');
+          },
+          retryIf: (_) => true,
+          schedule: const [Duration(seconds: 1), Duration(seconds: 1)],
+          sleep: (_) async => slept++,
+        ),
+        throwsA(isA<Exception>()),
+      );
+
+      // 2 retries -> 3 total attempts, 2 sleeps.
+      expect(calls, 3);
+      expect(slept, 2);
+    });
+
+    test('reports the attempt number to onRetry', () async {
+      final attempts = <int>[];
+      var calls = 0;
+
+      await retryWithBackoff(
+        () async {
+          calls++;
+          if (calls < 3) throw Exception('x');
+        },
+        retryIf: (_) => true,
+        schedule: const [Duration(seconds: 1), Duration(seconds: 1)],
+        sleep: (_) async {},
+        onRetry: (_, __, attempt) => attempts.add(attempt),
+      );
+
+      expect(attempts, const [1, 2]);
+    });
+  });
+}

--- a/test/services/auth_service_test.dart
+++ b/test/services/auth_service_test.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/services/sub_services/auth_service.dart';
 import 'package:matrix/matrix.dart';
@@ -150,6 +153,98 @@ void main() {
         service.isPermanentAuthFailure(Exception('network')),
         isFalse,
       );
+    });
+  });
+
+  group('isTransientAuthFailure', () {
+    test('classifies network errors as transient', () {
+      expect(
+        service.isTransientAuthFailure(const SocketException('down')),
+        isTrue,
+      );
+    });
+
+    test('classifies timeouts as transient', () {
+      expect(
+        service.isTransientAuthFailure(TimeoutException('slow')),
+        isTrue,
+      );
+    });
+
+    test('classifies rate-limiting as transient', () {
+      final error = MatrixException.fromJson({
+        'errcode': 'M_LIMIT_EXCEEDED',
+        'error': 'Too many requests',
+        'retry_after_ms': 2000,
+      });
+
+      expect(service.isTransientAuthFailure(error), isTrue);
+    });
+
+    test('classifies other server MatrixExceptions as transient', () {
+      final error = MatrixException.fromJson({
+        'errcode': 'M_UNKNOWN',
+        'error': 'Internal server error',
+      });
+
+      expect(service.isTransientAuthFailure(error), isTrue);
+    });
+
+    test('does not classify permanent auth failures as transient', () {
+      for (final errcode in const [
+        'M_UNKNOWN_TOKEN',
+        'M_FORBIDDEN',
+        'M_USER_DEACTIVATED',
+      ]) {
+        final error = MatrixException.fromJson({
+          'errcode': errcode,
+          'error': 'nope',
+        });
+        expect(
+          service.isTransientAuthFailure(error),
+          isFalse,
+          reason: '$errcode should be permanent',
+        );
+      }
+    });
+
+    test('does not classify unrelated errors as transient', () {
+      expect(service.isTransientAuthFailure(StateError('bug')), isFalse);
+    });
+  });
+
+  group('reconnecting state', () {
+    test('enterReconnecting is a no-op while signed out', () {
+      service.enterReconnecting();
+      expect(service.isReconnecting, isFalse);
+    });
+
+    test('enters and exits reconnecting while signed in', () {
+      service.isLoggedIn = true;
+
+      var notifications = 0;
+      service.addListener(() => notifications++);
+
+      service.enterReconnecting();
+      expect(service.isReconnecting, isTrue);
+
+      // Re-entering does not re-notify.
+      service.enterReconnecting();
+
+      service.exitReconnecting();
+      expect(service.isReconnecting, isFalse);
+
+      expect(notifications, 2);
+    });
+
+    test('logout clears reconnecting', () async {
+      service.isLoggedIn = true;
+      service.enterReconnecting();
+
+      await service.logout();
+
+      expect(service.isReconnecting, isFalse);
+      expect(service.isLoggedIn, isFalse);
     });
   });
 

--- a/test/services/matrix_service_auth_test.dart
+++ b/test/services/matrix_service_auth_test.dart
@@ -28,6 +28,7 @@ void main() {
       client: mockClient,
       storage: mockStorage,
       clientName: 'test',
+      backoff: (_) async {},
     );
   });
 

--- a/test/services/matrix_service_resilience_test.dart
+++ b/test/services/matrix_service_resilience_test.dart
@@ -1,0 +1,167 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:matrix/matrix.dart';
+import 'package:matrix/src/utils/cached_stream_controller.dart';
+import 'package:mockito/mockito.dart';
+
+import 'matrix_service_test.mocks.dart';
+
+class _FakeDatabase extends Fake implements DatabaseApi {
+  _FakeDatabase(this._stored);
+  final Map<String, dynamic>? _stored;
+
+  @override
+  Future<Map<String, dynamic>?> getClient(String name) async => _stored;
+}
+
+MatrixException _permanent() => MatrixException.fromJson({
+      'errcode': 'M_UNKNOWN_TOKEN',
+      'error': 'Token revoked',
+    });
+
+void main() {
+  // Restore activates the session, which touches WidgetsBinding. The default
+  // (non-resumed) test lifecycle keeps foreground sync deferred, so no timers
+  // are scheduled.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockClient mockClient;
+  late MockFlutterSecureStorage mockStorage;
+  late MatrixService service;
+
+  MatrixService buildService({Map<String, dynamic>? stored}) {
+    when(mockClient.rooms).thenReturn([]);
+    when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
+    when(mockClient.onPresenceChanged)
+        .thenReturn(CachedStreamController<CachedPresence>());
+    when(mockClient.onLoginStateChanged)
+        .thenReturn(CachedStreamController<LoginState>());
+    when(mockClient.onUiaRequest).thenReturn(CachedStreamController());
+    when(mockClient.database).thenReturn(_FakeDatabase(stored));
+    final s = MatrixService(
+      client: mockClient,
+      storage: mockStorage,
+      clientName: 'test',
+      backoff: (_) async {},
+    );
+    addTearDown(s.dispose);
+    return s;
+  }
+
+  setUp(() {
+    mockClient = MockClient();
+    mockStorage = MockFlutterSecureStorage();
+  });
+
+  group('handleSoftLogout (token refresh)', () {
+    setUp(() {
+      service = buildService(stored: {'token': 't'});
+      service.auth.isLoggedIn = true;
+      when(mockClient.accessToken).thenReturn('tok');
+      when(mockClient.userID).thenReturn('@u:e.com');
+      when(mockClient.homeserver).thenReturn(Uri.parse('https://e.com'));
+      when(mockClient.deviceID).thenReturn('D1');
+      when(mockClient.encryption).thenReturn(null);
+    });
+
+    test('retries transient failures then recovers', () async {
+      var calls = 0;
+      when(mockClient.refreshAccessToken()).thenAnswer((_) async {
+        calls++;
+        if (calls <= 2) throw const SocketException('down');
+      });
+
+      await service.handleSoftLogout();
+
+      expect(calls, 3);
+      expect(service.isLoggedIn, isTrue);
+      expect(service.isReconnecting, isFalse);
+    });
+
+    test('keeps session reconnecting after exhausting retries', () async {
+      var calls = 0;
+      when(mockClient.refreshAccessToken()).thenAnswer((_) async {
+        calls++;
+        throw const SocketException('down');
+      });
+
+      await service.handleSoftLogout();
+
+      // 4 retries -> 5 total attempts.
+      expect(calls, 5);
+      expect(service.isLoggedIn, isTrue);
+      expect(service.isReconnecting, isTrue);
+    });
+
+    test('logs out promptly on permanent failure', () async {
+      var calls = 0;
+      when(mockClient.refreshAccessToken()).thenAnswer((_) async {
+        calls++;
+        throw _permanent();
+      });
+
+      await service.handleSoftLogout();
+
+      expect(calls, 1);
+      expect(service.isLoggedIn, isFalse);
+      expect(service.isReconnecting, isFalse);
+    });
+  });
+
+  group('session restore', () {
+    test('retries transient failures then recovers', () async {
+      service = buildService(stored: {'token': 't'});
+      var initCalls = 0;
+      when(mockClient.init()).thenAnswer((_) async {
+        initCalls++;
+        if (initCalls <= 2) throw const SocketException('down');
+      });
+      when(mockClient.isLogged()).thenAnswer((_) => initCalls >= 3);
+
+      await service.init();
+
+      expect(initCalls, 3);
+      expect(service.isLoggedIn, isTrue);
+      expect(service.isReconnecting, isFalse);
+    });
+
+    test('stays reconnecting when session data loads but sync keeps failing',
+        () async {
+      service = buildService(stored: {'token': 't'});
+      var initCalls = 0;
+      var logged = false;
+      when(mockClient.init()).thenAnswer((_) async {
+        initCalls++;
+        // The final retry loads the session before the connectivity step fails.
+        if (initCalls >= 5) logged = true;
+        throw const SocketException('down');
+      });
+      when(mockClient.isLogged()).thenAnswer((_) => logged);
+
+      await service.init();
+
+      expect(initCalls, 5);
+      expect(service.isLoggedIn, isTrue);
+      expect(service.isReconnecting, isTrue);
+    });
+
+    test('logs out and clears session on permanent failure', () async {
+      service = buildService(stored: {'token': 't'});
+      var initCalls = 0;
+      when(mockClient.init()).thenAnswer((_) async {
+        initCalls++;
+        throw _permanent();
+      });
+      when(mockClient.isLogged()).thenReturn(false);
+
+      await service.init();
+
+      expect(initCalls, 1);
+      expect(service.isLoggedIn, isFalse);
+      expect(service.isReconnecting, isFalse);
+      verify(mockStorage.delete(key: 'kohera_test_access_token')).called(1);
+    });
+  });
+}

--- a/test/services/matrix_service_test.dart
+++ b/test/services/matrix_service_test.dart
@@ -58,6 +58,7 @@ void main() {
       client: mockClient,
       storage: mockStorage,
       clientName: 'test',
+      backoff: (_) async {},
     );
   });
 

--- a/test/services/sync_service_test.dart
+++ b/test/services/sync_service_test.dart
@@ -109,4 +109,62 @@ void main() {
       expect(service.syncing, isFalse);
     });
   });
+
+  group('startSync retries', () {
+    late SyncService retryService;
+
+    setUp(() {
+      retryService = SyncService(
+        client: mockClient,
+        sleep: (_) async {},
+        onPostSyncBackup: () async {},
+      );
+    });
+
+    test('does not retry by default', () async {
+      var retries = 0;
+
+      await expectLater(
+        retryService.startSync(
+          timeout: const Duration(milliseconds: 1),
+          onRetry: (_, __, ___) => retries++,
+        ),
+        throwsA(isA<TimeoutException>()),
+      );
+
+      expect(retries, 0);
+    });
+
+    test('retries with backoff then recovers when sync lands late', () async {
+      var retries = 0;
+
+      // Emitting from inside onRetry guarantees the first attempt times out
+      // before the sync arrives, making retry-then-recover deterministic.
+      await retryService.startSync(
+        timeout: const Duration(milliseconds: 50),
+        retrySchedule: const [Duration(seconds: 1)],
+        onRetry: (_, __, ___) {
+          retries++;
+          syncController.add(SyncUpdate(nextBatch: 'b1'));
+        },
+      );
+
+      expect(retries, 1);
+    });
+
+    test('throws TimeoutException after exhausting retries', () async {
+      var retries = 0;
+
+      await expectLater(
+        retryService.startSync(
+          timeout: const Duration(milliseconds: 20),
+          retrySchedule: const [Duration(seconds: 1), Duration(seconds: 1)],
+          onRetry: (_, __, ___) => retries++,
+        ),
+        throwsA(isA<TimeoutException>()),
+      );
+
+      expect(retries, 2);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Makes the auth lifecycle resilient to transient failures so a session survives network blips and recovers automatically, instead of ejecting the user to the login screen. Adds an explicit "authenticated but offline/reconnecting" state distinct from `isLoggedIn = false`.

## Changes

- **Shared backoff helper** — `lib/core/utils/retry.dart` adds `retryWithBackoff` using the repo's `2s/4s/8s/16s` schedule (`kAuthBackoffSchedule`), with an injectable `sleep` and an `onRetry` hook.
- **Normalised error classification** — `AuthService.isTransientAuthFailure()` is now shared by restore and soft-logout so they treat the same errcodes identically: only the permanent auth errcodes (`M_UNKNOWN_TOKEN` / `M_FORBIDDEN` / `M_USER_DEACTIVATED`) sign out; network / timeout / rate-limit / 5xx are retried. Resolves the asymmetry where restore kept the session but `handleSoftLogout` logged out on the same non-permanent errors.
- **Reconnecting state** — `AuthService` gains `enterReconnecting()` / `exitReconnecting()` / `isReconnecting`, surfaced via `MatrixService.isReconnecting`. The session stays logged in while reconnecting, so the router keeps the user in the app rather than redirecting to `/login`; the flag clears on recovery and on logout.
- **Retry wired into the three paths** — token refresh (`MatrixService.handleSoftLogout`), foreground sync startup (`SyncService.startSync`, opt-in schedule; default behaviour unchanged), and session restore (`_restoreFromDatabase` / `_restoreFromKeychain`). On a transient restore failure where session data is present, the session activates in a reconnecting state instead of bouncing to login.
- **UI** — `ReconnectingBanner` (`lib/features/home/widgets/reconnecting_banner.dart`) mounted in `HomeShell`, mirroring the existing banner pattern.
- **Correctness fix** — `_onAuthChanged` now runs sub-service startup/teardown only on an actual sign-in/out transition, so reconnecting toggles no longer restart sub-services.

## Testing

- [ ] `flutter analyze` is clean
- [ ] `flutter test` passes (run `dart run build_runner build --delete-conflicting-outputs` first if mocks changed)

> Note: the development container has no Flutter/Dart toolchain, so `flutter analyze` and `flutter test` could **not** be run locally — please confirm in CI. New tests added:
> - `test/core/utils/retry_test.dart` — backoff/retry semantics
> - `test/services/auth_service_test.dart` — `isTransientAuthFailure` + reconnecting-state transitions
> - `test/services/sync_service_test.dart` — sync retry-then-recover and exhaustion
> - `test/services/matrix_service_resilience_test.dart` — refresh/restore transient-retry-then-recover and permanent-failure-then-logout

No mock interfaces changed in a way that requires regeneration: `MockMatrixService` is never mounted into `HomeShell` in tests (only real `MatrixService` instances reach the router), so the new `isReconnecting` getter and banner do not break existing widget mocks.

## Screenshots / recordings

N/A — banner is a thin status strip using `secondaryContainer` colors and a small spinner, mirroring `KeyBackupBanner`.

## Linked issues

Closes #575

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline refs)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only WHY-context consistent with existing tricky-logic comments)
- [x] Tests added or updated to cover the change
- [x] Targets `master`

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCVMyoUxGEb9Z18j9cbdvP)_