### PR TITLE
fix: render OpenMoji at native resolution to avoid pixelation

### DIFF
--- a/lib/shared/widgets/openmoji_image.dart
+++ b/lib/shared/widgets/openmoji_image.dart
@@ -30,14 +30,14 @@ class OpenMojiImage extends StatelessWidget {
     if (asset == null) return _fallback();
 
     final s = size;
+    // Decode at native resolution (no cacheWidth): the 72px source upscales and
+    // pixelates if decoded smaller than its painted size. Downsampling from
+    // native uses the default medium filter quality and stays crisp.
     return Image.asset(
       asset,
       width: s,
       height: s,
       fit: BoxFit.contain,
-      cacheWidth: s == null
-          ? null
-          : (s * MediaQuery.devicePixelRatioOf(context)).round(),
       errorBuilder: (context, error, stackTrace) => _fallback(),
     );
   }


### PR DESCRIPTION
## Summary

Reaction chips and inline emoji rendered the OpenMoji 72px PNGs blocky/pixelated. `OpenMojiImage` decoded at `cacheWidth` (painted logical size × devicePixelRatio); when the painted size exceeded that decode — enlarged emoji-only messages, or any dpr mismatch — the small bitmap was upscaled and pixelated.

## Changes

- `lib/shared/widgets/openmoji_image.dart`: drop `cacheWidth`, decode at native resolution. Downsampling to the painted size uses the default medium filter quality and stays crisp. The 72px assets are tiny, so the decode-memory cost is negligible.

## Testing

- [x] `flutter analyze` clean
- [x] `openmoji_image_test`, `emoji_spans_test`, `reaction_chips_test` pass

## Notes

This reverts the `cacheWidth` micro-optimization from #565 (the memory saving on 72px assets was marginal and it caused the regression). The picker grid was already unaffected because it decodes at native (no `cacheWidth`).