### PR TITLE
feat(#573): add skin-tone selection to the OpenMoji picker

### DIFF
--- a/lib/core/services/preferences_service.dart
+++ b/lib/core/services/preferences_service.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:kohera/core/theme/custom_theme.dart';
+import 'package:kohera/core/utils/openmoji.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -78,6 +79,7 @@ class PreferencesService extends ChangeNotifier {
   static const _lastMobileTabKey = 'last_mobile_tab';
   static const _lastSeenVersionKey = 'last_seen_version';
   static const _lastDismissedUpdateKey = 'last_dismissed_update';
+  static const _skinToneKey = 'emoji_skin_tone';
 
   /// Initialise the underlying [SharedPreferences] instance.
   /// Must be called (and awaited) before reading any values.
@@ -143,6 +145,23 @@ class PreferencesService extends ChangeNotifier {
   Future<void> setLastMobileTab(MobileTab tab) async {
     await _prefs?.setString(_lastMobileTabKey, tab.name);
     debugPrint('[Kohera] Last mobile tab set to ${tab.label}');
+    notifyListeners();
+  }
+
+  // ── Emoji skin tone ───────────────────────────────────────────
+
+  SkinTone get skinTone {
+    final stored = _prefs?.getString(_skinToneKey);
+    if (stored == null) return SkinTone.none;
+    return SkinTone.values.firstWhere(
+      (t) => t.name == stored,
+      orElse: () => SkinTone.none,
+    );
+  }
+
+  Future<void> setSkinTone(SkinTone tone) async {
+    await _prefs?.setString(_skinToneKey, tone.name);
+    debugPrint('[Kohera] Emoji skin tone set to ${tone.label}');
     notifyListeners();
   }
 

--- a/lib/core/utils/openmoji.dart
+++ b/lib/core/utils/openmoji.dart
@@ -4,6 +4,59 @@ const _openMojiAssetDir = 'assets/openmoji';
 
 const _variationSelectors = {0xFE0E, 0xFE0F};
 
+/// A Unicode skin-tone modifier (Fitzpatrick scale), or [none] for the default
+/// yellow rendering.
+enum SkinTone {
+  none,
+  light,
+  mediumLight,
+  medium,
+  mediumDark,
+  dark;
+
+  /// The Unicode modifier codepoint (`U+1F3FB`–`U+1F3FF`), or null for [none].
+  int? get modifier => switch (this) {
+        SkinTone.none => null,
+        SkinTone.light => 0x1F3FB,
+        SkinTone.mediumLight => 0x1F3FC,
+        SkinTone.medium => 0x1F3FD,
+        SkinTone.mediumDark => 0x1F3FE,
+        SkinTone.dark => 0x1F3FF,
+      };
+
+  String get label => switch (this) {
+        SkinTone.none => 'Default',
+        SkinTone.light => 'Light',
+        SkinTone.mediumLight => 'Medium-light',
+        SkinTone.medium => 'Medium',
+        SkinTone.mediumDark => 'Medium-dark',
+        SkinTone.dark => 'Dark',
+      };
+
+  /// A sample toned emoji (raised hand) for swatches.
+  String get sample => applySkinTone('\u{270B}', this);
+}
+
+/// Returns [grapheme] with [tone] applied, inserting the modifier after the
+/// leading codepoint. Falls back to [grapheme] when [tone] is [SkinTone.none]
+/// or the toned variant has no bundled asset (so it is safe to call on any
+/// emoji).
+String applySkinTone(String grapheme, SkinTone tone) {
+  final modifier = tone.modifier;
+  if (modifier == null) return grapheme;
+
+  final runes =
+      grapheme.runes.where((c) => !_variationSelectors.contains(c)).toList();
+  if (runes.isEmpty) return grapheme;
+
+  final toned = String.fromCharCodes([runes.first, modifier, ...runes.skip(1)]);
+  return openMojiNameFor(toned) != null ? toned : grapheme;
+}
+
+/// Whether [grapheme] has at least one bundled skin-tone variant.
+bool openMojiSupportsSkinTone(String grapheme) =>
+    applySkinTone(grapheme, SkinTone.light) != grapheme;
+
 /// Codepoint sequence base name for [grapheme] following OpenMoji's filename
 /// convention: uppercase hex codepoints joined by `-`.
 String _name(Iterable<int> codepoints) => codepoints

--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -12,6 +12,7 @@ import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/app_config.dart';
 import 'package:kohera/core/services/call_service.dart';
 import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/core/services/sticker_pack_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/core/utils/platform_info.dart';
@@ -363,6 +364,7 @@ class _ChatScreenState extends State<ChatScreen>
   void _toggleStickerPicker() {
     final matrix = context.read<MatrixService>();
     final stickerService = context.read<StickerPackService>();
+    final skinTone = context.read<PreferencesService>().skinTone;
     final room = matrix.client.getRoomById(widget.roomId);
     if (room == null) return;
     unawaited(showModalBottomSheet<void>(
@@ -377,6 +379,7 @@ class _ChatScreenState extends State<ChatScreen>
         builder: (_, __) => StickerPickerOverlay(
           packs: stickerService.packsForRoom(room),
           client: matrix.client,
+          skinTone: skinTone,
           onStickerTapped: (sticker) {
             Navigator.of(sheetCtx).pop();
             unawaited(_handleStickerSelected(sticker));

--- a/lib/features/chat/widgets/emoji_picker_sheet.dart
+++ b/lib/features/chat/widgets/emoji_picker_sheet.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/features/chat/widgets/openmoji_picker.dart';
+import 'package:provider/provider.dart';
 
 // coverage:ignore-start
 
@@ -21,6 +23,7 @@ class _EmojiPickerDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
+    final prefs = context.watch<PreferencesService>();
 
     return Dialog(
       backgroundColor: cs.surfaceContainer,
@@ -30,6 +33,8 @@ class _EmojiPickerDialog extends StatelessWidget {
         width: 350,
         height: 400,
         child: OpenMojiPicker(
+          skinTone: prefs.skinTone,
+          onSkinToneChanged: prefs.setSkinTone,
           onSelected: (emoji) {
             Navigator.of(context).pop();
             onSelected(emoji);

--- a/lib/features/chat/widgets/hover_action_bar.dart
+++ b/lib/features/chat/widgets/hover_action_bar.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/core/utils/emoji_spans.dart';
+import 'package:kohera/core/utils/openmoji.dart';
 import 'package:kohera/features/chat/widgets/openmoji_picker.dart';
 import 'package:kohera/shared/widgets/openmoji_image.dart';
 import 'package:provider/provider.dart';
@@ -207,6 +208,7 @@ class _QuickReactOverlayState extends State<_QuickReactOverlay> {
   @override
   Widget build(BuildContext context) {
     final cs = widget.cs;
+    final tone = context.watch<PreferencesService>().skinTone;
     const gap = 4.0;
 
     return Stack(
@@ -260,21 +262,24 @@ class _QuickReactOverlayState extends State<_QuickReactOverlay> {
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         for (final emoji in kQuickReactEmojis)
-                          InkWell(
-                            borderRadius: BorderRadius.circular(20),
-                            onTap: () => widget.onEmojiSelected(emoji),
-                            child: Padding(
-                              padding: const EdgeInsets.all(6),
-                              child: Text.rich(
-                                TextSpan(
-                                  children: buildEmojiSpans(
-                                    emoji,
-                                    emojiTextStyle.copyWith(fontSize: 22),
+                          () {
+                            final toned = applySkinTone(emoji, tone);
+                            return InkWell(
+                              borderRadius: BorderRadius.circular(20),
+                              onTap: () => widget.onEmojiSelected(toned),
+                              child: Padding(
+                                padding: const EdgeInsets.all(6),
+                                child: Text.rich(
+                                  TextSpan(
+                                    children: buildEmojiSpans(
+                                      toned,
+                                      emojiTextStyle.copyWith(fontSize: 22),
+                                    ),
                                   ),
                                 ),
                               ),
-                            ),
-                          ),
+                            );
+                          }(),
                         if (widget.hasMore)
                           InkWell(
                             borderRadius: BorderRadius.circular(20),

--- a/lib/features/chat/widgets/hover_action_bar.dart
+++ b/lib/features/chat/widgets/hover_action_bar.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/core/utils/emoji_spans.dart';
 import 'package:kohera/features/chat/widgets/openmoji_picker.dart';
 import 'package:kohera/shared/widgets/openmoji_image.dart';
+import 'package:provider/provider.dart';
 
 /// Emoji offered in the quick-react bar, in display order.
 const kQuickReactEmojis = [
@@ -238,6 +240,9 @@ class _QuickReactOverlayState extends State<_QuickReactOverlay> {
                         width: 350,
                         height: 400,
                         child: OpenMojiPicker(
+                          skinTone: context.watch<PreferencesService>().skinTone,
+                          onSkinToneChanged:
+                              context.read<PreferencesService>().setSkinTone,
                           onSelected: widget.onEmojiSelected,
                         ),
                       ),

--- a/lib/features/chat/widgets/message_action_sheet.dart
+++ b/lib/features/chat/widgets/message_action_sheet.dart
@@ -2,9 +2,12 @@ import 'dart:async';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/core/utils/emoji_spans.dart';
+import 'package:kohera/core/utils/openmoji.dart';
 import 'package:kohera/features/chat/widgets/message_bubble.dart';
 import 'package:matrix/matrix.dart';
+import 'package:provider/provider.dart';
 
 // ── Data class ──────────────────────────────────────────
 
@@ -306,6 +309,7 @@ class _QuickReactBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
+    final tone = context.watch<PreferencesService>().skinTone;
 
     return Material(
       elevation: 4,
@@ -317,19 +321,20 @@ class _QuickReactBar extends StatelessWidget {
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: _quickEmojis.map((emoji) {
+            final toned = applySkinTone(emoji, tone);
             return Flexible(
               child: InkWell(
                 borderRadius: BorderRadius.circular(20),
                 onTap: () {
                   Navigator.of(context).pop();
-                  onQuickReact(emoji);
+                  onQuickReact(toned);
                 },
                 child: Padding(
                   padding: const EdgeInsets.all(8),
                   child: Text.rich(
                     TextSpan(
                       children: buildEmojiSpans(
-                        emoji,
+                        toned,
                         emojiTextStyle.copyWith(fontSize: 22),
                       ),
                     ),

--- a/lib/features/chat/widgets/openmoji_picker.dart
+++ b/lib/features/chat/widgets/openmoji_picker.dart
@@ -161,12 +161,33 @@ class _OpenMojiPickerState extends State<OpenMojiPicker> {
             child: GestureDetector(
               behavior: HitTestBehavior.translucent,
               onTap: _closeToneStrip,
-              child: Align(
-                alignment: Alignment.bottomCenter,
-                child: _ToneStrip(
-                  base: _toneStripBase!,
-                  onSelected: _onToneSelected,
-                ),
+              child: Stack(
+                children: [
+                  // The default-tone strip drops from the header swatch
+                  // (top-right); a per-emoji override sits near the bottom.
+                  if (_toneStripBase!.isEmpty)
+                    Positioned(
+                      top: 52,
+                      right: 8,
+                      child: _ToneStrip(
+                        base: _toneStripBase!,
+                        selected: widget.skinTone,
+                        onSelected: _onToneSelected,
+                      ),
+                    )
+                  else
+                    Positioned(
+                      left: 0,
+                      right: 0,
+                      bottom: 8,
+                      child: Center(
+                        child: _ToneStrip(
+                          base: _toneStripBase!,
+                          onSelected: _onToneSelected,
+                        ),
+                      ),
+                    ),
+                ],
               ),
             ),
           ),
@@ -179,10 +200,17 @@ class _OpenMojiPickerState extends State<OpenMojiPicker> {
 /// swatches are sample hands; for an override they are the toned variants of
 /// [base].
 class _ToneStrip extends StatelessWidget {
-  const _ToneStrip({required this.base, required this.onSelected});
+  const _ToneStrip({
+    required this.base,
+    required this.onSelected,
+    this.selected,
+  });
 
   final String base;
   final ValueChanged<SkinTone> onSelected;
+
+  /// Currently active tone, highlighted in the strip (default-tone mode).
+  final SkinTone? selected;
 
   @override
   Widget build(BuildContext context) {
@@ -200,8 +228,18 @@ class _ToneStrip extends StatelessWidget {
               InkWell(
                 borderRadius: BorderRadius.circular(8),
                 onTap: () => onSelected(tone),
-                child: Padding(
-                  padding: const EdgeInsets.all(6),
+                child: Container(
+                  margin: const EdgeInsets.all(2),
+                  padding: const EdgeInsets.all(4),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(8),
+                    color: tone == selected
+                        ? cs.primary.withValues(alpha: 0.18)
+                        : null,
+                    border: tone == selected
+                        ? Border.all(color: cs.primary, width: 1.5)
+                        : null,
+                  ),
                   child: SizedBox(
                     width: 30,
                     height: 30,

--- a/lib/features/chat/widgets/openmoji_picker.dart
+++ b/lib/features/chat/widgets/openmoji_picker.dart
@@ -11,8 +11,9 @@ import 'package:kohera/shared/widgets/openmoji_image.dart';
 /// searchable grid. Calls [onSelected] with the Unicode emoji on tap.
 ///
 /// Tone-supporting emoji render with [skinTone] applied; long-pressing one
-/// offers a per-emoji tone override. When [onSkinToneChanged] is provided a
-/// tone selector is shown for changing the default.
+/// opens an inline tone strip to insert a per-emoji override. When
+/// [onSkinToneChanged] is provided a header swatch opens the same strip for
+/// changing the default tone.
 class OpenMojiPicker extends StatefulWidget {
   const OpenMojiPicker({
     required this.onSelected,
@@ -47,12 +48,35 @@ class _OpenMojiPickerState extends State<OpenMojiPicker> {
   List<OpenMojiCategory>? _categories;
   String _query = '';
 
+  /// When non-null, the inline tone strip is open. An empty string means the
+  /// header (default-tone) strip; otherwise the per-emoji override for that
+  /// base grapheme.
+  String? _toneStripBase;
+
   @override
   void initState() {
     super.initState();
     unawaited(OpenMojiCatalog.load().then((categories) {
       if (mounted) setState(() => _categories = categories);
     }),);
+  }
+
+  void _openDefaultToneStrip() => setState(() => _toneStripBase = '');
+
+  void _openOverrideToneStrip(String base) =>
+      setState(() => _toneStripBase = base);
+
+  void _closeToneStrip() => setState(() => _toneStripBase = null);
+
+  void _onToneSelected(SkinTone tone) {
+    final base = _toneStripBase;
+    _closeToneStrip();
+    if (base == null) return;
+    if (base.isEmpty) {
+      widget.onSkinToneChanged?.call(tone);
+    } else {
+      widget.onSelected(applySkinTone(base, tone));
+    }
   }
 
   @override
@@ -63,94 +87,133 @@ class _OpenMojiPickerState extends State<OpenMojiPicker> {
       return const Center(child: CircularProgressIndicator());
     }
 
-    return Column(
+    return Stack(
       children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(8, 8, 8, 4),
-          child: Row(
-            children: [
-              Expanded(
-                child: TextField(
-                  decoration: InputDecoration(
-                    isDense: true,
-                    hintText: 'Search emoji',
-                    prefixIcon: const Icon(Icons.search, size: 20),
-                    filled: true,
-                    fillColor: cs.surfaceContainerHighest,
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(12),
-                      borderSide: BorderSide.none,
+        Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(8, 8, 8, 4),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      decoration: InputDecoration(
+                        isDense: true,
+                        hintText: 'Search emoji',
+                        prefixIcon: const Icon(Icons.search, size: 20),
+                        filled: true,
+                        fillColor: cs.surfaceContainerHighest,
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide: BorderSide.none,
+                        ),
+                      ),
+                      onChanged: (v) => setState(() => _query = v.trim()),
                     ),
                   ),
-                  onChanged: (v) => setState(() => _query = v.trim()),
+                  if (widget.onSkinToneChanged != null) ...[
+                    const SizedBox(width: 4),
+                    Tooltip(
+                      message: 'Default skin tone',
+                      child: InkWell(
+                        borderRadius: BorderRadius.circular(8),
+                        onTap: _openDefaultToneStrip,
+                        child: Padding(
+                          padding: const EdgeInsets.all(4),
+                          child: SizedBox(
+                            width: 28,
+                            height: 28,
+                            child: OpenMojiImage(
+                              grapheme: widget.skinTone.sample,
+                              size: 28,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            Expanded(
+              child: _query.isEmpty
+                  ? _CategoryTabs(
+                      categories: categories,
+                      icons: _icons,
+                      columns: widget.columns,
+                      skinTone: widget.skinTone,
+                      onSelected: widget.onSelected,
+                      onToneRequested: _openOverrideToneStrip,
+                    )
+                  : _EmojiGrid(
+                      emoji: OpenMojiCatalog.search(_query),
+                      columns: widget.columns,
+                      skinTone: widget.skinTone,
+                      onSelected: widget.onSelected,
+                      onToneRequested: _openOverrideToneStrip,
+                    ),
+            ),
+          ],
+        ),
+        if (_toneStripBase != null)
+          Positioned.fill(
+            child: GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onTap: _closeToneStrip,
+              child: Align(
+                alignment: Alignment.bottomCenter,
+                child: _ToneStrip(
+                  base: _toneStripBase!,
+                  onSelected: _onToneSelected,
                 ),
               ),
-              if (widget.onSkinToneChanged != null) ...[
-                const SizedBox(width: 4),
-                _SkinToneSelector(
-                  tone: widget.skinTone,
-                  onChanged: widget.onSkinToneChanged!,
-                ),
-              ],
-            ],
+            ),
           ),
-        ),
-        Expanded(
-          child: _query.isEmpty
-              ? _CategoryTabs(
-                  categories: categories,
-                  icons: _icons,
-                  columns: widget.columns,
-                  skinTone: widget.skinTone,
-                  onSelected: widget.onSelected,
-                )
-              : _EmojiGrid(
-                  emoji: OpenMojiCatalog.search(_query),
-                  columns: widget.columns,
-                  skinTone: widget.skinTone,
-                  onSelected: widget.onSelected,
-                ),
-        ),
       ],
     );
   }
 }
 
-/// Default skin-tone chooser shown in the picker header.
-class _SkinToneSelector extends StatelessWidget {
-  const _SkinToneSelector({required this.tone, required this.onChanged});
+/// Inline row of skin-tone swatches. For the default strip ([base] empty) the
+/// swatches are sample hands; for an override they are the toned variants of
+/// [base].
+class _ToneStrip extends StatelessWidget {
+  const _ToneStrip({required this.base, required this.onSelected});
 
-  final SkinTone tone;
-  final ValueChanged<SkinTone> onChanged;
+  final String base;
+  final ValueChanged<SkinTone> onSelected;
 
   @override
   Widget build(BuildContext context) {
-    return PopupMenuButton<SkinTone>(
-      tooltip: 'Default skin tone',
-      onSelected: onChanged,
-      itemBuilder: (context) => [
-        for (final t in SkinTone.values)
-          PopupMenuItem(
-            value: t,
-            child: Row(
-              children: [
-                SizedBox(
-                  width: 24,
-                  height: 24,
-                  child: OpenMojiImage(grapheme: t.sample, size: 24),
-                ),
-                const SizedBox(width: 12),
-                Text(t.label),
-              ],
-            ),
-          ),
-      ],
+    final cs = Theme.of(context).colorScheme;
+    return Material(
+      elevation: 6,
+      borderRadius: BorderRadius.circular(12),
+      color: cs.surfaceContainerHighest,
       child: Padding(
-        padding: const EdgeInsets.all(4),
-        child: SizedBox(
-          width: 28,
-          height: 28,
-          child: OpenMojiImage(grapheme: tone.sample, size: 28),
+        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final tone in SkinTone.values)
+              InkWell(
+                borderRadius: BorderRadius.circular(8),
+                onTap: () => onSelected(tone),
+                child: Padding(
+                  padding: const EdgeInsets.all(6),
+                  child: SizedBox(
+                    width: 30,
+                    height: 30,
+                    child: OpenMojiImage(
+                      grapheme: base.isEmpty
+                          ? tone.sample
+                          : applySkinTone(base, tone),
+                      size: 30,
+                    ),
+                  ),
+                ),
+              ),
+          ],
         ),
       ),
     );
@@ -164,6 +227,7 @@ class _CategoryTabs extends StatelessWidget {
     required this.columns,
     required this.skinTone,
     required this.onSelected,
+    required this.onToneRequested,
   });
 
   final List<OpenMojiCategory> categories;
@@ -171,6 +235,7 @@ class _CategoryTabs extends StatelessWidget {
   final int columns;
   final SkinTone skinTone;
   final void Function(String emoji) onSelected;
+  final void Function(String base) onToneRequested;
 
   @override
   Widget build(BuildContext context) {
@@ -200,6 +265,7 @@ class _CategoryTabs extends StatelessWidget {
                     columns: columns,
                     skinTone: skinTone,
                     onSelected: onSelected,
+                    onToneRequested: onToneRequested,
                   ),
               ],
             ),
@@ -216,12 +282,14 @@ class _EmojiGrid extends StatelessWidget {
     required this.columns,
     required this.skinTone,
     required this.onSelected,
+    required this.onToneRequested,
   });
 
   final List<OpenMojiEmoji> emoji;
   final int columns;
   final SkinTone skinTone;
   final void Function(String emoji) onSelected;
+  final void Function(String base) onToneRequested;
 
   @override
   Widget build(BuildContext context) {
@@ -247,9 +315,8 @@ class _EmojiGrid extends StatelessWidget {
         return InkWell(
           borderRadius: BorderRadius.circular(8),
           onTap: () => onSelected(shown),
-          onLongPress: supportsTone
-              ? () => _pickTone(context, e.emoji)
-              : null,
+          onLongPress:
+              supportsTone ? () => onToneRequested(e.emoji) : null,
           child: Padding(
             padding: const EdgeInsets.all(6),
             child: OpenMojiImage(grapheme: shown),
@@ -257,33 +324,5 @@ class _EmojiGrid extends StatelessWidget {
         );
       },
     );
-  }
-
-  Future<void> _pickTone(BuildContext context, String base) async {
-    final overlay =
-        Overlay.of(context).context.findRenderObject()! as RenderBox;
-    final box = context.findRenderObject()! as RenderBox;
-    final topLeft = box.localToGlobal(Offset.zero, ancestor: overlay);
-    final position = RelativeRect.fromRect(
-      topLeft & box.size,
-      Offset.zero & overlay.size,
-    );
-
-    final picked = await showMenu<SkinTone>(
-      context: context,
-      position: position,
-      items: [
-        for (final t in SkinTone.values)
-          PopupMenuItem(
-            value: t,
-            child: SizedBox(
-              width: 32,
-              height: 32,
-              child: OpenMojiImage(grapheme: applySkinTone(base, t), size: 32),
-            ),
-          ),
-      ],
-    );
-    if (picked != null) onSelected(applySkinTone(base, picked));
   }
 }

--- a/lib/features/chat/widgets/openmoji_picker.dart
+++ b/lib/features/chat/widgets/openmoji_picker.dart
@@ -113,8 +113,9 @@ class _OpenMojiPickerState extends State<OpenMojiPicker> {
                   ),
                   if (widget.onSkinToneChanged != null) ...[
                     const SizedBox(width: 4),
-                    Tooltip(
-                      message: 'Default skin tone',
+                    Semantics(
+                      button: true,
+                      label: 'Default skin tone',
                       child: InkWell(
                         borderRadius: BorderRadius.circular(8),
                         onTap: _openDefaultToneStrip,

--- a/lib/features/chat/widgets/openmoji_picker.dart
+++ b/lib/features/chat/widgets/openmoji_picker.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:kohera/core/utils/openmoji.dart';
 import 'package:kohera/core/utils/openmoji_catalog.dart';
 import 'package:kohera/shared/widgets/openmoji_image.dart';
 
@@ -8,11 +9,23 @@ import 'package:kohera/shared/widgets/openmoji_image.dart';
 
 /// In-house emoji picker rendering OpenMoji image assets in a tabbed,
 /// searchable grid. Calls [onSelected] with the Unicode emoji on tap.
+///
+/// Tone-supporting emoji render with [skinTone] applied; long-pressing one
+/// offers a per-emoji tone override. When [onSkinToneChanged] is provided a
+/// tone selector is shown for changing the default.
 class OpenMojiPicker extends StatefulWidget {
-  const OpenMojiPicker({required this.onSelected, super.key, this.columns = 8});
+  const OpenMojiPicker({
+    required this.onSelected,
+    super.key,
+    this.columns = 8,
+    this.skinTone = SkinTone.none,
+    this.onSkinToneChanged,
+  });
 
   final void Function(String emoji) onSelected;
   final int columns;
+  final SkinTone skinTone;
+  final ValueChanged<SkinTone>? onSkinToneChanged;
 
   @override
   State<OpenMojiPicker> createState() => _OpenMojiPickerState();
@@ -54,19 +67,32 @@ class _OpenMojiPickerState extends State<OpenMojiPicker> {
       children: [
         Padding(
           padding: const EdgeInsets.fromLTRB(8, 8, 8, 4),
-          child: TextField(
-            decoration: InputDecoration(
-              isDense: true,
-              hintText: 'Search emoji',
-              prefixIcon: const Icon(Icons.search, size: 20),
-              filled: true,
-              fillColor: cs.surfaceContainerHighest,
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide.none,
+          child: Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  decoration: InputDecoration(
+                    isDense: true,
+                    hintText: 'Search emoji',
+                    prefixIcon: const Icon(Icons.search, size: 20),
+                    filled: true,
+                    fillColor: cs.surfaceContainerHighest,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide.none,
+                    ),
+                  ),
+                  onChanged: (v) => setState(() => _query = v.trim()),
+                ),
               ),
-            ),
-            onChanged: (v) => setState(() => _query = v.trim()),
+              if (widget.onSkinToneChanged != null) ...[
+                const SizedBox(width: 4),
+                _SkinToneSelector(
+                  tone: widget.skinTone,
+                  onChanged: widget.onSkinToneChanged!,
+                ),
+              ],
+            ],
           ),
         ),
         Expanded(
@@ -75,15 +101,58 @@ class _OpenMojiPickerState extends State<OpenMojiPicker> {
                   categories: categories,
                   icons: _icons,
                   columns: widget.columns,
+                  skinTone: widget.skinTone,
                   onSelected: widget.onSelected,
                 )
               : _EmojiGrid(
                   emoji: OpenMojiCatalog.search(_query),
                   columns: widget.columns,
+                  skinTone: widget.skinTone,
                   onSelected: widget.onSelected,
                 ),
         ),
       ],
+    );
+  }
+}
+
+/// Default skin-tone chooser shown in the picker header.
+class _SkinToneSelector extends StatelessWidget {
+  const _SkinToneSelector({required this.tone, required this.onChanged});
+
+  final SkinTone tone;
+  final ValueChanged<SkinTone> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton<SkinTone>(
+      tooltip: 'Default skin tone',
+      onSelected: onChanged,
+      itemBuilder: (context) => [
+        for (final t in SkinTone.values)
+          PopupMenuItem(
+            value: t,
+            child: Row(
+              children: [
+                SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: OpenMojiImage(grapheme: t.sample, size: 24),
+                ),
+                const SizedBox(width: 12),
+                Text(t.label),
+              ],
+            ),
+          ),
+      ],
+      child: Padding(
+        padding: const EdgeInsets.all(4),
+        child: SizedBox(
+          width: 28,
+          height: 28,
+          child: OpenMojiImage(grapheme: tone.sample, size: 28),
+        ),
+      ),
     );
   }
 }
@@ -93,12 +162,14 @@ class _CategoryTabs extends StatelessWidget {
     required this.categories,
     required this.icons,
     required this.columns,
+    required this.skinTone,
     required this.onSelected,
   });
 
   final List<OpenMojiCategory> categories;
   final Map<String, IconData> icons;
   final int columns;
+  final SkinTone skinTone;
   final void Function(String emoji) onSelected;
 
   @override
@@ -127,6 +198,7 @@ class _CategoryTabs extends StatelessWidget {
                   _EmojiGrid(
                     emoji: c.emoji,
                     columns: columns,
+                    skinTone: skinTone,
                     onSelected: onSelected,
                   ),
               ],
@@ -142,11 +214,13 @@ class _EmojiGrid extends StatelessWidget {
   const _EmojiGrid({
     required this.emoji,
     required this.columns,
+    required this.skinTone,
     required this.onSelected,
   });
 
   final List<OpenMojiEmoji> emoji;
   final int columns;
+  final SkinTone skinTone;
   final void Function(String emoji) onSelected;
 
   @override
@@ -168,15 +242,48 @@ class _EmojiGrid extends StatelessWidget {
       itemCount: emoji.length,
       itemBuilder: (context, i) {
         final e = emoji[i];
+        final supportsTone = openMojiSupportsSkinTone(e.emoji);
+        final shown = supportsTone ? applySkinTone(e.emoji, skinTone) : e.emoji;
         return InkWell(
           borderRadius: BorderRadius.circular(8),
-          onTap: () => onSelected(e.emoji),
+          onTap: () => onSelected(shown),
+          onLongPress: supportsTone
+              ? () => _pickTone(context, e.emoji)
+              : null,
           child: Padding(
             padding: const EdgeInsets.all(6),
-            child: OpenMojiImage(grapheme: e.emoji),
+            child: OpenMojiImage(grapheme: shown),
           ),
         );
       },
     );
+  }
+
+  Future<void> _pickTone(BuildContext context, String base) async {
+    final overlay =
+        Overlay.of(context).context.findRenderObject()! as RenderBox;
+    final box = context.findRenderObject()! as RenderBox;
+    final topLeft = box.localToGlobal(Offset.zero, ancestor: overlay);
+    final position = RelativeRect.fromRect(
+      topLeft & box.size,
+      Offset.zero & overlay.size,
+    );
+
+    final picked = await showMenu<SkinTone>(
+      context: context,
+      position: position,
+      items: [
+        for (final t in SkinTone.values)
+          PopupMenuItem(
+            value: t,
+            child: SizedBox(
+              width: 32,
+              height: 32,
+              child: OpenMojiImage(grapheme: applySkinTone(base, t), size: 32),
+            ),
+          ),
+      ],
+    );
+    if (picked != null) onSelected(applySkinTone(base, picked));
   }
 }

--- a/lib/features/chat/widgets/sticker_picker_overlay.dart
+++ b/lib/features/chat/widgets/sticker_picker_overlay.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:kohera/core/models/sticker_pack.dart';
+import 'package:kohera/core/utils/openmoji.dart';
 import 'package:kohera/shared/widgets/mxc_image.dart';
 import 'package:kohera/shared/widgets/openmoji_image.dart';
 import 'package:matrix/matrix.dart';
@@ -12,6 +13,7 @@ class StickerPickerOverlay extends StatefulWidget {
     required this.onEmojiTapped,
     required this.onManagePacks,
     super.key,
+    this.skinTone = SkinTone.none,
   });
 
   final List<StickerPack> packs;
@@ -19,6 +21,7 @@ class StickerPickerOverlay extends StatefulWidget {
   final void Function(PackImage) onStickerTapped;
   final void Function(PackImage) onEmojiTapped;
   final VoidCallback onManagePacks;
+  final SkinTone skinTone;
 
   @override
   State<StickerPickerOverlay> createState() => _StickerPickerOverlayState();
@@ -302,14 +305,18 @@ class _StickerPickerOverlayState extends State<StickerPickerOverlay>
   }
 
   Widget _emojiItem(PackImage emoji) {
+    final base = emoji.emoji;
+    final toned = base == null ? null : applySkinTone(base, widget.skinTone);
     return Tooltip(
       message: emoji.altText,
       child: GestureDetector(
-        onTap: () => widget.onEmojiTapped(emoji),
+        onTap: () => widget.onEmojiTapped(
+          toned == null ? emoji : _withGrapheme(emoji, toned),
+        ),
         child: Padding(
           padding: const EdgeInsets.all(4),
-          child: emoji.emoji != null
-              ? OpenMojiImage(grapheme: emoji.emoji!, size: 40)
+          child: toned != null
+              ? OpenMojiImage(grapheme: toned, size: 40)
               : MxcImage(
                   mxcUrl: emoji.url.toString(),
                   client: widget.client,
@@ -323,4 +330,13 @@ class _StickerPickerOverlayState extends State<StickerPickerOverlay>
       ),
     );
   }
+
+  PackImage _withGrapheme(PackImage source, String grapheme) => PackImage(
+        shortcode: source.shortcode,
+        url: source.url,
+        isSticker: source.isSticker,
+        isEmoji: source.isEmoji,
+        body: source.body,
+        emoji: grapheme,
+      );
 }

--- a/test/core/utils/openmoji_test.dart
+++ b/test/core/utils/openmoji_test.dart
@@ -48,4 +48,33 @@ void main() {
       expect(openMojiAssetFor('x'), isNull);
     });
   });
+
+  group('skin tones', () {
+    test('applySkinTone inserts the modifier for a supporting emoji', () {
+      expect(applySkinTone('\u{1F44D}', SkinTone.dark), '\u{1F44D}\u{1F3FF}');
+      expect(
+        openMojiAssetFor(applySkinTone('\u{1F44D}', SkinTone.dark)),
+        'assets/openmoji/1F44D-1F3FF.png',
+      );
+    });
+
+    test('applySkinTone is a no-op for none', () {
+      expect(applySkinTone('\u{1F44D}', SkinTone.none), '\u{1F44D}');
+    });
+
+    test('applySkinTone falls back when no toned variant exists', () {
+      // Grinning face has no skin-tone variants.
+      expect(applySkinTone('\u{1F600}', SkinTone.dark), '\u{1F600}');
+    });
+
+    test('openMojiSupportsSkinTone reflects availability', () {
+      expect(openMojiSupportsSkinTone('\u{1F44D}'), isTrue);
+      expect(openMojiSupportsSkinTone('\u{1F600}'), isFalse);
+    });
+
+    test('SkinTone.sample renders a toned hand', () {
+      expect(SkinTone.dark.sample, '\u{270B}\u{1F3FF}');
+      expect(SkinTone.none.sample, '\u{270B}');
+    });
+  });
 }

--- a/test/services/preferences_service_test.dart
+++ b/test/services/preferences_service_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/services/preferences_service.dart';
+import 'package:kohera/core/utils/openmoji.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -446,6 +447,31 @@ void main() {
       expect(MobileTab.inbox.label, 'Inbox');
       expect(MobileTab.chats.label, 'Chats');
       expect(MobileTab.you.label, 'You');
+    });
+  });
+
+  group('emoji skin tone', () {
+    test('defaults to none', () {
+      expect(prefs.skinTone, SkinTone.none);
+    });
+
+    test('round-trips a chosen tone', () async {
+      await prefs.setSkinTone(SkinTone.medium);
+      expect(prefs.skinTone, SkinTone.medium);
+    });
+
+    test('notifies listeners on change', () async {
+      var notified = false;
+      prefs.addListener(() => notified = true);
+      await prefs.setSkinTone(SkinTone.dark);
+      expect(notified, isTrue);
+    });
+
+    test('falls back to none on unknown stored value', () async {
+      SharedPreferences.setMockInitialValues({'emoji_skin_tone': 'bogus'});
+      final sp = await SharedPreferences.getInstance();
+      final badPrefs = PreferencesService(prefs: sp);
+      expect(badPrefs.skinTone, SkinTone.none);
     });
   });
 

--- a/test/widgets/chat/hover_action_bar_test.dart
+++ b/test/widgets/chat/hover_action_bar_test.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/features/chat/widgets/hover_action_bar.dart';
 import 'package:kohera/shared/widgets/openmoji_image.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 /// Finds the [OpenMojiImage] rendered for [emoji].
 Finder _emojiImage(String emoji) => find.byWidgetPredicate(
@@ -14,17 +17,21 @@ void main() {
     void Function(String emoji)? onQuickReact,
     VoidCallback? onReply,
     void Function(Offset position)? onMore,
+    PreferencesService? prefs,
   }) {
-    return MaterialApp(
-      theme: ThemeData(splashFactory: InkRipple.splashFactory),
-      home: Scaffold(
-        body: Center(
-          child: HoverActionBar(
-            cs: const ColorScheme.light(),
-            onReact: onReact,
-            onQuickReact: onQuickReact,
-            onReply: onReply,
-            onMore: onMore ?? (_) {},
+    return ChangeNotifierProvider<PreferencesService>(
+      create: (_) => prefs ?? PreferencesService(),
+      child: MaterialApp(
+        theme: ThemeData(splashFactory: InkRipple.splashFactory),
+        home: Scaffold(
+          body: Center(
+            child: HoverActionBar(
+              cs: const ColorScheme.light(),
+              onReact: onReact,
+              onQuickReact: onQuickReact,
+              onReply: onReply,
+              onMore: onMore ?? (_) {},
+            ),
           ),
         ),
       ),
@@ -103,6 +110,26 @@ void main() {
 
       expect(selectedEmoji, '\u{1F44D}');
       expect(_emojiImage('\u{1F602}'), findsNothing);
+    });
+
+    testWidgets('quick-react applies the default skin tone', (tester) async {
+      SharedPreferences.setMockInitialValues({'emoji_skin_tone': 'dark'});
+      final sp = await SharedPreferences.getInstance();
+      final prefs = PreferencesService(prefs: sp);
+      String? reacted;
+
+      await tester.pumpWidget(
+        buildTestWidget(prefs: prefs, onQuickReact: (e) => reacted = e),
+      );
+      await tester.tap(find.byIcon(Icons.add_reaction_outlined));
+      await tester.pumpAndSettle();
+
+      // 👍 is toned; ❤️ (no variant) stays base.
+      expect(_emojiImage('\u{1F44D}\u{1F3FF}'), findsOneWidget);
+      expect(_emojiImage('\u{2764}\u{FE0F}'), findsOneWidget);
+
+      await tester.tap(_emojiImage('\u{1F44D}\u{1F3FF}'));
+      expect(reacted, '\u{1F44D}\u{1F3FF}');
     });
   });
 }

--- a/test/widgets/chat/openmoji_picker_test.dart
+++ b/test/widgets/chat/openmoji_picker_test.dart
@@ -107,11 +107,11 @@ void main() {
       (tester) async {
     await tester.pumpWidget(_wrap((_) {}));
     await tester.pump();
-    expect(find.byTooltip('Default skin tone'), findsNothing);
+    expect(find.bySemanticsLabel('Default skin tone'), findsNothing);
 
     await tester.pumpWidget(_wrap((_) {}, onSkinToneChanged: (_) {}));
     await tester.pump();
-    expect(find.byTooltip('Default skin tone'), findsOneWidget);
+    expect(find.bySemanticsLabel('Default skin tone'), findsOneWidget);
   });
 
   testWidgets('header swatch opens the default-tone strip and sets the tone',
@@ -120,7 +120,7 @@ void main() {
     await tester.pumpWidget(_wrap((_) {}, onSkinToneChanged: (t) => chosen = t));
     await tester.pump();
 
-    await tester.tap(find.byTooltip('Default skin tone'));
+    await tester.tap(find.bySemanticsLabel('Default skin tone'));
     await tester.pump();
 
     // The strip shows toned sample hands; tap the dark one.

--- a/test/widgets/chat/openmoji_picker_test.dart
+++ b/test/widgets/chat/openmoji_picker_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/utils/openmoji.dart';
 import 'package:kohera/core/utils/openmoji_catalog.dart';
 import 'package:kohera/features/chat/widgets/openmoji_picker.dart';
 import 'package:kohera/shared/widgets/openmoji_image.dart';
@@ -11,7 +12,8 @@ const _json = '''
 {"groups":[
   {"key":"smileys-emotion","emoji":[
     {"e":"😀","n":"1F600","s":"grinning face happy"},
-    {"e":"😢","n":"1F622","s":"crying face sad"}
+    {"e":"😢","n":"1F622","s":"crying face sad"},
+    {"e":"👍","n":"1F44D","s":"thumbs up"}
   ]},
   {"key":"flags","emoji":[
     {"e":"🇺🇸","n":"1F1FA-1F1F8","s":"flag united states"}
@@ -32,12 +34,21 @@ Finder _cell(String emoji) => find.byWidgetPredicate(
       (w) => w is OpenMojiImage && w.grapheme == emoji,
     );
 
-Widget _wrap(void Function(String) onSelected) => MaterialApp(
+Widget _wrap(
+  void Function(String) onSelected, {
+  SkinTone skinTone = SkinTone.none,
+  ValueChanged<SkinTone>? onSkinToneChanged,
+}) =>
+    MaterialApp(
       home: Scaffold(
         body: SizedBox(
           width: 350,
           height: 400,
-          child: OpenMojiPicker(onSelected: onSelected),
+          child: OpenMojiPicker(
+            onSelected: onSelected,
+            skinTone: skinTone,
+            onSkinToneChanged: onSkinToneChanged,
+          ),
         ),
       ),
     );
@@ -74,5 +85,32 @@ void main() {
 
     expect(_cell('🇺🇸'), findsOneWidget);
     expect(_cell('😀'), findsNothing);
+  });
+
+  testWidgets('applies the default skin tone to supporting emoji', (tester) async {
+    String? selected;
+    await tester.pumpWidget(
+      _wrap((e) => selected = e, skinTone: SkinTone.dark),
+    );
+    await tester.pump();
+
+    // 👍 gets the dark modifier; 😀 (no variant) is unchanged.
+    expect(_cell('\u{1F44D}\u{1F3FF}'), findsOneWidget);
+    expect(_cell('\u{1F44D}'), findsNothing);
+    expect(_cell('😀'), findsOneWidget);
+
+    await tester.tap(_cell('\u{1F44D}\u{1F3FF}'));
+    expect(selected, '\u{1F44D}\u{1F3FF}');
+  });
+
+  testWidgets('shows the skin-tone selector only when onSkinToneChanged is set',
+      (tester) async {
+    await tester.pumpWidget(_wrap((_) {}));
+    await tester.pump();
+    expect(find.byType(PopupMenuButton<SkinTone>), findsNothing);
+
+    await tester.pumpWidget(_wrap((_) {}, onSkinToneChanged: (_) {}));
+    await tester.pump();
+    expect(find.byType(PopupMenuButton<SkinTone>), findsOneWidget);
   });
 }

--- a/test/widgets/chat/openmoji_picker_test.dart
+++ b/test/widgets/chat/openmoji_picker_test.dart
@@ -107,10 +107,37 @@ void main() {
       (tester) async {
     await tester.pumpWidget(_wrap((_) {}));
     await tester.pump();
-    expect(find.byType(PopupMenuButton<SkinTone>), findsNothing);
+    expect(find.byTooltip('Default skin tone'), findsNothing);
 
     await tester.pumpWidget(_wrap((_) {}, onSkinToneChanged: (_) {}));
     await tester.pump();
-    expect(find.byType(PopupMenuButton<SkinTone>), findsOneWidget);
+    expect(find.byTooltip('Default skin tone'), findsOneWidget);
+  });
+
+  testWidgets('header swatch opens the default-tone strip and sets the tone',
+      (tester) async {
+    SkinTone? chosen;
+    await tester.pumpWidget(_wrap((_) {}, onSkinToneChanged: (t) => chosen = t));
+    await tester.pump();
+
+    await tester.tap(find.byTooltip('Default skin tone'));
+    await tester.pump();
+
+    // The strip shows toned sample hands; tap the dark one.
+    await tester.tap(_cell(SkinTone.dark.sample));
+    expect(chosen, SkinTone.dark);
+  });
+
+  testWidgets('long-press opens a per-emoji tone override', (tester) async {
+    String? selected;
+    await tester.pumpWidget(_wrap((e) => selected = e));
+    await tester.pump();
+
+    await tester.longPress(_cell('👍'));
+    await tester.pump();
+
+    // Strip shows toned variants; the dark one only exists in the strip.
+    await tester.tap(_cell('\u{1F44D}\u{1F3FF}'));
+    expect(selected, '\u{1F44D}\u{1F3FF}');
   });
 }


### PR DESCRIPTION
## Summary

Restore skin-tone selection in the in-house `OpenMojiPicker` (a regression vs the removed `emoji_picker_flutter`), with a remembered default tone and per-emoji override.

## Changes

- **Resolver** (`openmoji.dart`): `SkinTone` enum (Fitzpatrick `1F3FB`–`1F3FF`); `applySkinTone(grapheme, tone)` inserts the modifier after the leading codepoint and **falls back to the base grapheme when no toned asset is bundled** (safe on any emoji); `openMojiSupportsSkinTone` detects support at runtime against the manifest — no metadata changes needed.
- **Preference** (`preferences_service.dart`): default `skinTone`, persisted and notifying like the other prefs.
- **Picker** (`openmoji_picker.dart`): tone-supporting cells render with the default tone applied; long-press a cell for a per-emoji tone override; a default-tone selector appears in the header when `onSkinToneChanged` is supplied. Non-tone emoji are untouched.
- **Wiring**: the reaction-emoji dialog (`emoji_picker_sheet.dart`) and the hover overlay picker (`hover_action_bar.dart`) read tone + setter from `PreferencesService`.

## Out of scope

- Recently-used emoji (#565 carryover).
- Per-component tones for multi-person ZWJ sequences (single modifier only).

## Testing

- [x] `flutter analyze` clean
- [x] Resolver tests: `applySkinTone` apply/no-op/fallback, `openMojiSupportsSkinTone`, `SkinTone.sample`
- [x] Preference tests: default/round-trip/notify/unknown-value
- [x] Picker tests: default tone applied to supporting emoji (and inserted on tap), non-tone unaffected, selector shown only with `onSkinToneChanged`
- Note: full suite has 37 **pre-existing** failures unrelated to this change (`room_members_section`, `chat_app_bar`, `room_tile`) — identical on clean `master`.

## Design note

Tone support is detected at runtime (`applySkinTone` + manifest lookup) rather than via a metadata flag — simpler, and avoids regenerating/bloating `metadata.json`.

## Linked issues

Closes #573
Refs #566

## Checklist

- [x] Conventional Commits subject; issue refs in footer
- [x] Logs use `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added
- [x] Tests added/updated to cover the change
- [x] Targets `master`
