### PR TITLE
feat(#581): show emoji & sticker picker inline at the compose bar

### DIFF
--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -72,6 +72,9 @@ class _ChatScreenState extends State<ChatScreen>
   // ── Compose state ───────────────────────────────────────
   final _compose = ComposeStateController();
 
+  /// Whether the inline emoji & sticker panel is shown above the compose bar.
+  bool _emojiPanelOpen = false;
+
   // ── Typing ─────────────────────────────────────────────
   TypingController? _typingCtrl;
 
@@ -110,9 +113,18 @@ class _ChatScreenState extends State<ChatScreen>
     _actions = _createActions();
     _search = _createSearchController();
     _initControllers();
+    _composeFocusNode.addListener(_onComposeFocusChanged);
     if (kIsWeb) {
       initWebPasteListener();
       _webPasteSub = webPasteImageStream.listen(_onWebPasteImage);
+    }
+  }
+
+  void _onComposeFocusChanged() {
+    // Focusing the input (e.g. to type) closes the inline emoji panel so the
+    // keyboard can take its place.
+    if (_composeFocusNode.hasFocus && _emojiPanelOpen) {
+      setState(() => _emojiPanelOpen = false);
     }
   }
 
@@ -362,39 +374,42 @@ class _ChatScreenState extends State<ChatScreen>
   // ── Sticker picker ────────────────────────────────────────
 
   void _toggleStickerPicker() {
-    final matrix = context.read<MatrixService>();
-    final stickerService = context.read<StickerPackService>();
-    final skinTone = context.read<PreferencesService>().skinTone;
-    final room = matrix.client.getRoomById(widget.roomId);
-    if (room == null) return;
-    unawaited(showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      useSafeArea: true,
-      builder: (sheetCtx) => DraggableScrollableSheet(
-        expand: false,
-        initialChildSize: 0.7,
-        minChildSize: 0.7,
-        maxChildSize: 0.9,
-        builder: (_, __) => StickerPickerOverlay(
-          packs: stickerService.packsForRoom(room),
-          client: matrix.client,
-          skinTone: skinTone,
-          onStickerTapped: (sticker) {
-            Navigator.of(sheetCtx).pop();
-            unawaited(_handleStickerSelected(sticker));
-          },
-          onEmojiTapped: (emoji) {
-            Navigator.of(sheetCtx).pop();
-            _handleEmojiSelected(emoji);
-          },
-          onManagePacks: () {
-            Navigator.of(sheetCtx).pop();
-            context.goNamed(Routes.settingsStickerPacks);
-          },
+    setState(() => _emojiPanelOpen = !_emojiPanelOpen);
+    if (_emojiPanelOpen) {
+      _composeFocusNode.unfocus();
+    }
+  }
+
+  Widget _buildEmojiPanel(MatrixService matrix, Room room) {
+    final cs = Theme.of(context).colorScheme;
+    final stickerService = context.watch<StickerPackService>();
+    final skinTone = context.watch<PreferencesService>().skinTone;
+    final height =
+        (MediaQuery.sizeOf(context).height * 0.4).clamp(240.0, 360.0);
+
+    return Container(
+      height: height,
+      decoration: BoxDecoration(
+        color: cs.surface,
+        border: Border(
+          top: BorderSide(color: cs.outlineVariant.withValues(alpha: 0.5)),
         ),
       ),
-    ),);
+      child: StickerPickerOverlay(
+        packs: stickerService.packsForRoom(room),
+        client: matrix.client,
+        skinTone: skinTone,
+        onStickerTapped: (sticker) {
+          setState(() => _emojiPanelOpen = false);
+          unawaited(_handleStickerSelected(sticker));
+        },
+        onEmojiTapped: _handleEmojiSelected,
+        onManagePacks: () {
+          setState(() => _emojiPanelOpen = false);
+          context.goNamed(Routes.settingsStickerPacks);
+        },
+      ),
+    );
   }
 
   Future<void> _handleStickerSelected(PackImage sticker) async {
@@ -443,6 +458,7 @@ class _ChatScreenState extends State<ChatScreen>
     _compose.dispose();
     _searchCtrl.dispose();
     _searchFocusNode.dispose();
+    _composeFocusNode.removeListener(_onComposeFocusChanged);
     _composeFocusNode.dispose();
     _typingCtrl?.dispose();
     _voiceCtrl?.dispose();
@@ -548,6 +564,7 @@ class _ChatScreenState extends State<ChatScreen>
           myUserId: matrix.client.userID,
           syncStream: matrix.client.onSync.stream,
         ),
+        if (_emojiPanelOpen) _buildEmojiPanel(matrix, room),
         ComposeBarSection(
           replyNotifier: _compose.replyNotifier,
           editNotifier: _compose.editNotifier,

--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -39,6 +39,7 @@ import 'package:kohera/features/chat/widgets/search_results_body.dart';
 import 'package:kohera/features/chat/widgets/sticker_picker_overlay.dart';
 import 'package:kohera/features/chat/widgets/typing_indicator.dart';
 import 'package:kohera/features/chat/widgets/web_image_paste.dart';
+import 'package:kohera/features/home/screens/home_shell.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 
@@ -374,10 +375,51 @@ class _ChatScreenState extends State<ChatScreen>
   // ── Sticker picker ────────────────────────────────────────
 
   void _toggleStickerPicker() {
+    final isNarrow =
+        MediaQuery.sizeOf(context).width < HomeShell.wideBreakpoint;
+    if (isNarrow) {
+      final matrix = context.read<MatrixService>();
+      final room = matrix.client.getRoomById(widget.roomId);
+      if (room != null) _openStickerSheet(matrix, room);
+      return;
+    }
     setState(() => _emojiPanelOpen = !_emojiPanelOpen);
     if (_emojiPanelOpen) {
       _composeFocusNode.unfocus();
     }
+  }
+
+  void _openStickerSheet(MatrixService matrix, Room room) {
+    final stickerService = context.read<StickerPackService>();
+    final skinTone = context.read<PreferencesService>().skinTone;
+    unawaited(showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (sheetCtx) => DraggableScrollableSheet(
+        expand: false,
+        initialChildSize: 0.7,
+        minChildSize: 0.7,
+        maxChildSize: 0.9,
+        builder: (_, __) => StickerPickerOverlay(
+          packs: stickerService.packsForRoom(room),
+          client: matrix.client,
+          skinTone: skinTone,
+          onStickerTapped: (sticker) {
+            Navigator.of(sheetCtx).pop();
+            unawaited(_handleStickerSelected(sticker));
+          },
+          onEmojiTapped: (emoji) {
+            Navigator.of(sheetCtx).pop();
+            _handleEmojiSelected(emoji);
+          },
+          onManagePacks: () {
+            Navigator.of(sheetCtx).pop();
+            context.goNamed(Routes.settingsStickerPacks);
+          },
+        ),
+      ),
+    ),);
   }
 
   Widget _buildEmojiPanel(MatrixService matrix, Room room) {

--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -384,30 +384,32 @@ class _ChatScreenState extends State<ChatScreen>
     final cs = Theme.of(context).colorScheme;
     final stickerService = context.watch<StickerPackService>();
     final skinTone = context.watch<PreferencesService>().skinTone;
-    final height =
-        (MediaQuery.sizeOf(context).height * 0.4).clamp(240.0, 360.0);
+    final size = MediaQuery.sizeOf(context);
+    final width = (size.width - 16).clamp(0.0, 360.0);
+    final height = (size.height * 0.45).clamp(240.0, 360.0);
 
-    return Container(
-      height: height,
-      decoration: BoxDecoration(
-        color: cs.surface,
-        border: Border(
-          top: BorderSide(color: cs.outlineVariant.withValues(alpha: 0.5)),
+    return Material(
+      elevation: 8,
+      color: cs.surfaceContainer,
+      borderRadius: BorderRadius.circular(16),
+      clipBehavior: Clip.antiAlias,
+      child: SizedBox(
+        width: width,
+        height: height,
+        child: StickerPickerOverlay(
+          packs: stickerService.packsForRoom(room),
+          client: matrix.client,
+          skinTone: skinTone,
+          onStickerTapped: (sticker) {
+            setState(() => _emojiPanelOpen = false);
+            unawaited(_handleStickerSelected(sticker));
+          },
+          onEmojiTapped: _handleEmojiSelected,
+          onManagePacks: () {
+            setState(() => _emojiPanelOpen = false);
+            context.goNamed(Routes.settingsStickerPacks);
+          },
         ),
-      ),
-      child: StickerPickerOverlay(
-        packs: stickerService.packsForRoom(room),
-        client: matrix.client,
-        skinTone: skinTone,
-        onStickerTapped: (sticker) {
-          setState(() => _emojiPanelOpen = false);
-          unawaited(_handleStickerSelected(sticker));
-        },
-        onEmojiTapped: _handleEmojiSelected,
-        onManagePacks: () {
-          setState(() => _emojiPanelOpen = false);
-          context.goNamed(Routes.settingsStickerPacks);
-        },
       ),
     );
   }
@@ -541,22 +543,39 @@ class _ChatScreenState extends State<ChatScreen>
         if (roomHasCall && !isInCall)
           JoinCallBanner(room: room, callService: callService),
         Expanded(
-          child: MessageListView(
-            key: _messageListKey,
-            room: room,
-            matrix: matrix,
-            initialEventId: widget.initialEventId,
-            highlightedEventId: _search.highlightedEventId,
-            onReply: _setReplyTo,
-            onEdit: (event, timeline) =>
-                _compose.setEditEvent(event, timeline, _msgCtrl),
-            onToggleReaction: _actions.toggleReaction,
-            onPin: _actions.togglePin,
-            onHighlight: _search.setHighlight,
-            onScrollBack: isTouchDevice ? _dismissKeyboard : null,
-            onOpenThread: _openThread,
-            onReplyInThread: _replyInThread,
-            onTimelineChanged: _onTimelineChanged,
+          child: Stack(
+            children: [
+              MessageListView(
+                key: _messageListKey,
+                room: room,
+                matrix: matrix,
+                initialEventId: widget.initialEventId,
+                highlightedEventId: _search.highlightedEventId,
+                onReply: _setReplyTo,
+                onEdit: (event, timeline) =>
+                    _compose.setEditEvent(event, timeline, _msgCtrl),
+                onToggleReaction: _actions.toggleReaction,
+                onPin: _actions.togglePin,
+                onHighlight: _search.setHighlight,
+                onScrollBack: isTouchDevice ? _dismissKeyboard : null,
+                onOpenThread: _openThread,
+                onReplyInThread: _replyInThread,
+                onTimelineChanged: _onTimelineChanged,
+              ),
+              if (_emojiPanelOpen) ...[
+                Positioned.fill(
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.translucent,
+                    onTap: () => setState(() => _emojiPanelOpen = false),
+                  ),
+                ),
+                Positioned(
+                  left: 8,
+                  bottom: 8,
+                  child: _buildEmojiPanel(matrix, room),
+                ),
+              ],
+            ],
           ),
         ),
         TypingIndicator(
@@ -564,7 +583,6 @@ class _ChatScreenState extends State<ChatScreen>
           myUserId: matrix.client.userID,
           syncStream: matrix.client.onSync.stream,
         ),
-        if (_emojiPanelOpen) _buildEmojiPanel(matrix, room),
         ComposeBarSection(
           replyNotifier: _compose.replyNotifier,
           editNotifier: _compose.editNotifier,

--- a/test/e2e/chat_screen_test.dart
+++ b/test/e2e/chat_screen_test.dart
@@ -172,8 +172,12 @@ void main() {
   // ── Inline emoji & sticker panel ────────────────────────────────
 
   group('Chat screen — emoji panel', () {
-    testWidgets('Stickers & Emoji button toggles the inline panel',
+    testWidgets('wide layout toggles the inline panel (no modal sheet)',
         (tester) async {
+      tester.view.physicalSize = const Size(1000, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
       stubTimeline(mockRoom, mockTimeline, []);
 
       await tester.pumpWidget(buildChatApp());
@@ -185,11 +189,30 @@ void main() {
       await tester.tap(find.byTooltip('Stickers & Emoji'));
       await tester.pumpAndSettle();
       expect(find.byType(StickerPickerOverlay), findsOneWidget);
+      expect(find.byType(DraggableScrollableSheet), findsNothing);
 
       // Re-tap closes it.
       await tester.tap(find.byTooltip('Stickers & Emoji'));
       await tester.pumpAndSettle();
       expect(find.byType(StickerPickerOverlay), findsNothing);
+    });
+
+    testWidgets('narrow layout opens the picker in a bottom sheet',
+        (tester) async {
+      tester.view.physicalSize = const Size(420, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      stubTimeline(mockRoom, mockTimeline, []);
+
+      await tester.pumpWidget(buildChatApp());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Stickers & Emoji'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DraggableScrollableSheet), findsOneWidget);
+      expect(find.byType(StickerPickerOverlay), findsOneWidget);
     });
   });
 

--- a/test/e2e/chat_screen_test.dart
+++ b/test/e2e/chat_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:kohera/core/services/sticker_pack_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/chat/screens/chat_screen.dart';
 import 'package:kohera/features/chat/services/media_playback_service.dart';
+import 'package:kohera/features/chat/widgets/sticker_picker_overlay.dart';
 import 'package:matrix/matrix.dart';
 import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:mockito/annotations.dart';
@@ -167,6 +168,30 @@ void main() {
       ),
     );
   }
+
+  // ── Inline emoji & sticker panel ────────────────────────────────
+
+  group('Chat screen — emoji panel', () {
+    testWidgets('Stickers & Emoji button toggles the inline panel',
+        (tester) async {
+      stubTimeline(mockRoom, mockTimeline, []);
+
+      await tester.pumpWidget(buildChatApp());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(StickerPickerOverlay), findsNothing);
+
+      // Open: the panel renders inline (no modal route).
+      await tester.tap(find.byTooltip('Stickers & Emoji'));
+      await tester.pumpAndSettle();
+      expect(find.byType(StickerPickerOverlay), findsOneWidget);
+
+      // Re-tap closes it.
+      await tester.tap(find.byTooltip('Stickers & Emoji'));
+      await tester.pumpAndSettle();
+      expect(find.byType(StickerPickerOverlay), findsNothing);
+    });
+  });
 
   // ── Group 1: Basic Display ──────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Replace the modal bottom sheet for the emoji & sticker picker with a responsive treatment: an **inline floating popover** on wide layouts and the **bottom sheet** on narrow (phone) layouts. Reuses the existing `StickerPickerOverlay`, so OpenMoji + emoji.gg custom emoji + stickers stay unified (resolves the emoji.gg question from #581).

## Behaviour

- **Wide layouts** (≥ `HomeShell.wideBreakpoint`, 720): a rounded floating popover anchored bottom-left in the message area, above the compose bar. Overlays the chat (doesn't push it up), with a tap-outside scrim to dismiss; focusing the input or re-tapping the button closes it. Emoji taps insert and keep it open (emoji-keyboard style); sticker taps and "Manage packs" close it.
- **Narrow layouts** (< 720, phones): the modal bottom sheet, which suits phone widths better.
- Both paths share `StickerPickerOverlay` and identical selection / skin-tone behaviour.

## Changes

- `chat_screen.dart`:
  - `_toggleStickerPicker` branches on `MediaQuery` width vs `HomeShell.wideBreakpoint` — `_openStickerSheet` (modal) on narrow, inline `_emojiPanelOpen` popover on wide.
  - Inline popover rendered in the message-area `Stack` with a dismiss scrim; height/width clamped to read as a compact card. No `CompositedTransformFollower` (the sticker picker's `Tooltip`s would otherwise hit the layer-transform crash).
  - Focusing the compose input closes the inline popover.

## Design decisions (from the issue)

- **Panel content: Unified** — reuse `StickerPickerOverlay` (OpenMoji + emoji.gg + stickers).
- **Responsive:** inline popover on wide, bottom sheet on narrow (updated from the original "inline everywhere" after testing on a phone).

## Testing

- [x] `flutter analyze` clean
- [x] e2e: wide layout toggles the inline panel (no `DraggableScrollableSheet`); narrow layout opens the picker in a bottom sheet
- [x] Full suite: only the 37 pre-existing failures (`room_members_section`, `chat_app_bar`, `room_tile`), unrelated — identical on clean `master`

## Out of scope

- Reaction-emoji entry from message actions (`showEmojiPickerSheet`) stays a dialog.
- A caret/arrow pointing at the button (would require follower-anchoring → tooltip crash).

## Linked issues

Closes #581
Refs #566

## Checklist

- [x] Conventional Commits subject; issue refs in footer
- [x] Logs use `debugPrint('[Kohera] ...')` (none added)
- [x] No stray comments added
- [x] Tests added/updated to cover the change
- [x] Targets `master`
