### PR TITLE
feat(#497): add Remember Me to pre-fill credentials on re-login

### DIFF
--- a/lib/core/services/matrix_service.dart
+++ b/lib/core/services/matrix_service.dart
@@ -179,11 +179,13 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
     required String homeserver,
     required String username,
     required String password,
+    bool rememberCredentials = false,
   }) async {
     final success = await auth.login(
       homeserver: homeserver,
       username: username,
       password: password,
+      rememberCredentials: rememberCredentials,
     );
     if (success) {
       uia.setCachedPassword(password);

--- a/lib/core/services/sub_services/auth_service.dart
+++ b/lib/core/services/sub_services/auth_service.dart
@@ -40,6 +40,7 @@ class AuthService extends ChangeNotifier {
     required String homeserver,
     required String username,
     required String password,
+    bool rememberCredentials = false,
   }) async {
     loginError = null;
 
@@ -67,6 +68,18 @@ class AuthService extends ChangeNotifier {
           'userId=${_client.userID}, '
           'encryption=${_client.encryption != null ? "available" : "null"}, '
           'encryptionEnabled=${_client.encryptionEnabled}');
+
+      // Save before notifyListeners() so the credential is stored before
+      // the router redirect fires and the login screen is disposed.
+      if (rememberCredentials) {
+        await saveLoginCredentials(
+          homeserver: homeserver,
+          username: username,
+          password: password,
+        );
+      } else {
+        await clearLoginCredentials(homeserver);
+      }
 
       isLoggedIn = true;
       notifyListeners();
@@ -338,6 +351,43 @@ class AuthService extends ChangeNotifier {
       _storage.delete(key: koheraKey(_clientName, 'homeserver')),
       _storage.delete(key: koheraKey(_clientName, 'device_id')),
       _storage.delete(key: koheraKey(_clientName, 'olm_account')),
+    ]);
+  }
+
+  // ── Saved Login Credentials ──────────────────────────────────
+
+  static String _savedLoginKey(String homeserver, String suffix) =>
+      'kohera_saved_login_${homeserver.trim().toLowerCase()}_$suffix';
+
+  Future<void> saveLoginCredentials({
+    required String homeserver,
+    required String username,
+    required String password,
+  }) async {
+    await Future.wait([
+      _storage.write(
+          key: _savedLoginKey(homeserver, 'username'), value: username,),
+      _storage.write(
+          key: _savedLoginKey(homeserver, 'password'), value: password,),
+    ]);
+  }
+
+  Future<({String username, String password})?> loadLoginCredentials(
+      String homeserver,) async {
+    final results = await Future.wait([
+      _storage.read(key: _savedLoginKey(homeserver, 'username')),
+      _storage.read(key: _savedLoginKey(homeserver, 'password')),
+    ]);
+    final username = results[0];
+    final password = results[1];
+    if (username == null || password == null) return null;
+    return (username: username, password: password);
+  }
+
+  Future<void> clearLoginCredentials(String homeserver) async {
+    await Future.wait([
+      _storage.delete(key: _savedLoginKey(homeserver, 'username')),
+      _storage.delete(key: _savedLoginKey(homeserver, 'password')),
     ]);
   }
 

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kohera/core/models/server_auth_capabilities.dart';
 import 'package:kohera/core/services/client_manager.dart';
@@ -29,6 +30,7 @@ class _LoginScreenState extends State<LoginScreen>
   final _usernameCtrl = TextEditingController();
   final _passwordCtrl = TextEditingController();
   bool _obscurePassword = true;
+  bool _rememberMe = false;
 
   late final AnimationController _fadeCtrl;
   late final Animation<double> _fadeAnim;
@@ -52,6 +54,7 @@ class _LoginScreenState extends State<LoginScreen>
       capabilities: widget.capabilities,
     );
     _controller.addListener(_onControllerChanged);
+    unawaited(_loadSavedCredentials());
   }
 
   @override
@@ -75,11 +78,23 @@ class _LoginScreenState extends State<LoginScreen>
     setState(() {});
   }
 
+  Future<void> _loadSavedCredentials() async {
+    final saved = await _controller.loadSavedCredentials();
+    if (saved == null || !mounted) return;
+    setState(() {
+      _usernameCtrl.text = saved.username;
+      _passwordCtrl.text = saved.password;
+      _rememberMe = true;
+    });
+  }
+
   Future<void> _login() async {
-    await _controller.login(
+    final success = await _controller.login(
       username: _usernameCtrl.text,
       password: _passwordCtrl.text,
+      rememberCredentials: _rememberMe,
     );
+    TextInput.finishAutofillContext(shouldSave: success);
   }
 
   @override
@@ -182,7 +197,17 @@ class _LoginScreenState extends State<LoginScreen>
                         ],
                       ),
                     ),
-                    const SizedBox(height: 8),
+                    const SizedBox(height: 4),
+                    CheckboxListTile(
+                      value: _rememberMe,
+                      onChanged: formEnabled
+                          ? (v) => setState(() => _rememberMe = v ?? false)
+                          : null,
+                      title: const Text('Remember me'),
+                      controlAffinity: ListTileControlAffinity.leading,
+                      contentPadding: EdgeInsets.zero,
+                      dense: true,
+                    ),
 
                     // ── Error ──
                     if (_controller.error != null)

--- a/lib/features/auth/widgets/login_controller.dart
+++ b/lib/features/auth/widgets/login_controller.dart
@@ -57,9 +57,13 @@ class LoginController extends ChangeNotifier {
 
   // ── Password login ────────────────────────────────────────────
 
+  Future<({String username, String password})?> loadSavedCredentials() =>
+      matrixService.auth.loadLoginCredentials(_homeserver);
+
   Future<bool> login({
     required String username,
     required String password,
+    bool rememberCredentials = false,
   }) async {
     _error = null;
     _state = LoginState.loggingIn;
@@ -69,9 +73,10 @@ class LoginController extends ChangeNotifier {
       homeserver: _homeserver,
       username: username,
       password: password,
+      rememberCredentials: rememberCredentials,
     );
 
-    if (_isDisposed) return false;
+    if (_isDisposed) return success;
 
     if (success) {
       if (!clientManager.services.contains(matrixService)) {

--- a/test/screens/chat_search_test.mocks.dart
+++ b/test/screens/chat_search_test.mocks.dart
@@ -4,13 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i19;
-import 'dart:ui' as _i21;
+import 'dart:typed_data' as _i20;
+import 'dart:ui' as _i22;
 
-import 'package:flutter/services.dart' as _i22;
-import 'package:flutter/widgets.dart' as _i23;
+import 'package:flutter/services.dart' as _i23;
+import 'package:flutter/widgets.dart' as _i24;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/matrix_service.dart' as _i21;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -25,14 +26,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i18;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i16;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i17;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i24;
+import 'package:matrix/src/utils/space_child.dart' as _i25;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i18;
+import 'package:mockito/src/dummies.dart' as _i19;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -846,8 +847,9 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_75(
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -856,9 +858,19 @@ class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_76 extends _i1.SmartFake
+class _FakeRoomSummary_76 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_76(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_77 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_76(
+  _FakeLatestReceiptState_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,8 +879,8 @@ class _FakeLatestReceiptState_76 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_77(
+class _FakeTimeline_78 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -877,8 +889,8 @@ class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_78(
+class _FakeUser_79 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -887,8 +899,8 @@ class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_79 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_79(
+class _FakeRoom_80 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -897,9 +909,9 @@ class _FakeRoom_79 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeTimelineChunk_80 extends _i1.SmartFake
-    implements _i16.TimelineChunk {
-  _FakeTimelineChunk_80(
+class _FakeTimelineChunk_81 extends _i1.SmartFake
+    implements _i17.TimelineChunk {
+  _FakeTimelineChunk_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -926,12 +938,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i17.KeyVerificationMethod> get verificationMethods =>
+  Set<_i18.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i17.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
-      ) as Set<_i17.KeyVerificationMethod>);
+        returnValue: <_i18.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
+      ) as Set<_i18.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1051,11 +1063,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1092,11 +1104,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1126,11 +1138,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1139,11 +1151,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1429,34 +1441,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i17.KeyVerification>
+  _i3.CachedStreamController<_i18.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i17.KeyVerification>(
+                _FakeCachedStreamController_6<_i18.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i17.KeyVerification>);
+          ) as _i3.CachedStreamController<_i18.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1612,7 +1624,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1901,14 +1913,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2296,8 +2308,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValue: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2313,8 +2325,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2355,7 +2367,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2371,7 +2383,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2420,7 +2432,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2441,7 +2453,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2544,7 +2556,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2562,7 +2574,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3081,7 +3093,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i19.Uint8List? file, {
+    _i20.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3433,7 +3445,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3447,7 +3459,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3598,7 +3610,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i19.Uint8List? body,
+    _i20.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4976,7 +4988,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4998,7 +5010,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5492,7 +5504,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5504,7 +5516,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6512,7 +6524,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6523,7 +6535,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6771,7 +6783,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6783,7 +6795,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7043,7 +7055,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7056,7 +7068,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7123,7 +7135,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7136,7 +7148,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7184,7 +7196,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7196,7 +7208,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7444,7 +7456,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7455,7 +7467,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7717,7 +7729,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i19.Uint8List? body, {
+    _i20.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7744,7 +7756,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7774,11 +7786,11 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7903,6 +7915,19 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -8000,6 +8025,15 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -8044,7 +8078,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8069,6 +8103,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8078,6 +8113,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8138,7 +8174,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8147,7 +8183,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8166,7 +8202,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8177,7 +8213,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8225,7 +8261,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i23.RouteInformation? routeInformation) =>
+          _i24.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8263,7 +8299,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8272,7 +8308,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8281,16 +8317,16 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
-      ) as _i5.Future<_i21.AppExitResponse>);
+            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+      ) as _i5.Future<_i22.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8318,11 +8354,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8352,11 +8388,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_75(
+        returnValue: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_75(
+        returnValueForMissingStub: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
@@ -8409,11 +8445,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8449,11 +8485,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8469,11 +8505,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8482,11 +8518,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8529,11 +8565,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8576,11 +8612,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_76(
+        returnValue: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_76(
+        returnValueForMissingStub: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8799,18 +8835,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i24.SpaceParent>[],
-        returnValueForMissingStub: <_i24.SpaceParent>[],
-      ) as List<_i24.SpaceParent>);
+        returnValue: <_i25.SpaceParent>[],
+        returnValueForMissingStub: <_i25.SpaceParent>[],
+      ) as List<_i25.SpaceParent>);
 
   @override
-  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i24.SpaceChild>[],
-        returnValueForMissingStub: <_i24.SpaceChild>[],
-      ) as List<_i24.SpaceChild>);
+        returnValue: <_i25.SpaceChild>[],
+        returnValueForMissingStub: <_i25.SpaceChild>[],
+      ) as List<_i25.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8977,14 +9013,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9032,7 +9068,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9040,7 +9076,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9055,7 +9091,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9063,7 +9099,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9157,7 +9193,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9165,7 +9201,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9407,7 +9443,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9418,7 +9454,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9507,15 +9543,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i16.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i17.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i16.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i16.TimelineChunk?>.value(),
-      ) as _i5.Future<_i16.TimelineChunk?>);
+        returnValue: _i5.Future<_i17.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i17.TimelineChunk?>.value(),
+      ) as _i5.Future<_i17.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9556,7 +9592,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9573,7 +9609,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9637,14 +9673,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9660,14 +9696,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9723,7 +9759,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9731,7 +9767,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10043,11 +10079,11 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_79(
+        returnValue: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_79(
+        returnValueForMissingStub: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
@@ -10097,17 +10133,17 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       ) as bool);
 
   @override
-  _i16.TimelineChunk get chunk => (super.noSuchMethod(
+  _i17.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_80(
+        returnValue: _FakeTimelineChunk_81(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_80(
+        returnValueForMissingStub: _FakeTimelineChunk_81(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i16.TimelineChunk);
+      ) as _i17.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10210,7 +10246,7 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       );
 
   @override
-  set chunk(_i16.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i17.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,

--- a/test/screens/devices_screen_test.mocks.dart
+++ b/test/screens/devices_screen_test.mocks.dart
@@ -4,13 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -25,12 +26,12 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -844,6 +845,17 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -862,12 +874,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -987,11 +999,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1028,11 +1040,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1062,11 +1074,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1075,11 +1087,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1365,34 +1377,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1548,7 +1560,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1837,14 +1849,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2232,8 +2244,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2249,8 +2261,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2291,7 +2303,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2307,7 +2319,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2356,7 +2368,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2377,7 +2389,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2480,7 +2492,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2498,7 +2510,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3017,7 +3029,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3369,7 +3381,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3383,7 +3395,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3534,7 +3546,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4912,7 +4924,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4934,7 +4946,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5428,7 +5440,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5440,7 +5452,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6448,7 +6460,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6459,7 +6471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6707,7 +6719,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6719,7 +6731,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6979,7 +6991,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6992,7 +7004,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7059,7 +7071,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7072,7 +7084,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7120,7 +7132,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7132,7 +7144,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7380,7 +7392,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7391,7 +7403,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7653,7 +7665,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7680,7 +7692,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7710,11 +7722,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7839,6 +7851,19 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7936,6 +7961,15 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7980,7 +8014,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8005,6 +8039,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8014,6 +8049,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8074,7 +8110,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8083,7 +8119,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8102,7 +8138,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8113,7 +8149,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8161,7 +8197,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8199,7 +8235,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8208,7 +8244,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8217,16 +8253,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8312,7 +8348,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> runKeyRecovery({_i16.OpenSSSS? ssssKey}) =>
+  _i5.Future<void> runKeyRecovery({_i17.OpenSSSS? ssssKey}) =>
       (super.noSuchMethod(
         Invocation.method(
           #runKeyRecovery,
@@ -8366,7 +8402,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8375,7 +8411,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/test/screens/room_permissions_screen_test.mocks.dart
+++ b/test/screens/room_permissions_screen_test.mocks.dart
@@ -4,13 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -25,14 +26,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i25;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i23;
+import 'package:matrix/src/utils/space_child.dart' as _i24;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -846,8 +847,9 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_75(
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -856,9 +858,19 @@ class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_76 extends _i1.SmartFake
+class _FakeRoomSummary_76 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_76(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_77 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_76(
+  _FakeLatestReceiptState_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,8 +879,8 @@ class _FakeLatestReceiptState_76 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_77(
+class _FakeTimeline_78 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -877,8 +889,8 @@ class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_78(
+class _FakeUser_79 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -887,8 +899,8 @@ class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_79 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_79(
+class _FakeRoom_80 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -897,8 +909,8 @@ class _FakeRoom_79 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeMatrixFile_80 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_80(
+class _FakeMatrixFile_81 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -907,8 +919,8 @@ class _FakeMatrixFile_80 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_81 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_81(
+class _FakeEvent_82 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -935,12 +947,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1060,11 +1072,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1101,11 +1113,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1135,11 +1147,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1148,11 +1160,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1438,34 +1450,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1621,7 +1633,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1910,14 +1922,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2305,8 +2317,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2322,8 +2334,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2364,7 +2376,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2380,7 +2392,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2429,7 +2441,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2450,7 +2462,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2553,7 +2565,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2571,7 +2583,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3090,7 +3102,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3442,7 +3454,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3456,7 +3468,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3607,7 +3619,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4985,7 +4997,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5007,7 +5019,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5501,7 +5513,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5513,7 +5525,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6521,7 +6533,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6532,7 +6544,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6780,7 +6792,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6792,7 +6804,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7052,7 +7064,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7065,7 +7077,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7132,7 +7144,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7145,7 +7157,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7193,7 +7205,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7205,7 +7217,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7453,7 +7465,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7464,7 +7476,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7726,7 +7738,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7753,7 +7765,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7783,11 +7795,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7912,6 +7924,19 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -8009,6 +8034,15 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -8053,7 +8087,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8078,6 +8112,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8087,6 +8122,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8147,7 +8183,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8156,7 +8192,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8175,7 +8211,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8186,7 +8222,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8234,7 +8270,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8272,7 +8308,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8281,7 +8317,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8290,16 +8326,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8327,11 +8363,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8361,11 +8397,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_75(
+        returnValue: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_75(
+        returnValueForMissingStub: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
@@ -8418,11 +8454,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8458,11 +8494,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8478,11 +8514,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8491,11 +8527,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8538,11 +8574,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8585,11 +8621,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_76(
+        returnValue: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_76(
+        returnValueForMissingStub: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8808,18 +8844,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i23.SpaceParent>[],
-        returnValueForMissingStub: <_i23.SpaceParent>[],
-      ) as List<_i23.SpaceParent>);
+        returnValue: <_i24.SpaceParent>[],
+        returnValueForMissingStub: <_i24.SpaceParent>[],
+      ) as List<_i24.SpaceParent>);
 
   @override
-  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i23.SpaceChild>[],
-        returnValueForMissingStub: <_i23.SpaceChild>[],
-      ) as List<_i23.SpaceChild>);
+        returnValue: <_i24.SpaceChild>[],
+        returnValueForMissingStub: <_i24.SpaceChild>[],
+      ) as List<_i24.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8986,14 +9022,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9041,7 +9077,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9049,7 +9085,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9064,7 +9100,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9072,7 +9108,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9166,7 +9202,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9174,7 +9210,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9416,7 +9452,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9427,7 +9463,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9516,15 +9552,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i25.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i24.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i24.TimelineChunk?>.value(),
-      ) as _i5.Future<_i24.TimelineChunk?>);
+        returnValue: _i5.Future<_i25.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i25.TimelineChunk?>.value(),
+      ) as _i5.Future<_i25.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9565,7 +9601,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9582,7 +9618,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9646,14 +9682,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9669,14 +9705,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9732,7 +9768,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9740,7 +9776,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10052,11 +10088,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.getter(#sender),
         ),
@@ -10065,11 +10101,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10078,11 +10114,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_79(
+        returnValue: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_79(
+        returnValueForMissingStub: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
@@ -10105,11 +10141,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10118,11 +10154,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10131,11 +10167,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10144,11 +10180,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10157,11 +10193,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10170,11 +10206,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10239,11 +10275,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10252,11 +10288,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10309,11 +10345,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10398,11 +10434,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10420,11 +10456,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10635,7 +10671,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i18.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i19.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10650,7 +10686,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_80(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_81(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10664,7 +10700,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_80(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_81(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10700,7 +10736,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10715,7 +10751,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10752,7 +10788,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10766,7 +10802,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10803,7 +10839,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10817,7 +10853,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10851,7 +10887,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10864,7 +10900,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10940,14 +10976,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_81(
+        returnValue: _FakeEvent_82(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_81(
+        returnValueForMissingStub: _FakeEvent_82(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -10964,11 +11000,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_79(
+        returnValue: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_79(
+        returnValueForMissingStub: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
@@ -10977,11 +11013,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -11047,11 +11083,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11076,11 +11112,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11098,11 +11134,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11149,7 +11185,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11161,7 +11197,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11231,7 +11267,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11244,7 +11280,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/services/chat_message_actions_test.mocks.dart
+++ b/test/services/chat_message_actions_test.mocks.dart
@@ -4,19 +4,20 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i6;
-import 'dart:typed_data' as _i23;
-import 'dart:ui' as _i26;
+import 'dart:typed_data' as _i24;
+import 'dart:ui' as _i27;
 
-import 'package:flutter/scheduler.dart' as _i20;
-import 'package:flutter/services.dart' as _i27;
-import 'package:flutter/src/foundation/assertions.dart' as _i30;
-import 'package:flutter/src/foundation/diagnostics.dart' as _i19;
-import 'package:flutter/src/material/banner.dart' as _i29;
-import 'package:flutter/src/material/scaffold.dart' as _i17;
-import 'package:flutter/src/material/snack_bar.dart' as _i28;
-import 'package:flutter/widgets.dart' as _i18;
+import 'package:flutter/scheduler.dart' as _i21;
+import 'package:flutter/services.dart' as _i28;
+import 'package:flutter/src/foundation/assertions.dart' as _i31;
+import 'package:flutter/src/foundation/diagnostics.dart' as _i20;
+import 'package:flutter/src/material/banner.dart' as _i30;
+import 'package:flutter/src/material/scaffold.dart' as _i18;
+import 'package:flutter/src/material/snack_bar.dart' as _i29;
+import 'package:flutter/widgets.dart' as _i19;
 import 'package:http/http.dart' as _i5;
-import 'package:kohera/core/services/matrix_service.dart' as _i25;
+import 'package:kohera/core/services/matrix_service.dart' as _i26;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i17;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i15;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i11;
@@ -31,14 +32,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i8;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i9;
-import 'package:matrix/encryption.dart' as _i24;
+import 'package:matrix/encryption.dart' as _i25;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i7;
 import 'package:matrix/src/models/timeline_chunk.dart' as _i4;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i22;
+import 'package:matrix/src/utils/space_child.dart' as _i23;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i21;
+import 'package:mockito/src/dummies.dart' as _i22;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -933,9 +934,20 @@ class _FakeOutboxService_82 extends _i1.SmartFake
         );
 }
 
-class _FakeScaffoldMessenger_83 extends _i1.SmartFake
-    implements _i17.ScaffoldMessenger {
-  _FakeScaffoldMessenger_83(
+class _FakeStickerPackService_83 extends _i1.SmartFake
+    implements _i17.StickerPackService {
+  _FakeStickerPackService_83(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeScaffoldMessenger_84 extends _i1.SmartFake
+    implements _i18.ScaffoldMessenger {
+  _FakeScaffoldMessenger_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -945,12 +957,12 @@ class _FakeScaffoldMessenger_83 extends _i1.SmartFake
 
   @override
   String toString(
-          {_i18.DiagnosticLevel? minLevel = _i18.DiagnosticLevel.info}) =>
+          {_i19.DiagnosticLevel? minLevel = _i19.DiagnosticLevel.info}) =>
       super.toString();
 }
 
-class _FakeBuildContext_84 extends _i1.SmartFake implements _i18.BuildContext {
-  _FakeBuildContext_84(
+class _FakeBuildContext_85 extends _i1.SmartFake implements _i19.BuildContext {
+  _FakeBuildContext_85(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -959,9 +971,9 @@ class _FakeBuildContext_84 extends _i1.SmartFake implements _i18.BuildContext {
         );
 }
 
-class _FakeScaffoldFeatureController_85<T extends _i18.Widget, U>
-    extends _i1.SmartFake implements _i17.ScaffoldFeatureController<T, U> {
-  _FakeScaffoldFeatureController_85(
+class _FakeScaffoldFeatureController_86<T extends _i19.Widget, U>
+    extends _i1.SmartFake implements _i18.ScaffoldFeatureController<T, U> {
+  _FakeScaffoldFeatureController_86(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -970,8 +982,8 @@ class _FakeScaffoldFeatureController_85<T extends _i18.Widget, U>
         );
 }
 
-class _FakeWidget_86 extends _i1.SmartFake implements _i18.Widget {
-  _FakeWidget_86(
+class _FakeWidget_87 extends _i1.SmartFake implements _i19.Widget {
+  _FakeWidget_87(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -981,13 +993,13 @@ class _FakeWidget_86 extends _i1.SmartFake implements _i18.Widget {
 
   @override
   String toString(
-          {_i18.DiagnosticLevel? minLevel = _i18.DiagnosticLevel.info}) =>
+          {_i19.DiagnosticLevel? minLevel = _i19.DiagnosticLevel.info}) =>
       super.toString();
 }
 
-class _FakeDiagnosticsNode_87 extends _i1.SmartFake
-    implements _i18.DiagnosticsNode {
-  _FakeDiagnosticsNode_87(
+class _FakeDiagnosticsNode_88 extends _i1.SmartFake
+    implements _i19.DiagnosticsNode {
+  _FakeDiagnosticsNode_88(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -997,14 +1009,14 @@ class _FakeDiagnosticsNode_87 extends _i1.SmartFake
 
   @override
   String toString({
-    _i19.TextTreeConfiguration? parentConfiguration,
-    _i18.DiagnosticLevel? minLevel = _i18.DiagnosticLevel.info,
+    _i20.TextTreeConfiguration? parentConfiguration,
+    _i19.DiagnosticLevel? minLevel = _i19.DiagnosticLevel.info,
   }) =>
       super.toString();
 }
 
-class _FakeTicker_88 extends _i1.SmartFake implements _i20.Ticker {
-  _FakeTicker_88(
+class _FakeTicker_89 extends _i1.SmartFake implements _i21.Ticker {
+  _FakeTicker_89(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -1023,11 +1035,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1114,11 +1126,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -1154,11 +1166,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1174,11 +1186,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1187,11 +1199,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1234,11 +1246,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1504,18 +1516,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i22.SpaceParent>[],
-        returnValueForMissingStub: <_i22.SpaceParent>[],
-      ) as List<_i22.SpaceParent>);
+        returnValue: <_i23.SpaceParent>[],
+        returnValueForMissingStub: <_i23.SpaceParent>[],
+      ) as List<_i23.SpaceParent>);
 
   @override
-  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i22.SpaceChild>[],
-        returnValueForMissingStub: <_i22.SpaceChild>[],
-      ) as List<_i22.SpaceChild>);
+        returnValue: <_i23.SpaceChild>[],
+        returnValueForMissingStub: <_i23.SpaceChild>[],
+      ) as List<_i23.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -1682,14 +1694,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -1737,7 +1749,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -1745,7 +1757,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i21.dummyValue<String>(
+            _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -1760,7 +1772,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -1768,7 +1780,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i21.dummyValue<String>(
+            _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -1862,7 +1874,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -1870,7 +1882,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i21.dummyValue<String>(
+            _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2112,7 +2124,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2123,7 +2135,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i21.dummyValue<String>(
+            _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2428,7 +2440,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2436,7 +2448,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i21.dummyValue<String>(
+            _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2814,11 +2826,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -2827,11 +2839,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -2840,11 +2852,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -2853,11 +2865,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -2866,11 +2878,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -2935,11 +2947,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -2948,11 +2960,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -3005,11 +3017,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -3094,11 +3106,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -3116,11 +3128,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -3331,7 +3343,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i6.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i6.Future<_i23.Uint8List> Function(Uri)? downloadCallback,
+    _i6.Future<_i24.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -3396,7 +3408,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -3411,7 +3423,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i21.dummyValue<String>(
+            _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -3448,7 +3460,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -3462,7 +3474,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -3499,7 +3511,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -3513,7 +3525,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -3547,7 +3559,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -3560,7 +3572,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -4037,12 +4049,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i24.KeyVerificationMethod> get verificationMethods =>
+  Set<_i25.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i24.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i24.KeyVerificationMethod>{},
-      ) as Set<_i24.KeyVerificationMethod>);
+        returnValue: <_i25.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i25.KeyVerificationMethod>{},
+      ) as Set<_i25.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -4162,11 +4174,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -4203,11 +4215,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -4237,11 +4249,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -4250,11 +4262,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -4541,34 +4553,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i24.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i25.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_1<_i24.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_1<_i25.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_1<_i24.RoomKeyRequest>(
+            _FakeCachedStreamController_1<_i25.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i24.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i25.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i24.KeyVerification>
+  _i3.CachedStreamController<_i25.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_1<_i24.KeyVerification>(
+            returnValue: _FakeCachedStreamController_1<_i25.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_1<_i24.KeyVerification>(
+                _FakeCachedStreamController_1<_i25.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i24.KeyVerification>);
+          ) as _i3.CachedStreamController<_i25.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -4724,7 +4736,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i24.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i25.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -5013,14 +5025,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -5408,8 +5420,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i21.ifNotNull(
-              _i21.dummyValueOrNull<T>(
+        returnValue: _i22.ifNotNull(
+              _i22.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -5425,8 +5437,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i21.ifNotNull(
-              _i21.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i22.ifNotNull(
+              _i22.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -5467,7 +5479,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -5483,7 +5495,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i21.dummyValue<String>(
+            _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -5532,7 +5544,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -5553,7 +5565,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i21.dummyValue<String>(
+            _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -5656,7 +5668,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -5674,7 +5686,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i21.dummyValue<String>(
+            _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -6196,7 +6208,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i6.Future<Uri> uploadContent(
-    _i23.Uint8List? file, {
+    _i24.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -6548,7 +6560,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -6562,7 +6574,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i21.dummyValue<String>(
+            _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -6713,7 +6725,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i5.BaseResponse? response,
-    _i23.Uint8List? body,
+    _i24.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8091,7 +8103,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -8113,7 +8125,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i21.dummyValue<String>(
+            _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -8607,7 +8619,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -8619,7 +8631,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i21.dummyValue<String>(
+            _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -9627,7 +9639,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -9638,7 +9650,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i21.dummyValue<String>(
+            _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -9886,7 +9898,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9898,7 +9910,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i21.dummyValue<String>(
+            _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -10158,7 +10170,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -10171,7 +10183,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i21.dummyValue<String>(
+            _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -10238,7 +10250,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -10251,7 +10263,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i21.dummyValue<String>(
+            _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -10299,7 +10311,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -10311,7 +10323,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i21.dummyValue<String>(
+            _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -10559,7 +10571,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -10570,7 +10582,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i21.dummyValue<String>(
+            _i6.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -10832,7 +10844,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i6.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i23.Uint8List? body, {
+    _i24.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -10859,7 +10871,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i25.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i26.MatrixService {
   @override
   _i8.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -10889,11 +10901,11 @@ class MockMatrixService extends _i1.Mock implements _i25.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -11018,6 +11030,19 @@ class MockMatrixService extends _i1.Mock implements _i25.MatrixService {
       ) as _i16.OutboxService);
 
   @override
+  _i17.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_83(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_83(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i17.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -11115,6 +11140,15 @@ class MockMatrixService extends _i1.Mock implements _i25.MatrixService {
       );
 
   @override
+  set stickerPacks(_i17.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -11159,7 +11193,7 @@ class MockMatrixService extends _i1.Mock implements _i25.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i26.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i27.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -11184,6 +11218,7 @@ class MockMatrixService extends _i1.Mock implements _i25.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -11193,6 +11228,7 @@ class MockMatrixService extends _i1.Mock implements _i25.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i6.Future<bool>.value(false),
@@ -11253,7 +11289,7 @@ class MockMatrixService extends _i1.Mock implements _i25.MatrixService {
       ) as _i6.Future<void>);
 
   @override
-  void addListener(_i26.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i27.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -11262,7 +11298,7 @@ class MockMatrixService extends _i1.Mock implements _i25.MatrixService {
       );
 
   @override
-  void removeListener(_i26.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i27.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -11281,7 +11317,7 @@ class MockMatrixService extends _i1.Mock implements _i25.MatrixService {
       ) as _i6.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i27.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i28.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -11292,7 +11328,7 @@ class MockMatrixService extends _i1.Mock implements _i25.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i27.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i28.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -11340,7 +11376,7 @@ class MockMatrixService extends _i1.Mock implements _i25.MatrixService {
 
   @override
   _i6.Future<bool> didPushRouteInformation(
-          _i18.RouteInformation? routeInformation) =>
+          _i19.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -11378,7 +11414,7 @@ class MockMatrixService extends _i1.Mock implements _i25.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i26.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i27.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -11387,7 +11423,7 @@ class MockMatrixService extends _i1.Mock implements _i25.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i26.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i27.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -11396,16 +11432,16 @@ class MockMatrixService extends _i1.Mock implements _i25.MatrixService {
       );
 
   @override
-  _i6.Future<_i26.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i6.Future<_i27.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i6.Future<_i26.AppExitResponse>.value(_i26.AppExitResponse.exit),
+            _i6.Future<_i27.AppExitResponse>.value(_i27.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i6.Future<_i26.AppExitResponse>.value(_i26.AppExitResponse.exit),
-      ) as _i6.Future<_i26.AppExitResponse>);
+            _i6.Future<_i27.AppExitResponse>.value(_i27.AppExitResponse.exit),
+      ) as _i6.Future<_i27.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -11430,32 +11466,32 @@ class MockMatrixService extends _i1.Mock implements _i25.MatrixService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockScaffoldMessengerState extends _i1.Mock
-    implements _i17.ScaffoldMessengerState {
+    implements _i18.ScaffoldMessengerState {
   @override
-  _i17.ScaffoldMessenger get widget => (super.noSuchMethod(
+  _i18.ScaffoldMessenger get widget => (super.noSuchMethod(
         Invocation.getter(#widget),
-        returnValue: _FakeScaffoldMessenger_83(
+        returnValue: _FakeScaffoldMessenger_84(
           this,
           Invocation.getter(#widget),
         ),
-        returnValueForMissingStub: _FakeScaffoldMessenger_83(
+        returnValueForMissingStub: _FakeScaffoldMessenger_84(
           this,
           Invocation.getter(#widget),
         ),
-      ) as _i17.ScaffoldMessenger);
+      ) as _i18.ScaffoldMessenger);
 
   @override
-  _i18.BuildContext get context => (super.noSuchMethod(
+  _i19.BuildContext get context => (super.noSuchMethod(
         Invocation.getter(#context),
-        returnValue: _FakeBuildContext_84(
+        returnValue: _FakeBuildContext_85(
           this,
           Invocation.getter(#context),
         ),
-        returnValueForMissingStub: _FakeBuildContext_84(
+        returnValueForMissingStub: _FakeBuildContext_85(
           this,
           Invocation.getter(#context),
         ),
-      ) as _i18.BuildContext);
+      ) as _i19.BuildContext);
 
   @override
   bool get mounted => (super.noSuchMethod(
@@ -11474,10 +11510,10 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  _i17.ScaffoldFeatureController<_i28.SnackBar, _i28.SnackBarClosedReason>
+  _i18.ScaffoldFeatureController<_i29.SnackBar, _i29.SnackBarClosedReason>
       showSnackBar(
-    _i28.SnackBar? snackBar, {
-    _i18.AnimationStyle? snackBarAnimationStyle,
+    _i29.SnackBar? snackBar, {
+    _i19.AnimationStyle? snackBarAnimationStyle,
   }) =>
           (super.noSuchMethod(
             Invocation.method(
@@ -11485,8 +11521,8 @@ class MockScaffoldMessengerState extends _i1.Mock
               [snackBar],
               {#snackBarAnimationStyle: snackBarAnimationStyle},
             ),
-            returnValue: _FakeScaffoldFeatureController_85<_i28.SnackBar,
-                _i28.SnackBarClosedReason>(
+            returnValue: _FakeScaffoldFeatureController_86<_i29.SnackBar,
+                _i29.SnackBarClosedReason>(
               this,
               Invocation.method(
                 #showSnackBar,
@@ -11494,8 +11530,8 @@ class MockScaffoldMessengerState extends _i1.Mock
                 {#snackBarAnimationStyle: snackBarAnimationStyle},
               ),
             ),
-            returnValueForMissingStub: _FakeScaffoldFeatureController_85<
-                _i28.SnackBar, _i28.SnackBarClosedReason>(
+            returnValueForMissingStub: _FakeScaffoldFeatureController_86<
+                _i29.SnackBar, _i29.SnackBarClosedReason>(
               this,
               Invocation.method(
                 #showSnackBar,
@@ -11503,13 +11539,13 @@ class MockScaffoldMessengerState extends _i1.Mock
                 {#snackBarAnimationStyle: snackBarAnimationStyle},
               ),
             ),
-          ) as _i17.ScaffoldFeatureController<_i28.SnackBar,
-              _i28.SnackBarClosedReason>);
+          ) as _i18.ScaffoldFeatureController<_i29.SnackBar,
+              _i29.SnackBarClosedReason>);
 
   @override
   void removeCurrentSnackBar(
-          {_i28.SnackBarClosedReason? reason =
-              _i28.SnackBarClosedReason.remove}) =>
+          {_i29.SnackBarClosedReason? reason =
+              _i29.SnackBarClosedReason.remove}) =>
       super.noSuchMethod(
         Invocation.method(
           #removeCurrentSnackBar,
@@ -11521,8 +11557,8 @@ class MockScaffoldMessengerState extends _i1.Mock
 
   @override
   void hideCurrentSnackBar(
-          {_i28.SnackBarClosedReason? reason =
-              _i28.SnackBarClosedReason.hide}) =>
+          {_i29.SnackBarClosedReason? reason =
+              _i29.SnackBarClosedReason.hide}) =>
       super.noSuchMethod(
         Invocation.method(
           #hideCurrentSnackBar,
@@ -11542,37 +11578,37 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  _i17.ScaffoldFeatureController<_i29.MaterialBanner,
-      _i29.MaterialBannerClosedReason> showMaterialBanner(
-          _i29.MaterialBanner? materialBanner) =>
+  _i18.ScaffoldFeatureController<_i30.MaterialBanner,
+      _i30.MaterialBannerClosedReason> showMaterialBanner(
+          _i30.MaterialBanner? materialBanner) =>
       (super.noSuchMethod(
         Invocation.method(
           #showMaterialBanner,
           [materialBanner],
         ),
-        returnValue: _FakeScaffoldFeatureController_85<_i29.MaterialBanner,
-            _i29.MaterialBannerClosedReason>(
+        returnValue: _FakeScaffoldFeatureController_86<_i30.MaterialBanner,
+            _i30.MaterialBannerClosedReason>(
           this,
           Invocation.method(
             #showMaterialBanner,
             [materialBanner],
           ),
         ),
-        returnValueForMissingStub: _FakeScaffoldFeatureController_85<
-            _i29.MaterialBanner, _i29.MaterialBannerClosedReason>(
+        returnValueForMissingStub: _FakeScaffoldFeatureController_86<
+            _i30.MaterialBanner, _i30.MaterialBannerClosedReason>(
           this,
           Invocation.method(
             #showMaterialBanner,
             [materialBanner],
           ),
         ),
-      ) as _i17.ScaffoldFeatureController<_i29.MaterialBanner,
-          _i29.MaterialBannerClosedReason>);
+      ) as _i18.ScaffoldFeatureController<_i30.MaterialBanner,
+          _i30.MaterialBannerClosedReason>);
 
   @override
   void removeCurrentMaterialBanner(
-          {_i29.MaterialBannerClosedReason? reason =
-              _i29.MaterialBannerClosedReason.remove}) =>
+          {_i30.MaterialBannerClosedReason? reason =
+              _i30.MaterialBannerClosedReason.remove}) =>
       super.noSuchMethod(
         Invocation.method(
           #removeCurrentMaterialBanner,
@@ -11584,8 +11620,8 @@ class MockScaffoldMessengerState extends _i1.Mock
 
   @override
   void hideCurrentMaterialBanner(
-          {_i29.MaterialBannerClosedReason? reason =
-              _i29.MaterialBannerClosedReason.hide}) =>
+          {_i30.MaterialBannerClosedReason? reason =
+              _i30.MaterialBannerClosedReason.hide}) =>
       super.noSuchMethod(
         Invocation.method(
           #hideCurrentMaterialBanner,
@@ -11605,26 +11641,26 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  _i18.Widget build(_i18.BuildContext? context) => (super.noSuchMethod(
+  _i19.Widget build(_i19.BuildContext? context) => (super.noSuchMethod(
         Invocation.method(
           #build,
           [context],
         ),
-        returnValue: _FakeWidget_86(
+        returnValue: _FakeWidget_87(
           this,
           Invocation.method(
             #build,
             [context],
           ),
         ),
-        returnValueForMissingStub: _FakeWidget_86(
+        returnValueForMissingStub: _FakeWidget_87(
           this,
           Invocation.method(
             #build,
             [context],
           ),
         ),
-      ) as _i18.Widget);
+      ) as _i19.Widget);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -11645,7 +11681,7 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  void didUpdateWidget(_i17.ScaffoldMessenger? oldWidget) => super.noSuchMethod(
+  void didUpdateWidget(_i18.ScaffoldMessenger? oldWidget) => super.noSuchMethod(
         Invocation.method(
           #didUpdateWidget,
           [oldWidget],
@@ -11663,7 +11699,7 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  void setState(_i26.VoidCallback? fn) => super.noSuchMethod(
+  void setState(_i27.VoidCallback? fn) => super.noSuchMethod(
         Invocation.method(
           #setState,
           [fn],
@@ -11690,7 +11726,7 @@ class MockScaffoldMessengerState extends _i1.Mock
       );
 
   @override
-  void debugFillProperties(_i30.DiagnosticPropertiesBuilder? properties) =>
+  void debugFillProperties(_i31.DiagnosticPropertiesBuilder? properties) =>
       super.noSuchMethod(
         Invocation.method(
           #debugFillProperties,
@@ -11701,7 +11737,7 @@ class MockScaffoldMessengerState extends _i1.Mock
 
   @override
   String toString(
-          {_i18.DiagnosticLevel? minLevel = _i18.DiagnosticLevel.info}) =>
+          {_i19.DiagnosticLevel? minLevel = _i19.DiagnosticLevel.info}) =>
       super.toString();
 
   @override
@@ -11710,14 +11746,14 @@ class MockScaffoldMessengerState extends _i1.Mock
           #toStringShort,
           [],
         ),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.method(
             #toStringShort,
             [],
           ),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.method(
             #toStringShort,
@@ -11727,9 +11763,9 @@ class MockScaffoldMessengerState extends _i1.Mock
       ) as String);
 
   @override
-  _i18.DiagnosticsNode toDiagnosticsNode({
+  _i19.DiagnosticsNode toDiagnosticsNode({
     String? name,
-    _i30.DiagnosticsTreeStyle? style,
+    _i31.DiagnosticsTreeStyle? style,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -11740,7 +11776,7 @@ class MockScaffoldMessengerState extends _i1.Mock
             #style: style,
           },
         ),
-        returnValue: _FakeDiagnosticsNode_87(
+        returnValue: _FakeDiagnosticsNode_88(
           this,
           Invocation.method(
             #toDiagnosticsNode,
@@ -11751,7 +11787,7 @@ class MockScaffoldMessengerState extends _i1.Mock
             },
           ),
         ),
-        returnValueForMissingStub: _FakeDiagnosticsNode_87(
+        returnValueForMissingStub: _FakeDiagnosticsNode_88(
           this,
           Invocation.method(
             #toDiagnosticsNode,
@@ -11762,27 +11798,27 @@ class MockScaffoldMessengerState extends _i1.Mock
             },
           ),
         ),
-      ) as _i18.DiagnosticsNode);
+      ) as _i19.DiagnosticsNode);
 
   @override
-  _i20.Ticker createTicker(_i20.TickerCallback? onTick) => (super.noSuchMethod(
+  _i21.Ticker createTicker(_i21.TickerCallback? onTick) => (super.noSuchMethod(
         Invocation.method(
           #createTicker,
           [onTick],
         ),
-        returnValue: _FakeTicker_88(
+        returnValue: _FakeTicker_89(
           this,
           Invocation.method(
             #createTicker,
             [onTick],
           ),
         ),
-        returnValueForMissingStub: _FakeTicker_88(
+        returnValueForMissingStub: _FakeTicker_89(
           this,
           Invocation.method(
             #createTicker,
             [onTick],
           ),
         ),
-      ) as _i20.Ticker);
+      ) as _i21.Ticker);
 }

--- a/test/services/ios_voip_push_service_test.mocks.dart
+++ b/test/services/ios_voip_push_service_test.mocks.dart
@@ -3,16 +3,17 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i14;
-import 'dart:typed_data' as _i24;
-import 'dart:ui' as _i20;
+import 'dart:async' as _i15;
+import 'dart:typed_data' as _i25;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
-import 'package:http/http.dart' as _i13;
-import 'package:kohera/core/services/call_service.dart' as _i25;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
-import 'package:kohera/core/services/preferences_service.dart' as _i17;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
+import 'package:http/http.dart' as _i14;
+import 'package:kohera/core/services/call_service.dart' as _i26;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/preferences_service.dart' as _i18;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i12;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -23,26 +24,26 @@ import 'package:kohera/core/services/sub_services/space_access_service.dart'
     as _i8;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
-import 'package:kohera/features/calling/models/call_participant.dart' as _i28;
-import 'package:kohera/features/calling/models/call_state.dart' as _i30;
-import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i29;
-import 'package:kohera/features/calling/services/livekit_service.dart' as _i26;
-import 'package:kohera/features/calling/services/ringtone_service.dart' as _i31;
+import 'package:kohera/features/calling/models/call_participant.dart' as _i29;
+import 'package:kohera/features/calling/models/call_state.dart' as _i31;
+import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i30;
+import 'package:kohera/features/calling/services/livekit_service.dart' as _i27;
+import 'package:kohera/features/calling/services/ringtone_service.dart' as _i32;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
 import 'package:kohera/features/notifications/services/notification_service.dart'
-    as _i32;
-import 'package:livekit_client/livekit_client.dart' as _i27;
-import 'package:matrix/encryption.dart' as _i23;
+    as _i33;
+import 'package:livekit_client/livekit_client.dart' as _i28;
+import 'package:matrix/encryption.dart' as _i24;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i15;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i18;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i12;
-import 'package:matrix/src/utils/space_child.dart' as _i33;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i16;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i13;
+import 'package:matrix/src/utils/space_child.dart' as _i34;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i19;
+import 'package:mockito/src/dummies.dart' as _i20;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -164,8 +165,9 @@ class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
         );
 }
 
-class _FakeDatabaseApi_10 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_10(
+class _FakeStickerPackService_10 extends _i1.SmartFake
+    implements _i12.StickerPackService {
+  _FakeStickerPackService_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -174,8 +176,8 @@ class _FakeDatabaseApi_10 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_11 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_11(
+class _FakeDatabaseApi_11 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -184,9 +186,19 @@ class _FakeFilter_11 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_12 extends _i1.SmartFake
+class _FakeFilter_12 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_12(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeNativeImplementations_13 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_12(
+  _FakeNativeImplementations_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -195,8 +207,8 @@ class _FakeNativeImplementations_12 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_13 extends _i1.SmartFake implements Duration {
-  _FakeDuration_13(
+class _FakeDuration_14 extends _i1.SmartFake implements Duration {
+  _FakeDuration_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -205,9 +217,9 @@ class _FakeDuration_13 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_14 extends _i1.SmartFake
+class _FakePushruleEvaluator_15 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_14(
+  _FakePushruleEvaluator_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -216,8 +228,8 @@ class _FakePushruleEvaluator_14 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_15 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_15(
+class _FakeProfile_16 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -226,9 +238,9 @@ class _FakeProfile_15 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeCachedStreamController_16<T> extends _i1.SmartFake
-    implements _i12.CachedStreamController<T> {
-  _FakeCachedStreamController_16(
+class _FakeCachedStreamController_17<T> extends _i1.SmartFake
+    implements _i13.CachedStreamController<T> {
+  _FakeCachedStreamController_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -237,8 +249,8 @@ class _FakeCachedStreamController_16<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_17 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_17(
+class _FakeDateTime_18 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -247,8 +259,8 @@ class _FakeDateTime_17 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_18 extends _i1.SmartFake implements _i13.Client {
-  _FakeClient_18(
+class _FakeClient_19 extends _i1.SmartFake implements _i14.Client {
+  _FakeClient_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -257,9 +269,9 @@ class _FakeClient_18 extends _i1.SmartFake implements _i13.Client {
         );
 }
 
-class _FakeDiscoveryInformation_19 extends _i1.SmartFake
+class _FakeDiscoveryInformation_20 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_19(
+  _FakeDiscoveryInformation_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -268,9 +280,9 @@ class _FakeDiscoveryInformation_19 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_20 extends _i1.SmartFake
+class _FakeGetVersionsResponse_21 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_20(
+  _FakeGetVersionsResponse_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -279,9 +291,9 @@ class _FakeGetVersionsResponse_20 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_21 extends _i1.SmartFake
+class _FakeRegisterResponse_22 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_21(
+  _FakeRegisterResponse_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -290,8 +302,8 @@ class _FakeRegisterResponse_21 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_22 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_22(
+class _FakeLoginResponse_23 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -300,9 +312,9 @@ class _FakeLoginResponse_22 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_23 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_24 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_23(
+  _FakeGetAuthMetadataResponse_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -311,8 +323,8 @@ class _FakeGetAuthMetadataResponse_23 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_24<T1> extends _i1.SmartFake implements _i14.Future<T1> {
-  _FakeFuture_24(
+class _FakeFuture_25<T1> extends _i1.SmartFake implements _i15.Future<T1> {
+  _FakeFuture_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -321,8 +333,8 @@ class _FakeFuture_24<T1> extends _i1.SmartFake implements _i14.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_25 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_25(
+class _FakeSyncUpdate_26 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -331,9 +343,9 @@ class _FakeSyncUpdate_25 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_26 extends _i1.SmartFake
+class _FakeCachedProfileInformation_27 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_26(
+  _FakeCachedProfileInformation_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -342,8 +354,8 @@ class _FakeCachedProfileInformation_26 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_27 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_27(
+class _FakeMediaConfig_28 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -352,8 +364,8 @@ class _FakeMediaConfig_27 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_28 extends _i1.SmartFake implements _i15.FileResponse {
-  _FakeFileResponse_28(
+class _FakeFileResponse_29 extends _i1.SmartFake implements _i16.FileResponse {
+  _FakeFileResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -362,8 +374,8 @@ class _FakeFileResponse_28 extends _i1.SmartFake implements _i15.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_29 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_29(
+class _FakePreviewForUrl_30 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -372,8 +384,8 @@ class _FakePreviewForUrl_29 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeUri_30 extends _i1.SmartFake implements Uri {
-  _FakeUri_30(
+class _FakeUri_31 extends _i1.SmartFake implements Uri {
+  _FakeUri_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -382,9 +394,9 @@ class _FakeUri_30 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_31 extends _i1.SmartFake
+class _FakeCachedPresence_32 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_31(
+  _FakeCachedPresence_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -393,9 +405,9 @@ class _FakeCachedPresence_31 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_32 extends _i1.SmartFake
+class _FakeTurnServerCredentials_33 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_32(
+  _FakeTurnServerCredentials_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -404,9 +416,9 @@ class _FakeTurnServerCredentials_32 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_33 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_34 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_33(
+  _FakeRoomKeysUpdateResponse_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -415,8 +427,8 @@ class _FakeRoomKeysUpdateResponse_33 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_34 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_34(
+class _FakeKeyBackupData_35 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -425,9 +437,9 @@ class _FakeKeyBackupData_34 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_35 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_36 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_35(
+  _FakeGetWellknownSupportResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -436,9 +448,9 @@ class _FakeGetWellknownSupportResponse_35 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_36 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_37 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_36(
+  _FakeGenerateLoginTokenResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -447,9 +459,9 @@ class _FakeGenerateLoginTokenResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_37 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_38 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_37(
+  _FakeGetRoomSummaryResponse$3_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -458,9 +470,9 @@ class _FakeGetRoomSummaryResponse$3_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_38 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_39 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_38(
+  _FakeGetSpaceHierarchyResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -469,9 +481,9 @@ class _FakeGetSpaceHierarchyResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_39 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_40 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_39(
+  _FakeGetRelatingEventsResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -480,9 +492,9 @@ class _FakeGetRelatingEventsResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_40 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_41 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_40(
+  _FakeGetRelatingEventsWithRelTypeResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -491,9 +503,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -502,9 +514,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_42 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_43 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_42(
+  _FakeGetThreadRootsResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -513,9 +525,9 @@ class _FakeGetThreadRootsResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_43 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_44 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_43(
+  _FakeGetEventByTimestampResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -524,9 +536,9 @@ class _FakeGetEventByTimestampResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_44 extends _i1.SmartFake
+class _FakeRequestTokenResponse_45 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_44(
+  _FakeRequestTokenResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -535,9 +547,9 @@ class _FakeRequestTokenResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_45 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_46 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_45(
+  _FakeTokenOwnerInfo_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -546,8 +558,8 @@ class _FakeTokenOwnerInfo_45 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_46 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_46(
+class _FakeWhoIsInfo_47 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -556,8 +568,8 @@ class _FakeWhoIsInfo_46 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_47 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_47(
+class _FakeCapabilities_48 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -566,8 +578,8 @@ class _FakeCapabilities_47 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_48 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_48(
+class _FakeDevice_49 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -576,9 +588,9 @@ class _FakeDevice_48 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_49 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_50 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_49(
+  _FakeGetRoomIdByAliasResponse_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -587,9 +599,9 @@ class _FakeGetRoomIdByAliasResponse_49 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_50 extends _i1.SmartFake
+class _FakeGetEventsResponse_51 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_50(
+  _FakeGetEventsResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -598,9 +610,9 @@ class _FakeGetEventsResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_51 extends _i1.SmartFake
+class _FakePeekEventsResponse_52 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_51(
+  _FakePeekEventsResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -609,8 +621,8 @@ class _FakePeekEventsResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_52 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_52(
+class _FakeMatrixEvent_53 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -619,9 +631,9 @@ class _FakeMatrixEvent_52 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_53 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_54 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_53(
+  _FakeGetKeysChangesResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -630,9 +642,9 @@ class _FakeGetKeysChangesResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_54 extends _i1.SmartFake
+class _FakeClaimKeysResponse_55 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_54(
+  _FakeClaimKeysResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -641,9 +653,9 @@ class _FakeClaimKeysResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_55 extends _i1.SmartFake
+class _FakeQueryKeysResponse_56 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_55(
+  _FakeQueryKeysResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -652,9 +664,9 @@ class _FakeQueryKeysResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_56 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_57 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_56(
+  _FakeGetNotificationsResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -663,9 +675,9 @@ class _FakeGetNotificationsResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_57 extends _i1.SmartFake
+class _FakeGetPresenceResponse_58 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_57(
+  _FakeGetPresenceResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -674,9 +686,9 @@ class _FakeGetPresenceResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_58 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_59 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_58(
+  _FakeGetPublicRoomsResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -685,9 +697,9 @@ class _FakeGetPublicRoomsResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_59 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_60 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_59(
+  _FakeQueryPublicRoomsResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -696,8 +708,8 @@ class _FakeQueryPublicRoomsResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_60 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_60(
+class _FakePushRuleSet_61 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -706,9 +718,9 @@ class _FakePushRuleSet_60 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_61 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_62 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_61(
+  _FakeGetPushRulesGlobalResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -717,8 +729,8 @@ class _FakeGetPushRulesGlobalResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_62 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_62(
+class _FakePushRule_63 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -727,9 +739,9 @@ class _FakePushRule_62 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_63 extends _i1.SmartFake
+class _FakeRefreshResponse_64 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_63(
+  _FakeRefreshResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -738,8 +750,8 @@ class _FakeRefreshResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_64 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_64(
+class _FakeRoomKeys_65 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -748,8 +760,8 @@ class _FakeRoomKeys_64 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_65 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_65(
+class _FakeRoomKeyBackup_66 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -758,9 +770,9 @@ class _FakeRoomKeyBackup_65 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_66 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_67 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_66(
+  _FakeGetRoomKeysVersionCurrentResponse_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -769,9 +781,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_66 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_67 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_68 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_67(
+  _FakeGetRoomKeysVersionResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -780,8 +792,8 @@ class _FakeGetRoomKeysVersionResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_68 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_68(
+class _FakeEventContext_69 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -790,9 +802,9 @@ class _FakeEventContext_68 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_69 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_70 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_69(
+  _FakeGetRoomEventsResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -801,8 +813,8 @@ class _FakeGetRoomEventsResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_70 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_70(
+class _FakeSearchResults_71 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -811,9 +823,9 @@ class _FakeSearchResults_70 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_71 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_72 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_71(
+  _FakeGetProtocolMetadataResponse$2_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -822,9 +834,9 @@ class _FakeGetProtocolMetadataResponse$2_71 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_72 extends _i1.SmartFake
+class _FakeOpenIdCredentials_73 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_72(
+  _FakeOpenIdCredentials_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -833,9 +845,9 @@ class _FakeOpenIdCredentials_72 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_73 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_74 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_73(
+  _FakeSearchUserDirectoryResponse_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -844,9 +856,9 @@ class _FakeSearchUserDirectoryResponse_73 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_74 extends _i1.SmartFake
+class _FakeCreateContentResponse_75 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_74(
+  _FakeCreateContentResponse_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -855,8 +867,8 @@ class _FakeCreateContentResponse_74 extends _i1.SmartFake
         );
 }
 
-class _FakeResponse_75 extends _i1.SmartFake implements _i13.Response {
-  _FakeResponse_75(
+class _FakeResponse_76 extends _i1.SmartFake implements _i14.Response {
+  _FakeResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -865,9 +877,9 @@ class _FakeResponse_75 extends _i1.SmartFake implements _i13.Response {
         );
 }
 
-class _FakeMatrixService_76 extends _i1.SmartFake
-    implements _i16.MatrixService {
-  _FakeMatrixService_76(
+class _FakeMatrixService_77 extends _i1.SmartFake
+    implements _i17.MatrixService {
+  _FakeMatrixService_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -876,9 +888,9 @@ class _FakeMatrixService_76 extends _i1.SmartFake
         );
 }
 
-class _FakePreferencesService_77 extends _i1.SmartFake
-    implements _i17.PreferencesService {
-  _FakePreferencesService_77(
+class _FakePreferencesService_78 extends _i1.SmartFake
+    implements _i18.PreferencesService {
+  _FakePreferencesService_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -887,8 +899,8 @@ class _FakePreferencesService_77 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_78 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_78(
+class _FakeRoomSummary_79 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -897,9 +909,9 @@ class _FakeRoomSummary_78 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_79 extends _i1.SmartFake
+class _FakeLatestReceiptState_80 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_79(
+  _FakeLatestReceiptState_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -908,8 +920,8 @@ class _FakeLatestReceiptState_79 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_80 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_80(
+class _FakeTimeline_81 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -918,8 +930,8 @@ class _FakeTimeline_80 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_81 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_81(
+class _FakeUser_82 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -928,8 +940,8 @@ class _FakeUser_81 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeRoom_82 extends _i1.SmartFake implements _i4.Room {
-  _FakeRoom_82(
+class _FakeRoom_83 extends _i1.SmartFake implements _i4.Room {
+  _FakeRoom_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -938,9 +950,9 @@ class _FakeRoom_82 extends _i1.SmartFake implements _i4.Room {
         );
 }
 
-class _FakeTimelineChunk_83 extends _i1.SmartFake
-    implements _i18.TimelineChunk {
-  _FakeTimelineChunk_83(
+class _FakeTimelineChunk_84 extends _i1.SmartFake
+    implements _i19.TimelineChunk {
+  _FakeTimelineChunk_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -952,7 +964,7 @@ class _FakeTimelineChunk_83 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -982,11 +994,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1111,6 +1123,19 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i11.OutboxService);
 
   @override
+  _i12.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i12.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -1208,6 +1233,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set stickerPacks(_i12.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -1215,14 +1249,14 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i15.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1252,7 +1286,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1262,21 +1296,22 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i15.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> login({
+  _i15.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1286,14 +1321,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> completeSsoLogin({
+  _i15.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1306,12 +1342,12 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> completeRegistration(
+  _i15.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1321,32 +1357,32 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i15.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1355,7 +1391,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1364,17 +1400,17 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i15.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1385,7 +1421,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1422,26 +1458,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i15.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+  _i15.Future<bool> didPushRouteInformation(
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1471,7 +1507,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1480,7 +1516,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1489,16 +1525,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i15.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i14.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i15.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i14.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i14.Future<_i20.AppExitResponse>);
+            _i15.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i15.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1526,23 +1562,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_10(
+        returnValue: _FakeDatabaseApi_11(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_10(
+        returnValueForMissingStub: _FakeDatabaseApi_11(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i23.KeyVerificationMethod> get verificationMethods =>
+  Set<_i24.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i23.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i23.KeyVerificationMethod>{},
-      ) as Set<_i23.KeyVerificationMethod>);
+        returnValue: <_i24.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i24.KeyVerificationMethod>{},
+      ) as Set<_i24.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1603,11 +1639,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_11(
+        returnValue: _FakeFilter_12(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_11(
+        returnValueForMissingStub: _FakeFilter_12(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -1616,11 +1652,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_12(
+        returnValue: _FakeNativeImplementations_13(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_12(
+        returnValueForMissingStub: _FakeNativeImplementations_13(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -1636,11 +1672,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_13(
+        returnValue: _FakeDuration_14(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_13(
+        returnValueForMissingStub: _FakeDuration_14(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -1649,11 +1685,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_13(
+        returnValue: _FakeDuration_14(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_13(
+        returnValueForMissingStub: _FakeDuration_14(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -1662,11 +1698,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1703,11 +1739,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1737,11 +1773,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1750,11 +1786,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1777,11 +1813,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_14(
+        returnValue: _FakePushruleEvaluator_15(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_14(
+        returnValueForMissingStub: _FakePushruleEvaluator_15(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -1802,332 +1838,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i14.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i15.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i12.CachedStreamController<String> get onUserProfileUpdate =>
+  _i13.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_16<String>(
+        returnValue: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i14.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i15.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i14.Future<List<_i4.Room>>);
+            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i15.Future<List<_i4.Room>>);
 
   @override
-  _i12.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i13.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_16<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_17<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.EventUpdate>(
+            _FakeCachedStreamController_17<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.EventUpdate>);
+      ) as _i13.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i13.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_16<_i4.Event>(
+        returnValue: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i13.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_16<_i4.Event>(
+        returnValue: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onNotification =>
+  _i13.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_16<_i4.Event>(
+        returnValue: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i13.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_16<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_17<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_17<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i13.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i12.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i13.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_16<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_17<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_16<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_17<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i12.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i13.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i12.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i13.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_16<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_17<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.LoginState>(
+            _FakeCachedStreamController_17<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i12.CachedStreamController<_i4.LoginState>);
+      ) as _i13.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i12.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i13.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_16<bool>(
+        returnValue: _FakeCachedStreamController_17<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i12.CachedStreamController<bool>);
+      ) as _i13.CachedStreamController<bool>);
 
   @override
-  _i12.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i13.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_16<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_17<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i12.CachedStreamController<_i4.SdkError>);
+      ) as _i13.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i12.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i13.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_16<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_17<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.SyncUpdate>(
+            _FakeCachedStreamController_17<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i12.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i13.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i13.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_16<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_17<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_17<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i12.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i13.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.Presence> get onPresence =>
+  _i13.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_16<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_17<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i12.CachedStreamController<_i4.Presence>);
+      ) as _i13.CachedStreamController<_i4.Presence>);
 
   @override
-  _i12.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i13.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_16<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_17<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.CachedPresence>(
+            _FakeCachedStreamController_17<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i12.CachedStreamController<_i4.CachedPresence>);
+      ) as _i13.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i12.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i13.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_16<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_17<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.BasicEvent>(
+            _FakeCachedStreamController_17<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i12.CachedStreamController<_i4.BasicEvent>);
+      ) as _i13.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i12.CachedStreamController<_i23.RoomKeyRequest> get onRoomKeyRequest =>
+  _i13.CachedStreamController<_i24.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_16<_i23.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_17<_i24.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i23.RoomKeyRequest>(
+            _FakeCachedStreamController_17<_i24.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i12.CachedStreamController<_i23.RoomKeyRequest>);
+      ) as _i13.CachedStreamController<_i24.RoomKeyRequest>);
 
   @override
-  _i12.CachedStreamController<_i23.KeyVerification>
+  _i13.CachedStreamController<_i24.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_16<_i23.KeyVerification>(
+            returnValue: _FakeCachedStreamController_17<_i24.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_16<_i23.KeyVerification>(
+                _FakeCachedStreamController_17<_i24.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i12.CachedStreamController<_i23.KeyVerification>);
+          ) as _i13.CachedStreamController<_i24.KeyVerification>);
 
   @override
-  _i12.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i13.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_16<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_17<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_17<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i12.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i13.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i13.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_16<_i4.Event>(
+        returnValue: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<String> get onCancelSendEvent =>
+  _i13.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_16<String>(
+        returnValue: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i12.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i13.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_16<
+            returnValue: _FakeCachedStreamController_17<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_16<
+            returnValueForMissingStub: _FakeCachedStreamController_17<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i12.CachedStreamController<
+          ) as _i13.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -2147,11 +2183,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_17(
+        returnValue: _FakeDateTime_18(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_17(
+        returnValueForMissingStub: _FakeDateTime_18(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2224,7 +2260,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i23.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i24.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2279,7 +2315,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i14.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i15.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2290,7 +2326,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i14.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i15.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -2401,7 +2437,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -2410,7 +2446,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -2419,7 +2455,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -2446,20 +2482,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Client get httpClient => (super.noSuchMethod(
+  _i14.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_18(
+        returnValue: _FakeClient_19(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_18(
+        returnValueForMissingStub: _FakeClient_19(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i13.Client);
+      ) as _i14.Client);
 
   @override
-  set httpClient(_i13.Client? value) => super.noSuchMethod(
+  set httpClient(_i14.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -2486,7 +2522,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<void> refreshAccessToken(
+  _i15.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2494,9 +2530,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -2514,14 +2550,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2558,33 +2594,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i14.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i15.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_19(
+        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_20(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_19(
+        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_20(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i14.Future<_i4.DiscoveryInformation>);
+      ) as _i15.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i14.Future<
+  _i15.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -2606,7 +2642,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i14.Future<
+        returnValue: _i15.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2614,7 +2650,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_20(
+          _FakeGetVersionsResponse_21(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2629,7 +2665,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i14.Future<
+        returnValueForMissingStub: _i15.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2637,7 +2673,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_20(
+          _FakeGetVersionsResponse_21(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2652,7 +2688,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i14.Future<
+      ) as _i15.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -2661,7 +2697,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i14.Future<_i4.DiscoveryInformation> getWellknown({
+  _i15.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2674,8 +2710,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_19(
+        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_20(
           this,
           Invocation.method(
             #getWellknown,
@@ -2686,8 +2722,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_19(
+        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_20(
           this,
           Invocation.method(
             #getWellknown,
@@ -2698,10 +2734,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.DiscoveryInformation>);
+      ) as _i15.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i14.Future<_i4.RegisterResponse> register({
+  _i15.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -2729,7 +2765,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_21(
+            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_22(
           this,
           Invocation.method(
             #register,
@@ -2748,7 +2784,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_21(
+            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_22(
           this,
           Invocation.method(
             #register,
@@ -2766,10 +2802,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RegisterResponse>);
+      ) as _i15.Future<_i4.RegisterResponse>);
 
   @override
-  _i14.Future<_i4.LoginResponse> login(
+  _i15.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -2799,7 +2835,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_22(
+        returnValue: _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_23(
           this,
           Invocation.method(
             #login,
@@ -2819,7 +2855,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_22(
+            _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_23(
           this,
           Invocation.method(
             #login,
@@ -2838,10 +2874,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.LoginResponse>);
+      ) as _i15.Future<_i4.LoginResponse>);
 
   @override
-  _i14.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i15.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2854,8 +2890,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_23(
+        returnValue: _i15.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_24(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2867,8 +2903,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_23(
+            _i15.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_24(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2879,74 +2915,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i15.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logoutAll() => (super.noSuchMethod(
+  _i15.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<T> uiaRequestBackground<T>(
-          _i14.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i15.Future<T> uiaRequestBackground<T>(
+          _i15.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValue: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i14.Future<T>.value(v),
+              (T v) => _i15.Future<T>.value(v),
             ) ??
-            _FakeFuture_24<T>(
+            _FakeFuture_25<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i19.ifNotNull(
-              _i19.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i20.ifNotNull(
+              _i20.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i14.Future<T>.value(v),
+              (T v) => _i15.Future<T>.value(v),
             ) ??
-            _FakeFuture_24<T>(
+            _FakeFuture_25<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i14.Future<T>);
+      ) as _i15.Future<T>);
 
   @override
-  _i14.Future<String> startDirectChat(
+  _i15.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -2968,7 +3004,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2984,7 +3020,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i19.dummyValue<String>(
+            _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2999,10 +3035,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> createGroupChat({
+  _i15.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -3033,7 +3069,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3054,7 +3090,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i19.dummyValue<String>(
+            _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3074,10 +3110,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i15.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -3093,7 +3129,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3106,7 +3142,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3118,21 +3154,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i15.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<String> createSpace({
+  _i15.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -3157,7 +3193,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3175,7 +3211,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i19.dummyValue<String>(
+            _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3192,10 +3228,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i15.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3203,7 +3239,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3212,7 +3248,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3220,10 +3256,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i14.Future<_i4.Profile> fetchOwnProfile({
+  _i15.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3236,7 +3272,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3248,7 +3284,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3259,10 +3295,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i14.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i15.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3276,8 +3312,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i14.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_26(
+        returnValue: _i15.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_27(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3289,8 +3325,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_26(
+            _i15.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_27(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3301,10 +3337,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.CachedProfileInformation>);
+      ) as _i15.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i14.Future<_i4.Profile> getProfileFromUserId(
+  _i15.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3322,7 +3358,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3336,7 +3372,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3349,7 +3385,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -3371,31 +3407,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i14.Future<List<_i4.Room>>);
+            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i15.Future<List<_i4.Room>>);
 
   @override
-  _i14.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i15.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i14.Future<List<_i4.ArchivedRoom>>);
+            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i15.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i14.Future<_i4.GetVersionsResponse> getVersions({
+  _i15.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3408,8 +3444,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_20(
+        returnValue: _i15.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_21(
           this,
           Invocation.method(
             #getVersions,
@@ -3420,8 +3456,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_20(
+        returnValueForMissingStub: _i15.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_21(
           this,
           Invocation.method(
             #getVersions,
@@ -3432,20 +3468,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetVersionsResponse>);
+      ) as _i15.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i14.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i15.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.MediaConfig> getConfig({
+  _i15.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3458,7 +3494,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
+        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
           this,
           Invocation.method(
             #getConfig,
@@ -3470,7 +3506,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
+            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
           this,
           Invocation.method(
             #getConfig,
@@ -3481,10 +3517,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.MediaConfig>);
+      ) as _i15.Future<_i4.MediaConfig>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContent(
+  _i15.Future<_i16.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -3504,7 +3540,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContent,
@@ -3520,7 +3556,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContent,
@@ -3535,10 +3571,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentOverrideName(
+  _i15.Future<_i16.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -3560,7 +3596,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3577,7 +3613,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3593,10 +3629,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentThumbnail(
+  _i15.Future<_i16.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -3624,7 +3660,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3644,7 +3680,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3663,10 +3699,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i15.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -3676,7 +3712,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
+        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3685,7 +3721,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
+            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3693,11 +3729,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i14.Future<_i4.PreviewForUrl>);
+      ) as _i15.Future<_i4.PreviewForUrl>);
 
   @override
-  _i14.Future<Uri> uploadContent(
-    _i24.Uint8List? file, {
+  _i15.Future<Uri> uploadContent(
+    _i25.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3710,7 +3746,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i14.Future<Uri>.value(_FakeUri_30(
+        returnValue: _i15.Future<Uri>.value(_FakeUri_31(
           this,
           Invocation.method(
             #uploadContent,
@@ -3721,7 +3757,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_30(
+        returnValueForMissingStub: _i15.Future<Uri>.value(_FakeUri_31(
           this,
           Invocation.method(
             #uploadContent,
@@ -3732,10 +3768,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<Uri>);
+      ) as _i15.Future<Uri>);
 
   @override
-  _i14.Future<void> setTyping(
+  _i15.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -3751,42 +3787,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> exportDump() => (super.noSuchMethod(
+  _i15.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i15.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i15.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Event?> getEventByPushNotification(
+  _i15.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -3802,12 +3838,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
-  _i14.Future<void> init({
+  _i15.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -3842,9 +3878,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -3856,40 +3892,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<void> clear() => (super.noSuchMethod(
+  _i15.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i15.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ensureNotSoftLoggedOut(
+  _i15.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSync(
+  _i15.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -3899,9 +3935,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -3914,29 +3950,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i14.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i15.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i15.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDevice(
+  _i15.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -3950,12 +3986,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDevicesOfUserIds(
+  _i15.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -3971,12 +4007,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDeviceEncrypted(
+  _i15.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -3996,12 +4032,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDeviceEncryptedChunked(
+  _i15.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -4015,23 +4051,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i15.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> joinRoom(
+  _i15.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -4049,7 +4085,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4063,7 +4099,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i19.dummyValue<String>(
+            _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4076,10 +4112,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> changePassword(
+  _i15.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -4095,22 +4131,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> clearCache() => (super.noSuchMethod(
+  _i15.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ignoreUser(
+  _i15.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4120,22 +4156,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i15.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i15.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4146,7 +4182,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_31(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_32(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4155,7 +4191,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_31(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_32(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4163,32 +4199,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i14.Future<_i4.CachedPresence>);
+      ) as _i15.Future<_i4.CachedPresence>);
 
   @override
-  _i14.Future<void> abortSync() => (super.noSuchMethod(
+  _i15.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i15.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEventWithMetadata(
+  _i15.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4208,14 +4244,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i13.BaseResponse? response,
-    _i24.Uint8List? body,
+    _i14.BaseResponse? response,
+    _i25.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4247,7 +4283,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i14.Future<Map<String, Object?>> request(
+  _i15.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -4268,13 +4304,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> postPusher(
+  _i15.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -4284,57 +4320,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i15.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i15.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i15.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i14.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_32(
+        returnValue: _i15.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_33(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_32(
+        returnValueForMissingStub: _i15.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_33(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.TurnServerCredentials>);
+      ) as _i15.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4348,8 +4384,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4361,8 +4397,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4373,10 +4409,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4392,8 +4428,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4406,8 +4442,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4419,10 +4455,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i15.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4436,7 +4472,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
+        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4448,7 +4484,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
+            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4459,17 +4495,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.KeyBackupData>);
+      ) as _i15.Future<_i4.KeyBackupData>);
 
   @override
-  _i14.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i15.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i14.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_35(
+        returnValue: _i15.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_36(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -4477,18 +4513,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_35(
+            _i15.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_36(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i15.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i14.Future<int> pingAppservice(
+  _i15.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -4498,12 +4534,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i14.Future<int>.value(0),
-        returnValueForMissingStub: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+        returnValueForMissingStub: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
-  _i14.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i15.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4511,8 +4547,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_36(
+        returnValue: _i15.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_37(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4521,8 +4557,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_36(
+            _i15.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_37(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4530,15 +4566,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i14.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i15.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i14.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i15.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
+        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -4546,17 +4582,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
+            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.MediaConfig>);
+      ) as _i15.Future<_i4.MediaConfig>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentAuthed(
+  _i15.Future<_i16.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -4570,7 +4606,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4582,7 +4618,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4593,10 +4629,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentOverrideNameAuthed(
+  _i15.Future<_i16.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4612,7 +4648,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4625,7 +4661,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4637,10 +4673,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i15.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -4650,7 +4686,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
+        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4659,7 +4695,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
+            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4667,10 +4703,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i14.Future<_i4.PreviewForUrl>);
+      ) as _i15.Future<_i4.PreviewForUrl>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentThumbnailAuthed(
+  _i15.Future<_i16.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -4694,7 +4730,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4712,7 +4748,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4729,21 +4765,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<bool> registrationTokenValidity(String? token) =>
+  _i15.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i15.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -4753,8 +4789,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_37(
+        returnValue: _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_38(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4763,8 +4799,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_37(
+            _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_38(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4772,10 +4808,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i15.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i14.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i15.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -4793,8 +4829,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_38(
+        returnValue: _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_39(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4808,8 +4844,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_38(
+            _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_39(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4822,10 +4858,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i15.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i15.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -4849,8 +4885,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i14.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_39(
+        returnValue: _i15.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_40(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4868,8 +4904,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_39(
+            _i15.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_40(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4886,10 +4922,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i15.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -4917,8 +4953,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_40(
+                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_41(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4937,8 +4973,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_40(
+                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_41(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4956,10 +4992,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i15.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -4988,9 +5024,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i14.Future<
+            returnValue: _i15.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5009,9 +5045,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i14.Future<
+            returnValueForMissingStub: _i15.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5030,11 +5066,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i14
+          ) as _i15
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i14.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i15.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -5050,8 +5086,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i14.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_42(
+        returnValue: _i15.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_43(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5064,8 +5100,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_42(
+            _i15.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_43(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5077,10 +5113,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetThreadRootsResponse>);
+      ) as _i15.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i14.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i15.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -5094,8 +5130,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i14.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_43(
+        returnValue: _i15.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_44(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5107,8 +5143,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_43(
+            _i15.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_44(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5119,33 +5155,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i15.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i15.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i14.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i15.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i14.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i15.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i14.Future<Uri?>.value(),
-        returnValueForMissingStub: _i14.Future<Uri?>.value(),
-      ) as _i14.Future<Uri?>);
+        returnValue: _i15.Future<Uri?>.value(),
+        returnValueForMissingStub: _i15.Future<Uri?>.value(),
+      ) as _i15.Future<Uri?>);
 
   @override
-  _i14.Future<void> add3PID(
+  _i15.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -5159,12 +5195,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> bind3PID(
+  _i15.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5180,12 +5216,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i15.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5199,14 +5235,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5228,8 +5264,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5245,8 +5281,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5262,10 +5298,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5289,8 +5325,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5307,8 +5343,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5325,10 +5361,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i15.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5342,14 +5378,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i15.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -5364,14 +5400,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5393,8 +5429,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5410,8 +5446,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5427,10 +5463,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5454,8 +5490,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5472,8 +5508,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5490,16 +5526,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i15.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_45(
+            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -5507,22 +5543,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_45(
+            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.TokenOwnerInfo>);
+      ) as _i15.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i14.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i15.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_46(
+        returnValue: _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_47(
           this,
           Invocation.method(
             #getWhoIs,
@@ -5530,22 +5566,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_46(
+            _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_47(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i14.Future<_i4.WhoIsInfo>);
+      ) as _i15.Future<_i4.WhoIsInfo>);
 
   @override
-  _i14.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i15.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_47(
+        returnValue: _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_48(
           this,
           Invocation.method(
             #getCapabilities,
@@ -5553,17 +5589,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_47(
+            _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_48(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.Capabilities>);
+      ) as _i15.Future<_i4.Capabilities>);
 
   @override
-  _i14.Future<String> createRoom({
+  _i15.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -5596,7 +5632,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5618,7 +5654,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i19.dummyValue<String>(
+            _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5639,10 +5675,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> deleteDevices(
+  _i15.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5652,22 +5688,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.Device>?>.value(),
-      ) as _i14.Future<List<_i4.Device>?>);
+        returnValue: _i15.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.Device>?>.value(),
+      ) as _i15.Future<List<_i4.Device>?>);
 
   @override
-  _i14.Future<void> deleteDevice(
+  _i15.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5677,34 +5713,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i15.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i14.Future<_i4.Device>.value(_FakeDevice_48(
+        returnValue: _i15.Future<_i4.Device>.value(_FakeDevice_49(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Device>.value(_FakeDevice_48(
+        returnValueForMissingStub: _i15.Future<_i4.Device>.value(_FakeDevice_49(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i14.Future<_i4.Device>);
+      ) as _i15.Future<_i4.Device>);
 
   @override
-  _i14.Future<void> updateDevice(
+  _i15.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -5714,12 +5750,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i15.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -5734,24 +5770,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i15.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i14.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Visibility?>.value(),
-      ) as _i14.Future<_i4.Visibility?>);
+        returnValue: _i15.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Visibility?>.value(),
+      ) as _i15.Future<_i4.Visibility?>);
 
   @override
-  _i14.Future<void> setRoomVisibilityOnDirectory(
+  _i15.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -5761,30 +5797,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i15.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i15.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_49(
+        returnValue: _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_50(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -5792,18 +5828,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_49(
+            _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_50(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i15.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i14.Future<void> setRoomAlias(
+  _i15.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -5815,12 +5851,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetEventsResponse> getEvents({
+  _i15.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -5834,7 +5870,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_50(
+            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_51(
           this,
           Invocation.method(
             #getEvents,
@@ -5846,7 +5882,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_50(
+            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_51(
           this,
           Invocation.method(
             #getEvents,
@@ -5857,10 +5893,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetEventsResponse>);
+      ) as _i15.Future<_i4.GetEventsResponse>);
 
   @override
-  _i14.Future<_i4.PeekEventsResponse> peekEvents({
+  _i15.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -5875,8 +5911,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i14.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_51(
+        returnValue: _i15.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_52(
           this,
           Invocation.method(
             #peekEvents,
@@ -5888,8 +5924,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_51(
+        returnValueForMissingStub: _i15.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_52(
           this,
           Invocation.method(
             #peekEvents,
@@ -5901,16 +5937,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.PeekEventsResponse>);
+      ) as _i15.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i14.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i15.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
+        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
           this,
           Invocation.method(
             #getOneEvent,
@@ -5918,27 +5954,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
+            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i14.Future<_i4.MatrixEvent>);
+      ) as _i15.Future<_i4.MatrixEvent>);
 
   @override
-  _i14.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i15.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 
   @override
-  _i14.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i15.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -5950,8 +5986,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i14.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_53(
+        returnValue: _i15.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_54(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5962,8 +5998,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_53(
+            _i15.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_54(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5973,10 +6009,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.GetKeysChangesResponse>);
+      ) as _i15.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i14.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i15.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -5987,7 +6023,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_54(
+            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
           this,
           Invocation.method(
             #claimKeys,
@@ -5996,7 +6032,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_54(
+            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
           this,
           Invocation.method(
             #claimKeys,
@@ -6004,10 +6040,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i14.Future<_i4.ClaimKeysResponse>);
+      ) as _i15.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i14.Future<void> uploadCrossSigningKeys({
+  _i15.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -6024,12 +6060,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.QueryKeysResponse> queryKeys(
+  _i15.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -6040,7 +6076,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_55(
+            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
           this,
           Invocation.method(
             #queryKeys,
@@ -6049,7 +6085,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_55(
+            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
           this,
           Invocation.method(
             #queryKeys,
@@ -6057,10 +6093,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i14.Future<_i4.QueryKeysResponse>);
+      ) as _i15.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -6068,14 +6104,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i14.Future<
+            returnValue: _i15.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i14.Future<
+            returnValueForMissingStub: _i15.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i14.Future<Map<String, int>> uploadKeys({
+  _i15.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -6090,13 +6126,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i14.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i15.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i14.Future<Map<String, int>>);
+            _i15.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i15.Future<Map<String, int>>);
 
   @override
-  _i14.Future<String> knockRoom(
+  _i15.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -6110,7 +6146,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6122,7 +6158,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i19.dummyValue<String>(
+            _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6133,20 +6169,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i15.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i14.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i15.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i15.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i14.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i15.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6161,8 +6197,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i14.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_56(
+        returnValue: _i15.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_57(
           this,
           Invocation.method(
             #getNotifications,
@@ -6175,8 +6211,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_56(
+            _i15.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_57(
           this,
           Invocation.method(
             #getNotifications,
@@ -6188,35 +6224,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetNotificationsResponse>);
+      ) as _i15.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i14.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i15.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i14.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_57(
+        returnValue: _i15.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_58(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_57(
+        returnValueForMissingStub: _i15.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_58(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i14.Future<_i4.GetPresenceResponse>);
+      ) as _i15.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i14.Future<void> setPresence(
+  _i15.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -6230,12 +6266,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, Object?>> deleteProfileField(
+  _i15.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6248,13 +6284,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getProfileField(
+  _i15.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6267,13 +6303,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<Map<String, Object?>> setProfileField(
+  _i15.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6288,13 +6324,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i15.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6309,8 +6345,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i14.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_58(
+        returnValue: _i15.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_59(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6323,8 +6359,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_58(
+            _i15.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_59(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6336,10 +6372,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i15.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i14.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i15.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -6360,8 +6396,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i14.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_59(
+        returnValue: _i15.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_60(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6377,8 +6413,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_59(
+            _i15.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_60(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6393,25 +6429,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i15.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i14.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.Pusher>?>.value(),
-      ) as _i14.Future<List<_i4.Pusher>?>);
+        returnValue: _i15.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.Pusher>?>.value(),
+      ) as _i15.Future<List<_i4.Pusher>?>);
 
   @override
-  _i14.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i15.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_60(
+        returnValue: _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_61(
           this,
           Invocation.method(
             #getPushRules,
@@ -6419,24 +6455,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_60(
+            _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_61(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.PushRuleSet>);
+      ) as _i15.Future<_i4.PushRuleSet>);
 
   @override
-  _i14.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i15.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_61(
+        returnValue: _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_62(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -6444,18 +6480,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_61(
+            _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_62(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i15.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i14.Future<void> deletePushRule(
+  _i15.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6467,12 +6503,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.PushRule> getPushRule(
+  _i15.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6484,7 +6520,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<_i4.PushRule>.value(_FakePushRule_62(
+        returnValue: _i15.Future<_i4.PushRule>.value(_FakePushRule_63(
           this,
           Invocation.method(
             #getPushRule,
@@ -6495,7 +6531,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PushRule>.value(_FakePushRule_62(
+            _i15.Future<_i4.PushRule>.value(_FakePushRule_63(
           this,
           Invocation.method(
             #getPushRule,
@@ -6505,10 +6541,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.PushRule>);
+      ) as _i15.Future<_i4.PushRule>);
 
   @override
-  _i14.Future<void> setPushRule(
+  _i15.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -6532,12 +6568,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<Object?>> getPushRuleActions(
+  _i15.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6549,13 +6585,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i15.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i14.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i14.Future<List<Object?>>);
+            _i15.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i15.Future<List<Object?>>);
 
   @override
-  _i14.Future<void> setPushRuleActions(
+  _i15.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -6569,12 +6605,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> isPushRuleEnabled(
+  _i15.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6586,12 +6622,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> setPushRuleEnabled(
+  _i15.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -6605,19 +6641,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i15.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_63(
+            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_64(
           this,
           Invocation.method(
             #refresh,
@@ -6625,28 +6661,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_63(
+            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_64(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i14.Future<_i4.RefreshResponse>);
+      ) as _i15.Future<_i4.RefreshResponse>);
 
   @override
-  _i14.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i15.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i14.Future<bool?>.value(),
-        returnValueForMissingStub: _i14.Future<bool?>.value(),
-      ) as _i14.Future<bool?>);
+        returnValue: _i15.Future<bool?>.value(),
+        returnValueForMissingStub: _i15.Future<bool?>.value(),
+      ) as _i15.Future<bool?>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6668,8 +6704,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6685,8 +6721,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6702,10 +6738,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6729,8 +6765,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6747,8 +6783,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6765,17 +6801,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -6783,23 +6819,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i15.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_64(
+        returnValue: _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_65(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -6807,17 +6843,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_64(
+            _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_65(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeys>);
+      ) as _i15.Future<_i4.RoomKeys>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -6829,8 +6865,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6841,8 +6877,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6852,10 +6888,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6867,8 +6903,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6879,8 +6915,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6890,10 +6926,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6905,7 +6941,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_65(
+        returnValue: _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6916,7 +6952,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_65(
+            _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6926,10 +6962,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeyBackup>);
+      ) as _i15.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -6943,8 +6979,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6956,8 +6992,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6968,10 +7004,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6985,8 +7021,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -6998,8 +7034,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7010,10 +7046,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i15.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7027,7 +7063,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
+        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7039,7 +7075,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
+            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7050,10 +7086,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.KeyBackupData>);
+      ) as _i15.Future<_i4.KeyBackupData>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7069,8 +7105,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7083,8 +7119,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7096,18 +7132,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_66(
+                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_67(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -7115,18 +7151,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_66(
+                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_67(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i14.Future<String> postRoomKeysVersion(
+  _i15.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -7138,7 +7174,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7149,7 +7185,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i19.dummyValue<String>(
+            _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7159,29 +7195,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i15.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i15.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_67(
+        returnValue: _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_68(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7189,18 +7225,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_67(
+            _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_68(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i15.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i15.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -7215,24 +7251,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i15.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 
   @override
-  _i14.Future<void> ban(
+  _i15.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7246,12 +7282,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.EventContext> getEventContext(
+  _i15.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7269,7 +7305,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i4.EventContext>.value(_FakeEventContext_68(
+        returnValue: _i15.Future<_i4.EventContext>.value(_FakeEventContext_69(
           this,
           Invocation.method(
             #getEventContext,
@@ -7284,7 +7320,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.EventContext>.value(_FakeEventContext_68(
+            _i15.Future<_i4.EventContext>.value(_FakeEventContext_69(
           this,
           Invocation.method(
             #getEventContext,
@@ -7298,10 +7334,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.EventContext>);
+      ) as _i15.Future<_i4.EventContext>);
 
   @override
-  _i14.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i15.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7313,7 +7349,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
+        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7324,7 +7360,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
+            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7334,20 +7370,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.MatrixEvent>);
+      ) as _i15.Future<_i4.MatrixEvent>);
 
   @override
-  _i14.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> inviteBy3PID(
+  _i15.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -7359,12 +7395,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> inviteUser(
+  _i15.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7378,12 +7414,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> joinRoomById(
+  _i15.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -7397,7 +7433,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7409,7 +7445,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i19.dummyValue<String>(
+            _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7420,23 +7456,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i15.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i15.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i14.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i14.Future<Map<String, _i4.RoomMember>?>);
+            _i15.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i15.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i14.Future<void> kick(
+  _i15.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7450,12 +7486,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> leaveRoom(
+  _i15.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -7465,12 +7501,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i15.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -7486,12 +7522,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i14.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i14.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i15.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i15.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i14.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i15.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -7513,8 +7549,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_69(
+        returnValue: _i15.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_70(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7530,8 +7566,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_69(
+        returnValueForMissingStub: _i15.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_70(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7547,10 +7583,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomEventsResponse>);
+      ) as _i15.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i14.Future<void> setReadMarker(
+  _i15.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -7566,12 +7602,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> postReceipt(
+  _i15.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -7587,12 +7623,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEvent(
+  _i15.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -7608,12 +7644,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> reportRoom(
+  _i15.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -7625,12 +7661,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> reportEvent(
+  _i15.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -7648,12 +7684,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> sendMessage(
+  _i15.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -7669,7 +7705,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7682,7 +7718,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i19.dummyValue<String>(
+            _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7694,23 +7730,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i15.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i14.Future<List<_i4.MatrixEvent>>);
+            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i15.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i15.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -7727,13 +7763,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<String> setRoomStateWithKey(
+  _i15.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -7749,7 +7785,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7762,7 +7798,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i19.dummyValue<String>(
+            _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7774,10 +7810,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> unban(
+  _i15.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7791,12 +7827,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> upgradeRoom(
+  _i15.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -7810,7 +7846,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7822,7 +7858,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i19.dummyValue<String>(
+            _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7833,10 +7869,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.SearchResults> search(
+  _i15.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -7846,7 +7882,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_70(
+        returnValue: _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_71(
           this,
           Invocation.method(
             #search,
@@ -7855,7 +7891,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_70(
+            _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_71(
           this,
           Invocation.method(
             #search,
@@ -7863,10 +7899,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i14.Future<_i4.SearchResults>);
+      ) as _i15.Future<_i4.SearchResults>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> sync({
+  _i15.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -7887,7 +7923,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.method(
             #sync,
@@ -7903,7 +7939,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.method(
             #sync,
@@ -7918,22 +7954,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i15.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i14.Future<List<_i4.Location>>);
+            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i15.Future<List<_i4.Location>>);
 
   @override
-  _i14.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i15.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -7943,21 +7979,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i14.Future<List<_i4.Location>>);
+            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i15.Future<List<_i4.Location>>);
 
   @override
-  _i14.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i15.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_71(
+        returnValue: _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_72(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -7965,45 +8001,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_71(
+            _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_72(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i14.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i15.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i14.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i15.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8014,13 +8050,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getAccountData(
+  _i15.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -8033,13 +8069,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> setAccountData(
+  _i15.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -8053,12 +8089,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> defineFilter(
+  _i15.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -8070,7 +8106,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8081,7 +8117,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i19.dummyValue<String>(
+            _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8091,10 +8127,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.Filter> getFilter(
+  _i15.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -8106,7 +8142,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i14.Future<_i4.Filter>.value(_FakeFilter_11(
+        returnValue: _i15.Future<_i4.Filter>.value(_FakeFilter_12(
           this,
           Invocation.method(
             #getFilter,
@@ -8116,7 +8152,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Filter>.value(_FakeFilter_11(
+        returnValueForMissingStub: _i15.Future<_i4.Filter>.value(_FakeFilter_12(
           this,
           Invocation.method(
             #getFilter,
@@ -8126,10 +8162,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.Filter>);
+      ) as _i15.Future<_i4.Filter>);
 
   @override
-  _i14.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i15.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8142,7 +8178,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_72(
+            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8153,7 +8189,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_72(
+            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8163,10 +8199,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.OpenIdCredentials>);
+      ) as _i15.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i14.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i15.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8181,13 +8217,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> setAccountDataPerRoom(
+  _i15.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8203,12 +8239,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i15.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8220,12 +8256,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i14.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i14.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i14.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i15.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i15.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i15.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i14.Future<void> deleteRoomTag(
+  _i15.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8239,12 +8275,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setRoomTag(
+  _i15.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8260,12 +8296,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i15.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8275,8 +8311,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i14.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_73(
+        returnValue: _i15.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_74(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8285,8 +8321,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_73(
+            _i15.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_74(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8294,10 +8330,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i14.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i15.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> reportUser(
+  _i15.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8310,40 +8346,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i15.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i14.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_74(
+        returnValue: _i15.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_75(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_74(
+        returnValueForMissingStub: _i15.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_75(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.CreateContentResponse>);
+      ) as _i15.Future<_i4.CreateContentResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> uploadContentToMXC(
+  _i15.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i24.Uint8List? body, {
+    _i25.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8361,16 +8397,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [CallService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCallService extends _i1.Mock implements _i25.CallService {
+class MockCallService extends _i1.Mock implements _i26.CallService {
   @override
   _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -8392,36 +8428,36 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       ) as bool);
 
   @override
-  _i26.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
+  _i27.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
         Invocation.getter(#httpPostForTest),
         returnValue: (
-          _i13.Client httpClient,
+          _i14.Client httpClient,
           Uri url, {
           Object? body,
           Map<String, String>? headers,
         }) =>
-            _i14.Future<_i13.Response>.value(_FakeResponse_75(
+            _i15.Future<_i14.Response>.value(_FakeResponse_76(
           this,
           Invocation.getter(#httpPostForTest),
         )),
         returnValueForMissingStub: (
-          _i13.Client httpClient,
+          _i14.Client httpClient,
           Uri url, {
           Object? body,
           Map<String, String>? headers,
         }) =>
-            _i14.Future<_i13.Response>.value(_FakeResponse_75(
+            _i15.Future<_i14.Response>.value(_FakeResponse_76(
           this,
           Invocation.getter(#httpPostForTest),
         )),
-      ) as _i26.HttpPostFunction);
+      ) as _i27.HttpPostFunction);
 
   @override
-  List<_i27.RemoteParticipant> get participants => (super.noSuchMethod(
+  List<_i28.RemoteParticipant> get participants => (super.noSuchMethod(
         Invocation.getter(#participants),
-        returnValue: <_i27.RemoteParticipant>[],
-        returnValueForMissingStub: <_i27.RemoteParticipant>[],
-      ) as List<_i27.RemoteParticipant>);
+        returnValue: <_i28.RemoteParticipant>[],
+        returnValueForMissingStub: <_i28.RemoteParticipant>[],
+      ) as List<_i28.RemoteParticipant>);
 
   @override
   bool get isMicEnabled => (super.noSuchMethod(
@@ -8452,14 +8488,14 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       ) as bool);
 
   @override
-  List<_i27.Participant<_i27.TrackPublication<_i27.Track>>>
+  List<_i28.Participant<_i28.TrackPublication<_i28.Track>>>
       get activeSpeakers => (super.noSuchMethod(
             Invocation.getter(#activeSpeakers),
-            returnValue: <_i27
-                .Participant<_i27.TrackPublication<_i27.Track>>>[],
-            returnValueForMissingStub: <_i27
-                .Participant<_i27.TrackPublication<_i27.Track>>>[],
-          ) as List<_i27.Participant<_i27.TrackPublication<_i27.Track>>>);
+            returnValue: <_i28
+                .Participant<_i28.TrackPublication<_i28.Track>>>[],
+            returnValueForMissingStub: <_i28
+                .Participant<_i28.TrackPublication<_i28.Track>>>[],
+          ) as List<_i28.Participant<_i28.TrackPublication<_i28.Track>>>);
 
   @override
   bool get isCallingAvailable => (super.noSuchMethod(
@@ -8469,11 +8505,11 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       ) as bool);
 
   @override
-  List<_i28.CallParticipant> get allParticipants => (super.noSuchMethod(
+  List<_i29.CallParticipant> get allParticipants => (super.noSuchMethod(
         Invocation.getter(#allParticipants),
-        returnValue: <_i28.CallParticipant>[],
-        returnValueForMissingStub: <_i28.CallParticipant>[],
-      ) as List<_i28.CallParticipant>);
+        returnValue: <_i29.CallParticipant>[],
+        returnValueForMissingStub: <_i29.CallParticipant>[],
+      ) as List<_i29.CallParticipant>);
 
   @override
   bool get isSpeakerOn => (super.noSuchMethod(
@@ -8483,29 +8519,29 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       ) as bool);
 
   @override
-  _i14.Stream<_i29.IncomingCallInfo> get incomingCallStream =>
+  _i15.Stream<_i30.IncomingCallInfo> get incomingCallStream =>
       (super.noSuchMethod(
         Invocation.getter(#incomingCallStream),
-        returnValue: _i14.Stream<_i29.IncomingCallInfo>.empty(),
-        returnValueForMissingStub: _i14.Stream<_i29.IncomingCallInfo>.empty(),
-      ) as _i14.Stream<_i29.IncomingCallInfo>);
+        returnValue: _i15.Stream<_i30.IncomingCallInfo>.empty(),
+        returnValueForMissingStub: _i15.Stream<_i30.IncomingCallInfo>.empty(),
+      ) as _i15.Stream<_i30.IncomingCallInfo>);
 
   @override
-  _i14.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
+  _i15.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
         Invocation.getter(#nativeAcceptedCallStream),
-        returnValue: _i14.Stream<String>.empty(),
-        returnValueForMissingStub: _i14.Stream<String>.empty(),
-      ) as _i14.Stream<String>);
+        returnValue: _i15.Stream<String>.empty(),
+        returnValueForMissingStub: _i15.Stream<String>.empty(),
+      ) as _i15.Stream<String>);
 
   @override
-  _i30.KoheraCallState get callState => (super.noSuchMethod(
+  _i31.KoheraCallState get callState => (super.noSuchMethod(
         Invocation.getter(#callState),
-        returnValue: _i30.KoheraCallState.idle,
-        returnValueForMissingStub: _i30.KoheraCallState.idle,
-      ) as _i30.KoheraCallState);
+        returnValue: _i31.KoheraCallState.idle,
+        returnValueForMissingStub: _i31.KoheraCallState.idle,
+      ) as _i31.KoheraCallState);
 
   @override
-  set preferencesService(_i17.PreferencesService? prefs) => super.noSuchMethod(
+  set preferencesService(_i18.PreferencesService? prefs) => super.noSuchMethod(
         Invocation.setter(
           #preferencesService,
           prefs,
@@ -8514,7 +8550,7 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  set ringtoneService(_i31.RingtoneService? service) => super.noSuchMethod(
+  set ringtoneService(_i32.RingtoneService? service) => super.noSuchMethod(
         Invocation.setter(
           #ringtoneService,
           service,
@@ -8523,7 +8559,7 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  set roomFactoryForTest(_i26.LiveKitRoomFactory? factory) =>
+  set roomFactoryForTest(_i27.LiveKitRoomFactory? factory) =>
       super.noSuchMethod(
         Invocation.setter(
           #roomFactoryForTest,
@@ -8533,7 +8569,7 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  set httpPostForTest(_i26.HttpPostFunction? fn) => super.noSuchMethod(
+  set httpPostForTest(_i27.HttpPostFunction? fn) => super.noSuchMethod(
         Invocation.setter(
           #httpPostForTest,
           fn,
@@ -8567,27 +8603,27 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  _i14.Future<void> toggleMicrophone() => (super.noSuchMethod(
+  _i15.Future<void> toggleMicrophone() => (super.noSuchMethod(
         Invocation.method(
           #toggleMicrophone,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> toggleCamera() => (super.noSuchMethod(
+  _i15.Future<void> toggleCamera() => (super.noSuchMethod(
         Invocation.method(
           #toggleCamera,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> toggleScreenShare({
+  _i15.Future<void> toggleScreenShare({
     String? sourceId,
     bool? captureScreenAudio = false,
   }) =>
@@ -8600,39 +8636,39 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
             #captureScreenAudio: captureScreenAudio,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> toggleScreenAudio() => (super.noSuchMethod(
+  _i15.Future<void> toggleScreenAudio() => (super.noSuchMethod(
         Invocation.method(
           #toggleScreenAudio,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setOutputVolume(double? volume) => (super.noSuchMethod(
+  _i15.Future<void> setOutputVolume(double? volume) => (super.noSuchMethod(
         Invocation.method(
           #setOutputVolume,
           [volume],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> toggleSpeaker() => (super.noSuchMethod(
+  _i15.Future<void> toggleSpeaker() => (super.noSuchMethod(
         Invocation.method(
           #toggleSpeaker,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void setVoipPushHandlesCallKit(bool? value) => super.noSuchMethod(
@@ -8662,7 +8698,7 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8690,36 +8726,36 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  _i14.Future<void> joinCall(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> joinCall(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #joinCall,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> leaveCall() => (super.noSuchMethod(
+  _i15.Future<void> leaveCall() => (super.noSuchMethod(
         Invocation.method(
           #leaveCall,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> acceptCall({bool? withVideo = false}) =>
+  _i15.Future<void> acceptCall({bool? withVideo = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #acceptCall,
           [],
           {#withVideo: withVideo},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void declineCall() => super.noSuchMethod(
@@ -8741,9 +8777,9 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  _i14.Future<void> initiateCall(
+  _i15.Future<void> initiateCall(
     String? roomId, {
-    _i29.CallType? type = _i29.CallType.voice,
+    _i30.CallType? type = _i30.CallType.voice,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8751,9 +8787,9 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
           [roomId],
           {#type: type},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   bool roomHasActiveCall(String? roomId) => (super.noSuchMethod(
@@ -8846,7 +8882,7 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8855,7 +8891,7 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8864,17 +8900,17 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i15.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8885,7 +8921,7 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8922,26 +8958,26 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i15.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+  _i15.Future<bool> didPushRouteInformation(
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -8971,7 +9007,7 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8980,7 +9016,7 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8989,16 +9025,16 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  _i14.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i15.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i14.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i15.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i14.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i14.Future<_i20.AppExitResponse>);
+            _i15.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i15.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -9023,32 +9059,32 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockNotificationService extends _i1.Mock
-    implements _i32.NotificationService {
+    implements _i33.NotificationService {
   @override
-  _i16.MatrixService get matrixService => (super.noSuchMethod(
+  _i17.MatrixService get matrixService => (super.noSuchMethod(
         Invocation.getter(#matrixService),
-        returnValue: _FakeMatrixService_76(
+        returnValue: _FakeMatrixService_77(
           this,
           Invocation.getter(#matrixService),
         ),
-        returnValueForMissingStub: _FakeMatrixService_76(
+        returnValueForMissingStub: _FakeMatrixService_77(
           this,
           Invocation.getter(#matrixService),
         ),
-      ) as _i16.MatrixService);
+      ) as _i17.MatrixService);
 
   @override
-  _i17.PreferencesService get preferencesService => (super.noSuchMethod(
+  _i18.PreferencesService get preferencesService => (super.noSuchMethod(
         Invocation.getter(#preferencesService),
-        returnValue: _FakePreferencesService_77(
+        returnValue: _FakePreferencesService_78(
           this,
           Invocation.getter(#preferencesService),
         ),
-        returnValueForMissingStub: _FakePreferencesService_77(
+        returnValueForMissingStub: _FakePreferencesService_78(
           this,
           Invocation.getter(#preferencesService),
         ),
-      ) as _i17.PreferencesService);
+      ) as _i18.PreferencesService);
 
   @override
   bool get isAppResumed => (super.noSuchMethod(
@@ -9067,14 +9103,14 @@ class MockNotificationService extends _i1.Mock
       );
 
   @override
-  _i14.Future<void> init() => (super.noSuchMethod(
+  _i15.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void startListening() => super.noSuchMethod(
@@ -9095,7 +9131,7 @@ class MockNotificationService extends _i1.Mock
       );
 
   @override
-  _i14.Future<String?> downloadAvatarToTemp(
+  _i15.Future<String?> downloadAvatarToTemp(
     _i4.Client? client,
     Uri? avatarUrl,
     String? userId,
@@ -9109,9 +9145,9 @@ class MockNotificationService extends _i1.Mock
             userId,
           ],
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
   void navigateToRoom(String? roomId) => super.noSuchMethod(
@@ -9123,7 +9159,7 @@ class MockNotificationService extends _i1.Mock
       );
 
   @override
-  _i14.Future<void> showPushNotification({
+  _i15.Future<void> showPushNotification({
     required String? roomId,
     required String? title,
     required String? body,
@@ -9140,29 +9176,29 @@ class MockNotificationService extends _i1.Mock
             #senderName: senderName,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> cancelForRoom(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> cancelForRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #cancelForRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> cancelAll() => (super.noSuchMethod(
+  _i15.Future<void> cancelAll() => (super.noSuchMethod(
         Invocation.method(
           #cancelAll,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -9181,11 +9217,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -9215,11 +9251,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_78(
+        returnValue: _FakeRoomSummary_79(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_78(
+        returnValueForMissingStub: _FakeRoomSummary_79(
           this,
           Invocation.getter(#summary),
         ),
@@ -9249,11 +9285,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i14.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i15.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i14.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i14.Completer<dynamic>>[],
-      ) as List<_i14.Completer<dynamic>>);
+        returnValue: <_i15.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i15.Completer<dynamic>>[],
+      ) as List<_i15.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -9272,51 +9308,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i12.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i13.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_16<String>(
+        returnValue: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i12.CachedStreamController<String> get onSessionKeyReceived =>
+  _i13.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_16<String>(
+        returnValue: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -9332,11 +9368,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -9345,11 +9381,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -9392,11 +9428,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -9405,11 +9441,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_17(
+        returnValue: _FakeDateTime_18(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_17(
+        returnValueForMissingStub: _FakeDateTime_18(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -9439,11 +9475,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_79(
+        returnValue: _FakeLatestReceiptState_80(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_79(
+        returnValueForMissingStub: _FakeLatestReceiptState_80(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -9464,18 +9500,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i14.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i15.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -9662,18 +9698,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i33.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i34.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i33.SpaceParent>[],
-        returnValueForMissingStub: <_i33.SpaceParent>[],
-      ) as List<_i33.SpaceParent>);
+        returnValue: <_i34.SpaceParent>[],
+        returnValueForMissingStub: <_i34.SpaceParent>[],
+      ) as List<_i34.SpaceParent>);
 
   @override
-  List<_i33.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i34.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i33.SpaceChild>[],
-        returnValueForMissingStub: <_i33.SpaceChild>[],
-      ) as List<_i33.SpaceChild>);
+        returnValue: <_i34.SpaceChild>[],
+        returnValueForMissingStub: <_i34.SpaceChild>[],
+      ) as List<_i34.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -9786,14 +9822,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i14.Future<void> postLoad() => (super.noSuchMethod(
+  _i15.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -9821,15 +9857,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i14.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i15.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i14.Future<List<_i4.User>>);
+            _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i15.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -9840,14 +9876,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i19.dummyValue<String>(
+        returnValue: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i19.dummyValue<String>(
+        returnValueForMissingStub: _i20.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9857,18 +9893,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i14.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i15.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Event?> refreshLastEvent(
+  _i15.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9876,9 +9912,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -9890,12 +9926,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i14.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i15.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9903,22 +9939,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i19.dummyValue<String>(
+            _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i15.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9926,17 +9962,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i19.dummyValue<String>(
+            _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> addTag(
+  _i15.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -9946,27 +9982,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i15.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i15.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -9974,53 +10010,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i15.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i15.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+  _i15.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
         Invocation.method(
           #setLowPriority,
           [lowPriority],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i15.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -10028,14 +10064,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i19.dummyValue<String>(
+            _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -10047,7 +10083,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i14.Future<String?> sendTextEvent(
+  _i15.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -10079,12 +10115,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendReaction(
+  _i15.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -10098,12 +10134,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendLocation(
+  _i15.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -10117,12 +10153,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendFileEvent(
+  _i15.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -10150,25 +10186,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i15.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i14.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i15.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i14.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i15.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i14.Future<_i4.EncryptionHealthState>);
+      ) as _i15.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i14.Future<String?> sendEvent(
+  _i15.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -10192,73 +10228,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i15.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> leave() => (super.noSuchMethod(
+  _i15.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> forget() => (super.noSuchMethod(
+  _i15.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> setPower(
+  _i15.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -10270,7 +10306,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -10281,7 +10317,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i19.dummyValue<String>(
+            _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -10291,10 +10327,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> invite(
+  _i15.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -10304,12 +10340,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<int> requestHistory({
+  _i15.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -10326,32 +10362,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<int>.value(0),
-        returnValueForMissingStub: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+        returnValueForMissingStub: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
-  _i14.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i15.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setReadMarker(
+  _i15.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -10365,23 +10401,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i18.TimelineChunk?> getEventContext(String? eventId) =>
+  _i15.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i14.Future<_i18.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i14.Future<_i18.TimelineChunk?>.value(),
-      ) as _i14.Future<_i18.TimelineChunk?>);
+        returnValue: _i15.Future<_i19.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i15.Future<_i19.TimelineChunk?>.value(),
+      ) as _i15.Future<_i19.TimelineChunk?>);
 
   @override
-  _i14.Future<void> postReceipt(
+  _i15.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -10391,12 +10427,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Timeline> getTimeline({
+  _i15.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -10419,7 +10455,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i14.Future<_i4.Timeline>.value(_FakeTimeline_80(
+        returnValue: _i15.Future<_i4.Timeline>.value(_FakeTimeline_81(
           this,
           Invocation.method(
             #getTimeline,
@@ -10436,7 +10472,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Timeline>.value(_FakeTimeline_80(
+            _i15.Future<_i4.Timeline>.value(_FakeTimeline_81(
           this,
           Invocation.method(
             #getTimeline,
@@ -10452,7 +10488,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Timeline>);
+      ) as _i15.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -10471,7 +10507,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i14.Future<List<_i4.User>> requestParticipants([
+  _i15.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -10489,10 +10525,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i14.Future<List<_i4.User>>);
+            _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i15.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -10500,14 +10536,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_81(
+        returnValue: _FakeUser_82(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_81(
+        returnValueForMissingStub: _FakeUser_82(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -10523,14 +10559,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_81(
+        returnValue: _FakeUser_82(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_81(
+        returnValueForMissingStub: _FakeUser_82(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -10540,7 +10576,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i14.Future<_i4.User?> requestUser(
+  _i15.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -10556,19 +10592,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i14.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.User?>.value(),
-      ) as _i14.Future<_i4.User?>);
+        returnValue: _i15.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.User?>.value(),
+      ) as _i15.Future<_i4.User?>);
 
   @override
-  _i14.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i15.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -10581,12 +10617,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i14.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i15.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i14.Future<String>.value(_i19.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10594,14 +10630,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i19.dummyValue<String>(
+            _i15.Future<String>.value(_i20.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -10624,14 +10660,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i14.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i15.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -10670,18 +10706,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i14.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i15.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEvent(
+  _i15.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -10695,12 +10731,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> setTyping(
+  _i15.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -10710,12 +10746,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setJoinRules(
+  _i15.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -10729,59 +10765,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i15.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setHistoryVisibility(
+  _i15.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i15.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i15.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i15.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i14.Future<List<_i4.DeviceKeys>>);
+            _i15.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i15.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i14.Future<void> requestSessionKey(
+  _i15.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -10793,12 +10829,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setSpaceChild(
+  _i15.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -10814,44 +10850,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i15.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i14.Future<Uri>.value(_FakeUri_30(
+        returnValue: _i15.Future<Uri>.value(_FakeUri_31(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_30(
+        returnValueForMissingStub: _i15.Future<Uri>.value(_FakeUri_31(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i14.Future<Uri>);
+      ) as _i15.Future<Uri>);
 
   @override
-  _i14.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<
+  _i15.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -10878,21 +10914,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i14.Future<
+        returnValue: _i15.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i14.Future<
+        returnValueForMissingStub: _i15.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i14.Future<
+      ) as _i15.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -10907,11 +10943,11 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
   @override
   _i4.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_82(
+        returnValue: _FakeRoom_83(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_82(
+        returnValueForMissingStub: _FakeRoom_83(
           this,
           Invocation.getter(#room),
         ),
@@ -10961,17 +10997,17 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       ) as bool);
 
   @override
-  _i18.TimelineChunk get chunk => (super.noSuchMethod(
+  _i19.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_83(
+        returnValue: _FakeTimelineChunk_84(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_83(
+        returnValueForMissingStub: _FakeTimelineChunk_84(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i18.TimelineChunk);
+      ) as _i19.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10988,7 +11024,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       ) as bool);
 
   @override
-  set timelineSub(_i14.StreamSubscription<_i4.Event>? value) =>
+  set timelineSub(_i15.StreamSubscription<_i4.Event>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #timelineSub,
@@ -10998,7 +11034,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  set historySub(_i14.StreamSubscription<_i4.Event>? value) =>
+  set historySub(_i15.StreamSubscription<_i4.Event>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #historySub,
@@ -11008,7 +11044,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  set roomSub(_i14.StreamSubscription<_i4.SyncUpdate>? value) =>
+  set roomSub(_i15.StreamSubscription<_i4.SyncUpdate>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #roomSub,
@@ -11018,7 +11054,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  set sessionIdReceivedSub(_i14.StreamSubscription<String>? value) =>
+  set sessionIdReceivedSub(_i15.StreamSubscription<String>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #sessionIdReceivedSub,
@@ -11028,7 +11064,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  set cancelSendEventSub(_i14.StreamSubscription<String>? value) =>
+  set cancelSendEventSub(_i15.StreamSubscription<String>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #cancelSendEventSub,
@@ -11074,7 +11110,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  set chunk(_i18.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i19.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,
@@ -11083,17 +11119,17 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  _i14.Future<_i4.Event?> getEventById(String? id) => (super.noSuchMethod(
+  _i15.Future<_i4.Event?> getEventById(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [id],
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
-  _i14.Future<void> requestHistory({
+  _i15.Future<void> requestHistory({
     int? historyCount = 30,
     _i4.StateFilter? filter,
   }) =>
@@ -11106,12 +11142,12 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> requestFuture({
+  _i15.Future<void> requestFuture({
     int? historyCount = 30,
     _i4.StateFilter? filter,
   }) =>
@@ -11124,12 +11160,12 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<int> getRoomEvents({
+  _i15.Future<int> getRoomEvents({
     int? historyCount = 30,
     dynamic direction = _i4.Direction.b,
     _i4.StateFilter? filter,
@@ -11144,9 +11180,9 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<int>.value(0),
-        returnValueForMissingStub: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+        returnValueForMissingStub: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
   void cancelSubscriptions() => super.noSuchMethod(
@@ -11175,7 +11211,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  _i14.Future<void> setReadMarker({
+  _i15.Future<void> setReadMarker({
     String? eventId,
     bool? public,
   }) =>
@@ -11188,9 +11224,9 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #public: public,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void addAggregatedEvent(_i4.Event? event) => super.noSuchMethod(
@@ -11211,7 +11247,7 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
       );
 
   @override
-  _i14.Stream<List<_i4.Event>> searchEvent({
+  _i15.Stream<List<_i4.Event>> searchEvent({
     String? searchTerm,
     int? requestHistoryCount = 100,
     int? maxHistoryRequests = 10,
@@ -11232,12 +11268,12 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #searchFunc: searchFunc,
           },
         ),
-        returnValue: _i14.Stream<List<_i4.Event>>.empty(),
-        returnValueForMissingStub: _i14.Stream<List<_i4.Event>>.empty(),
-      ) as _i14.Stream<List<_i4.Event>>);
+        returnValue: _i15.Stream<List<_i4.Event>>.empty(),
+        returnValueForMissingStub: _i15.Stream<List<_i4.Event>>.empty(),
+      ) as _i15.Stream<List<_i4.Event>>);
 
   @override
-  _i14.Stream<(List<_i4.Event>, String?)> startSearch({
+  _i15.Stream<(List<_i4.Event>, String?)> startSearch({
     String? searchTerm,
     int? requestHistoryCount = 100,
     int? maxHistoryRequests = 10,
@@ -11260,8 +11296,8 @@ class MockTimeline extends _i1.Mock implements _i4.Timeline {
             #searchFunc: searchFunc,
           },
         ),
-        returnValue: _i14.Stream<(List<_i4.Event>, String?)>.empty(),
+        returnValue: _i15.Stream<(List<_i4.Event>, String?)>.empty(),
         returnValueForMissingStub:
-            _i14.Stream<(List<_i4.Event>, String?)>.empty(),
-      ) as _i14.Stream<(List<_i4.Event>, String?)>);
+            _i15.Stream<(List<_i4.Event>, String?)>.empty(),
+      ) as _i15.Stream<(List<_i4.Event>, String?)>);
 }

--- a/test/services/notification_service_test.mocks.dart
+++ b/test/services/notification_service_test.mocks.dart
@@ -3,25 +3,26 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i14;
-import 'dart:typed_data' as _i22;
-import 'dart:ui' as _i18;
+import 'dart:async' as _i15;
+import 'dart:typed_data' as _i23;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
 import 'package:flutter_local_notifications/src/flutter_local_notifications_plugin.dart'
-    as _i25;
-import 'package:flutter_local_notifications/src/initialization_settings.dart'
     as _i26;
-import 'package:flutter_local_notifications/src/notification_details.dart'
-    as _i28;
-import 'package:flutter_local_notifications/src/platform_specifics/android/schedule_mode.dart'
-    as _i30;
-import 'package:flutter_local_notifications/src/types.dart' as _i31;
-import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart'
+import 'package:flutter_local_notifications/src/initialization_settings.dart'
     as _i27;
-import 'package:http/http.dart' as _i13;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
+import 'package:flutter_local_notifications/src/notification_details.dart'
+    as _i29;
+import 'package:flutter_local_notifications/src/platform_specifics/android/schedule_mode.dart'
+    as _i31;
+import 'package:flutter_local_notifications/src/types.dart' as _i32;
+import 'package:flutter_local_notifications_platform_interface/flutter_local_notifications_platform_interface.dart'
+    as _i28;
+import 'package:http/http.dart' as _i14;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i12;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -36,15 +37,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i21;
+import 'package:matrix/encryption.dart' as _i22;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i15;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i12;
-import 'package:matrix/src/utils/space_child.dart' as _i23;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i16;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i25;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i13;
+import 'package:matrix/src/utils/space_child.dart' as _i24;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
-import 'package:timezone/timezone.dart' as _i29;
+import 'package:mockito/src/dummies.dart' as _i18;
+import 'package:timezone/timezone.dart' as _i30;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -166,8 +167,9 @@ class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
         );
 }
 
-class _FakeDatabaseApi_10 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_10(
+class _FakeStickerPackService_10 extends _i1.SmartFake
+    implements _i12.StickerPackService {
+  _FakeStickerPackService_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -176,8 +178,8 @@ class _FakeDatabaseApi_10 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_11 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_11(
+class _FakeDatabaseApi_11 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -186,9 +188,19 @@ class _FakeFilter_11 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_12 extends _i1.SmartFake
+class _FakeFilter_12 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_12(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeNativeImplementations_13 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_12(
+  _FakeNativeImplementations_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -197,8 +209,8 @@ class _FakeNativeImplementations_12 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_13 extends _i1.SmartFake implements Duration {
-  _FakeDuration_13(
+class _FakeDuration_14 extends _i1.SmartFake implements Duration {
+  _FakeDuration_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -207,9 +219,9 @@ class _FakeDuration_13 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_14 extends _i1.SmartFake
+class _FakePushruleEvaluator_15 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_14(
+  _FakePushruleEvaluator_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -218,8 +230,8 @@ class _FakePushruleEvaluator_14 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_15 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_15(
+class _FakeProfile_16 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -228,9 +240,9 @@ class _FakeProfile_15 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeCachedStreamController_16<T> extends _i1.SmartFake
-    implements _i12.CachedStreamController<T> {
-  _FakeCachedStreamController_16(
+class _FakeCachedStreamController_17<T> extends _i1.SmartFake
+    implements _i13.CachedStreamController<T> {
+  _FakeCachedStreamController_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -239,8 +251,8 @@ class _FakeCachedStreamController_16<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_17 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_17(
+class _FakeDateTime_18 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -249,8 +261,8 @@ class _FakeDateTime_17 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_18 extends _i1.SmartFake implements _i13.Client {
-  _FakeClient_18(
+class _FakeClient_19 extends _i1.SmartFake implements _i14.Client {
+  _FakeClient_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -259,9 +271,9 @@ class _FakeClient_18 extends _i1.SmartFake implements _i13.Client {
         );
 }
 
-class _FakeDiscoveryInformation_19 extends _i1.SmartFake
+class _FakeDiscoveryInformation_20 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_19(
+  _FakeDiscoveryInformation_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -270,9 +282,9 @@ class _FakeDiscoveryInformation_19 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_20 extends _i1.SmartFake
+class _FakeGetVersionsResponse_21 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_20(
+  _FakeGetVersionsResponse_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -281,9 +293,9 @@ class _FakeGetVersionsResponse_20 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_21 extends _i1.SmartFake
+class _FakeRegisterResponse_22 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_21(
+  _FakeRegisterResponse_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -292,8 +304,8 @@ class _FakeRegisterResponse_21 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_22 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_22(
+class _FakeLoginResponse_23 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -302,9 +314,9 @@ class _FakeLoginResponse_22 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_23 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_24 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_23(
+  _FakeGetAuthMetadataResponse_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -313,8 +325,8 @@ class _FakeGetAuthMetadataResponse_23 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_24<T1> extends _i1.SmartFake implements _i14.Future<T1> {
-  _FakeFuture_24(
+class _FakeFuture_25<T1> extends _i1.SmartFake implements _i15.Future<T1> {
+  _FakeFuture_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -323,8 +335,8 @@ class _FakeFuture_24<T1> extends _i1.SmartFake implements _i14.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_25 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_25(
+class _FakeSyncUpdate_26 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -333,9 +345,9 @@ class _FakeSyncUpdate_25 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_26 extends _i1.SmartFake
+class _FakeCachedProfileInformation_27 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_26(
+  _FakeCachedProfileInformation_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -344,8 +356,8 @@ class _FakeCachedProfileInformation_26 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_27 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_27(
+class _FakeMediaConfig_28 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -354,8 +366,8 @@ class _FakeMediaConfig_27 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_28 extends _i1.SmartFake implements _i15.FileResponse {
-  _FakeFileResponse_28(
+class _FakeFileResponse_29 extends _i1.SmartFake implements _i16.FileResponse {
+  _FakeFileResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -364,8 +376,8 @@ class _FakeFileResponse_28 extends _i1.SmartFake implements _i15.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_29 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_29(
+class _FakePreviewForUrl_30 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -374,8 +386,8 @@ class _FakePreviewForUrl_29 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeUri_30 extends _i1.SmartFake implements Uri {
-  _FakeUri_30(
+class _FakeUri_31 extends _i1.SmartFake implements Uri {
+  _FakeUri_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -384,9 +396,9 @@ class _FakeUri_30 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_31 extends _i1.SmartFake
+class _FakeCachedPresence_32 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_31(
+  _FakeCachedPresence_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -395,9 +407,9 @@ class _FakeCachedPresence_31 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_32 extends _i1.SmartFake
+class _FakeTurnServerCredentials_33 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_32(
+  _FakeTurnServerCredentials_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -406,9 +418,9 @@ class _FakeTurnServerCredentials_32 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_33 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_34 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_33(
+  _FakeRoomKeysUpdateResponse_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -417,8 +429,8 @@ class _FakeRoomKeysUpdateResponse_33 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_34 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_34(
+class _FakeKeyBackupData_35 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -427,9 +439,9 @@ class _FakeKeyBackupData_34 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_35 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_36 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_35(
+  _FakeGetWellknownSupportResponse_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -438,9 +450,9 @@ class _FakeGetWellknownSupportResponse_35 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_36 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_37 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_36(
+  _FakeGenerateLoginTokenResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -449,9 +461,9 @@ class _FakeGenerateLoginTokenResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_37 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_38 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_37(
+  _FakeGetRoomSummaryResponse$3_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -460,9 +472,9 @@ class _FakeGetRoomSummaryResponse$3_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_38 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_39 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_38(
+  _FakeGetSpaceHierarchyResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -471,9 +483,9 @@ class _FakeGetSpaceHierarchyResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_39 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_40 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_39(
+  _FakeGetRelatingEventsResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -482,9 +494,9 @@ class _FakeGetRelatingEventsResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_40 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_41 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_40(
+  _FakeGetRelatingEventsWithRelTypeResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -493,9 +505,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -504,9 +516,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_42 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_43 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_42(
+  _FakeGetThreadRootsResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -515,9 +527,9 @@ class _FakeGetThreadRootsResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_43 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_44 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_43(
+  _FakeGetEventByTimestampResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -526,9 +538,9 @@ class _FakeGetEventByTimestampResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_44 extends _i1.SmartFake
+class _FakeRequestTokenResponse_45 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_44(
+  _FakeRequestTokenResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -537,9 +549,9 @@ class _FakeRequestTokenResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_45 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_46 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_45(
+  _FakeTokenOwnerInfo_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -548,8 +560,8 @@ class _FakeTokenOwnerInfo_45 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_46 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_46(
+class _FakeWhoIsInfo_47 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -558,8 +570,8 @@ class _FakeWhoIsInfo_46 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_47 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_47(
+class _FakeCapabilities_48 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -568,8 +580,8 @@ class _FakeCapabilities_47 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_48 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_48(
+class _FakeDevice_49 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -578,9 +590,9 @@ class _FakeDevice_48 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_49 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_50 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_49(
+  _FakeGetRoomIdByAliasResponse_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -589,9 +601,9 @@ class _FakeGetRoomIdByAliasResponse_49 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_50 extends _i1.SmartFake
+class _FakeGetEventsResponse_51 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_50(
+  _FakeGetEventsResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -600,9 +612,9 @@ class _FakeGetEventsResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_51 extends _i1.SmartFake
+class _FakePeekEventsResponse_52 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_51(
+  _FakePeekEventsResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -611,8 +623,8 @@ class _FakePeekEventsResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_52 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_52(
+class _FakeMatrixEvent_53 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -621,9 +633,9 @@ class _FakeMatrixEvent_52 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_53 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_54 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_53(
+  _FakeGetKeysChangesResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -632,9 +644,9 @@ class _FakeGetKeysChangesResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_54 extends _i1.SmartFake
+class _FakeClaimKeysResponse_55 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_54(
+  _FakeClaimKeysResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -643,9 +655,9 @@ class _FakeClaimKeysResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_55 extends _i1.SmartFake
+class _FakeQueryKeysResponse_56 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_55(
+  _FakeQueryKeysResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -654,9 +666,9 @@ class _FakeQueryKeysResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_56 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_57 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_56(
+  _FakeGetNotificationsResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -665,9 +677,9 @@ class _FakeGetNotificationsResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_57 extends _i1.SmartFake
+class _FakeGetPresenceResponse_58 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_57(
+  _FakeGetPresenceResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -676,9 +688,9 @@ class _FakeGetPresenceResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_58 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_59 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_58(
+  _FakeGetPublicRoomsResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -687,9 +699,9 @@ class _FakeGetPublicRoomsResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_59 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_60 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_59(
+  _FakeQueryPublicRoomsResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -698,8 +710,8 @@ class _FakeQueryPublicRoomsResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_60 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_60(
+class _FakePushRuleSet_61 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -708,9 +720,9 @@ class _FakePushRuleSet_60 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_61 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_62 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_61(
+  _FakeGetPushRulesGlobalResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -719,8 +731,8 @@ class _FakeGetPushRulesGlobalResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_62 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_62(
+class _FakePushRule_63 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -729,9 +741,9 @@ class _FakePushRule_62 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_63 extends _i1.SmartFake
+class _FakeRefreshResponse_64 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_63(
+  _FakeRefreshResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -740,8 +752,8 @@ class _FakeRefreshResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_64 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_64(
+class _FakeRoomKeys_65 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -750,8 +762,8 @@ class _FakeRoomKeys_64 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_65 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_65(
+class _FakeRoomKeyBackup_66 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -760,9 +772,9 @@ class _FakeRoomKeyBackup_65 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_66 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_67 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_66(
+  _FakeGetRoomKeysVersionCurrentResponse_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -771,9 +783,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_66 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_67 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_68 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_67(
+  _FakeGetRoomKeysVersionResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -782,8 +794,8 @@ class _FakeGetRoomKeysVersionResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_68 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_68(
+class _FakeEventContext_69 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -792,9 +804,9 @@ class _FakeEventContext_68 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_69 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_70 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_69(
+  _FakeGetRoomEventsResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -803,8 +815,8 @@ class _FakeGetRoomEventsResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_70 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_70(
+class _FakeSearchResults_71 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -813,9 +825,9 @@ class _FakeSearchResults_70 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_71 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_72 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_71(
+  _FakeGetProtocolMetadataResponse$2_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -824,9 +836,9 @@ class _FakeGetProtocolMetadataResponse$2_71 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_72 extends _i1.SmartFake
+class _FakeOpenIdCredentials_73 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_72(
+  _FakeOpenIdCredentials_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -835,9 +847,9 @@ class _FakeOpenIdCredentials_72 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_73 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_74 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_73(
+  _FakeSearchUserDirectoryResponse_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -846,9 +858,9 @@ class _FakeSearchUserDirectoryResponse_73 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_74 extends _i1.SmartFake
+class _FakeCreateContentResponse_75 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_74(
+  _FakeCreateContentResponse_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -857,8 +869,8 @@ class _FakeCreateContentResponse_74 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_75 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_75(
+class _FakeRoomSummary_76 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,9 +879,9 @@ class _FakeRoomSummary_75 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_76 extends _i1.SmartFake
+class _FakeLatestReceiptState_77 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_76(
+  _FakeLatestReceiptState_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -878,8 +890,8 @@ class _FakeLatestReceiptState_76 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_77 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_77(
+class _FakeTimeline_78 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -888,8 +900,8 @@ class _FakeTimeline_77 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_78 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_78(
+class _FakeUser_79 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -901,7 +913,7 @@ class _FakeUser_78 extends _i1.SmartFake implements _i4.User {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -931,11 +943,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1060,6 +1072,19 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i11.OutboxService);
 
   @override
+  _i12.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i12.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -1157,6 +1182,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set stickerPacks(_i12.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -1164,14 +1198,14 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i15.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1201,7 +1235,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1211,21 +1245,22 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i15.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> login({
+  _i15.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1235,14 +1270,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> completeSsoLogin({
+  _i15.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1255,12 +1291,12 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> completeRegistration(
+  _i15.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1270,32 +1306,32 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i15.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1304,7 +1340,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1313,17 +1349,17 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i15.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1334,7 +1370,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1371,26 +1407,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i15.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+  _i15.Future<bool> didPushRouteInformation(
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1420,7 +1456,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1429,7 +1465,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1438,16 +1474,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i15.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i15.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i14.Future<_i18.AppExitResponse>);
+            _i15.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i15.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1475,23 +1511,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_10(
+        returnValue: _FakeDatabaseApi_11(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_10(
+        returnValueForMissingStub: _FakeDatabaseApi_11(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i21.KeyVerificationMethod> get verificationMethods =>
+  Set<_i22.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i21.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i21.KeyVerificationMethod>{},
-      ) as Set<_i21.KeyVerificationMethod>);
+        returnValue: <_i22.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i22.KeyVerificationMethod>{},
+      ) as Set<_i22.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1552,11 +1588,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_11(
+        returnValue: _FakeFilter_12(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_11(
+        returnValueForMissingStub: _FakeFilter_12(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -1565,11 +1601,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_12(
+        returnValue: _FakeNativeImplementations_13(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_12(
+        returnValueForMissingStub: _FakeNativeImplementations_13(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -1585,11 +1621,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_13(
+        returnValue: _FakeDuration_14(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_13(
+        returnValueForMissingStub: _FakeDuration_14(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -1598,11 +1634,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_13(
+        returnValue: _FakeDuration_14(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_13(
+        returnValueForMissingStub: _FakeDuration_14(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -1611,11 +1647,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1652,11 +1688,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1686,11 +1722,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1699,11 +1735,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1726,11 +1762,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_14(
+        returnValue: _FakePushruleEvaluator_15(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_14(
+        returnValueForMissingStub: _FakePushruleEvaluator_15(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -1751,332 +1787,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i14.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i15.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i12.CachedStreamController<String> get onUserProfileUpdate =>
+  _i13.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_16<String>(
+        returnValue: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i14.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i15.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i14.Future<List<_i4.Room>>);
+            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i15.Future<List<_i4.Room>>);
 
   @override
-  _i12.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i13.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_16<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_17<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.EventUpdate>(
+            _FakeCachedStreamController_17<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.EventUpdate>);
+      ) as _i13.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i13.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_16<_i4.Event>(
+        returnValue: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i13.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_16<_i4.Event>(
+        returnValue: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onNotification =>
+  _i13.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_16<_i4.Event>(
+        returnValue: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i13.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_16<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_17<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_17<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i13.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i12.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i13.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_16<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_17<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_16<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_17<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i12.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i13.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i12.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i13.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_16<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_17<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.LoginState>(
+            _FakeCachedStreamController_17<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i12.CachedStreamController<_i4.LoginState>);
+      ) as _i13.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i12.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i13.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_16<bool>(
+        returnValue: _FakeCachedStreamController_17<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i12.CachedStreamController<bool>);
+      ) as _i13.CachedStreamController<bool>);
 
   @override
-  _i12.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i13.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_16<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_17<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i12.CachedStreamController<_i4.SdkError>);
+      ) as _i13.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i12.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i13.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_16<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_17<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.SyncUpdate>(
+            _FakeCachedStreamController_17<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i12.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i13.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i13.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_16<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_17<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_17<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i12.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i13.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.Presence> get onPresence =>
+  _i13.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_16<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_17<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i12.CachedStreamController<_i4.Presence>);
+      ) as _i13.CachedStreamController<_i4.Presence>);
 
   @override
-  _i12.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i13.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_16<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_17<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.CachedPresence>(
+            _FakeCachedStreamController_17<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i12.CachedStreamController<_i4.CachedPresence>);
+      ) as _i13.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i12.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i13.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_16<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_17<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.BasicEvent>(
+            _FakeCachedStreamController_17<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i12.CachedStreamController<_i4.BasicEvent>);
+      ) as _i13.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i12.CachedStreamController<_i21.RoomKeyRequest> get onRoomKeyRequest =>
+  _i13.CachedStreamController<_i22.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_16<_i21.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_17<_i22.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i21.RoomKeyRequest>(
+            _FakeCachedStreamController_17<_i22.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i12.CachedStreamController<_i21.RoomKeyRequest>);
+      ) as _i13.CachedStreamController<_i22.RoomKeyRequest>);
 
   @override
-  _i12.CachedStreamController<_i21.KeyVerification>
+  _i13.CachedStreamController<_i22.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_16<_i21.KeyVerification>(
+            returnValue: _FakeCachedStreamController_17<_i22.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_16<_i21.KeyVerification>(
+                _FakeCachedStreamController_17<_i22.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i12.CachedStreamController<_i21.KeyVerification>);
+          ) as _i13.CachedStreamController<_i22.KeyVerification>);
 
   @override
-  _i12.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i13.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_16<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_17<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_16<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_17<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i12.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i13.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i13.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_16<_i4.Event>(
+        returnValue: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<String> get onCancelSendEvent =>
+  _i13.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_16<String>(
+        returnValue: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i12.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i13.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_16<
+            returnValue: _FakeCachedStreamController_17<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_16<
+            returnValueForMissingStub: _FakeCachedStreamController_17<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i12.CachedStreamController<
+          ) as _i13.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -2096,11 +2132,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_17(
+        returnValue: _FakeDateTime_18(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_17(
+        returnValueForMissingStub: _FakeDateTime_18(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2173,7 +2209,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i21.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i22.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2228,7 +2264,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i14.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i15.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2239,7 +2275,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i14.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i15.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -2350,7 +2386,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -2359,7 +2395,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -2368,7 +2404,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -2395,20 +2431,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Client get httpClient => (super.noSuchMethod(
+  _i14.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_18(
+        returnValue: _FakeClient_19(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_18(
+        returnValueForMissingStub: _FakeClient_19(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i13.Client);
+      ) as _i14.Client);
 
   @override
-  set httpClient(_i13.Client? value) => super.noSuchMethod(
+  set httpClient(_i14.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -2435,7 +2471,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<void> refreshAccessToken(
+  _i15.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2443,9 +2479,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -2463,14 +2499,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2507,33 +2543,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i14.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i15.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_19(
+        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_20(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_19(
+        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_20(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i14.Future<_i4.DiscoveryInformation>);
+      ) as _i15.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i14.Future<
+  _i15.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -2555,7 +2591,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i14.Future<
+        returnValue: _i15.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2563,7 +2599,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_20(
+          _FakeGetVersionsResponse_21(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2578,7 +2614,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i14.Future<
+        returnValueForMissingStub: _i15.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2586,7 +2622,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_20(
+          _FakeGetVersionsResponse_21(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2601,7 +2637,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i14.Future<
+      ) as _i15.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -2610,7 +2646,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i14.Future<_i4.DiscoveryInformation> getWellknown({
+  _i15.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2623,8 +2659,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_19(
+        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_20(
           this,
           Invocation.method(
             #getWellknown,
@@ -2635,8 +2671,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_19(
+        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_20(
           this,
           Invocation.method(
             #getWellknown,
@@ -2647,10 +2683,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.DiscoveryInformation>);
+      ) as _i15.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i14.Future<_i4.RegisterResponse> register({
+  _i15.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -2678,7 +2714,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_21(
+            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_22(
           this,
           Invocation.method(
             #register,
@@ -2697,7 +2733,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_21(
+            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_22(
           this,
           Invocation.method(
             #register,
@@ -2715,10 +2751,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RegisterResponse>);
+      ) as _i15.Future<_i4.RegisterResponse>);
 
   @override
-  _i14.Future<_i4.LoginResponse> login(
+  _i15.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -2748,7 +2784,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_22(
+        returnValue: _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_23(
           this,
           Invocation.method(
             #login,
@@ -2768,7 +2804,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_22(
+            _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_23(
           this,
           Invocation.method(
             #login,
@@ -2787,10 +2823,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.LoginResponse>);
+      ) as _i15.Future<_i4.LoginResponse>);
 
   @override
-  _i14.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i15.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2803,8 +2839,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_23(
+        returnValue: _i15.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_24(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2816,8 +2852,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_23(
+            _i15.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_24(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2828,74 +2864,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i15.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logoutAll() => (super.noSuchMethod(
+  _i15.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<T> uiaRequestBackground<T>(
-          _i14.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i15.Future<T> uiaRequestBackground<T>(
+          _i15.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i14.Future<T>.value(v),
+              (T v) => _i15.Future<T>.value(v),
             ) ??
-            _FakeFuture_24<T>(
+            _FakeFuture_25<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i14.Future<T>.value(v),
+              (T v) => _i15.Future<T>.value(v),
             ) ??
-            _FakeFuture_24<T>(
+            _FakeFuture_25<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i14.Future<T>);
+      ) as _i15.Future<T>);
 
   @override
-  _i14.Future<String> startDirectChat(
+  _i15.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -2917,7 +2953,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2933,7 +2969,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2948,10 +2984,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> createGroupChat({
+  _i15.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -2982,7 +3018,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3003,7 +3039,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3023,10 +3059,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i15.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -3042,7 +3078,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3055,7 +3091,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3067,21 +3103,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i15.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<String> createSpace({
+  _i15.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -3106,7 +3142,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3124,7 +3160,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3141,10 +3177,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i15.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3152,7 +3188,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3161,7 +3197,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3169,10 +3205,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i14.Future<_i4.Profile> fetchOwnProfile({
+  _i15.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3185,7 +3221,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3197,7 +3233,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3208,10 +3244,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i14.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i15.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3225,8 +3261,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i14.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_26(
+        returnValue: _i15.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_27(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3238,8 +3274,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_26(
+            _i15.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_27(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3250,10 +3286,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.CachedProfileInformation>);
+      ) as _i15.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i14.Future<_i4.Profile> getProfileFromUserId(
+  _i15.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3271,7 +3307,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3285,7 +3321,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_15(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_16(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3298,7 +3334,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -3320,31 +3356,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i14.Future<List<_i4.Room>>);
+            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i15.Future<List<_i4.Room>>);
 
   @override
-  _i14.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i15.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i14.Future<List<_i4.ArchivedRoom>>);
+            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i15.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i14.Future<_i4.GetVersionsResponse> getVersions({
+  _i15.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3357,8 +3393,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_20(
+        returnValue: _i15.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_21(
           this,
           Invocation.method(
             #getVersions,
@@ -3369,8 +3405,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_20(
+        returnValueForMissingStub: _i15.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_21(
           this,
           Invocation.method(
             #getVersions,
@@ -3381,20 +3417,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetVersionsResponse>);
+      ) as _i15.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i14.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i15.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.MediaConfig> getConfig({
+  _i15.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3407,7 +3443,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
+        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
           this,
           Invocation.method(
             #getConfig,
@@ -3419,7 +3455,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
+            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
           this,
           Invocation.method(
             #getConfig,
@@ -3430,10 +3466,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.MediaConfig>);
+      ) as _i15.Future<_i4.MediaConfig>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContent(
+  _i15.Future<_i16.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -3453,7 +3489,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContent,
@@ -3469,7 +3505,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContent,
@@ -3484,10 +3520,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentOverrideName(
+  _i15.Future<_i16.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -3509,7 +3545,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3526,7 +3562,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3542,10 +3578,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentThumbnail(
+  _i15.Future<_i16.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -3573,7 +3609,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3593,7 +3629,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3612,10 +3648,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i15.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -3625,7 +3661,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
+        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3634,7 +3670,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
+            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3642,11 +3678,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i14.Future<_i4.PreviewForUrl>);
+      ) as _i15.Future<_i4.PreviewForUrl>);
 
   @override
-  _i14.Future<Uri> uploadContent(
-    _i22.Uint8List? file, {
+  _i15.Future<Uri> uploadContent(
+    _i23.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3659,7 +3695,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i14.Future<Uri>.value(_FakeUri_30(
+        returnValue: _i15.Future<Uri>.value(_FakeUri_31(
           this,
           Invocation.method(
             #uploadContent,
@@ -3670,7 +3706,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_30(
+        returnValueForMissingStub: _i15.Future<Uri>.value(_FakeUri_31(
           this,
           Invocation.method(
             #uploadContent,
@@ -3681,10 +3717,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<Uri>);
+      ) as _i15.Future<Uri>);
 
   @override
-  _i14.Future<void> setTyping(
+  _i15.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -3700,42 +3736,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> exportDump() => (super.noSuchMethod(
+  _i15.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i15.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i15.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Event?> getEventByPushNotification(
+  _i15.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -3751,12 +3787,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
-  _i14.Future<void> init({
+  _i15.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -3791,9 +3827,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -3805,40 +3841,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<void> clear() => (super.noSuchMethod(
+  _i15.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i15.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ensureNotSoftLoggedOut(
+  _i15.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSync(
+  _i15.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -3848,9 +3884,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -3863,29 +3899,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i14.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i15.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i15.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDevice(
+  _i15.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -3899,12 +3935,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDevicesOfUserIds(
+  _i15.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -3920,12 +3956,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDeviceEncrypted(
+  _i15.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -3945,12 +3981,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDeviceEncryptedChunked(
+  _i15.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -3964,23 +4000,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i15.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> joinRoom(
+  _i15.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -3998,7 +4034,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4012,7 +4048,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4025,10 +4061,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> changePassword(
+  _i15.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -4044,22 +4080,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> clearCache() => (super.noSuchMethod(
+  _i15.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ignoreUser(
+  _i15.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4069,22 +4105,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i15.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i15.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4095,7 +4131,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_31(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_32(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4104,7 +4140,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_31(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_32(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4112,32 +4148,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i14.Future<_i4.CachedPresence>);
+      ) as _i15.Future<_i4.CachedPresence>);
 
   @override
-  _i14.Future<void> abortSync() => (super.noSuchMethod(
+  _i15.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i15.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEventWithMetadata(
+  _i15.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4157,14 +4193,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i13.BaseResponse? response,
-    _i22.Uint8List? body,
+    _i14.BaseResponse? response,
+    _i23.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4196,7 +4232,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i14.Future<Map<String, Object?>> request(
+  _i15.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -4217,13 +4253,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> postPusher(
+  _i15.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -4233,57 +4269,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i15.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i15.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i15.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i14.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_32(
+        returnValue: _i15.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_33(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_32(
+        returnValueForMissingStub: _i15.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_33(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.TurnServerCredentials>);
+      ) as _i15.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4297,8 +4333,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4310,8 +4346,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4322,10 +4358,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4341,8 +4377,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4355,8 +4391,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4368,10 +4404,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i15.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4385,7 +4421,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
+        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4397,7 +4433,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
+            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4408,17 +4444,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.KeyBackupData>);
+      ) as _i15.Future<_i4.KeyBackupData>);
 
   @override
-  _i14.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i15.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i14.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_35(
+        returnValue: _i15.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_36(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -4426,18 +4462,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_35(
+            _i15.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_36(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i15.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i14.Future<int> pingAppservice(
+  _i15.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -4447,12 +4483,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i14.Future<int>.value(0),
-        returnValueForMissingStub: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+        returnValueForMissingStub: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
-  _i14.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i15.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4460,8 +4496,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_36(
+        returnValue: _i15.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_37(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4470,8 +4506,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_36(
+            _i15.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_37(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4479,15 +4515,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i14.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i15.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i14.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i15.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
+        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -4495,17 +4531,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_27(
+            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.MediaConfig>);
+      ) as _i15.Future<_i4.MediaConfig>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentAuthed(
+  _i15.Future<_i16.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -4519,7 +4555,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4531,7 +4567,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4542,10 +4578,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentOverrideNameAuthed(
+  _i15.Future<_i16.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4561,7 +4597,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4574,7 +4610,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4586,10 +4622,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i15.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -4599,7 +4635,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
+        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4608,7 +4644,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_29(
+            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4616,10 +4652,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i14.Future<_i4.PreviewForUrl>);
+      ) as _i15.Future<_i4.PreviewForUrl>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentThumbnailAuthed(
+  _i15.Future<_i16.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -4643,7 +4679,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4661,7 +4697,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_28(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4678,21 +4714,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<bool> registrationTokenValidity(String? token) =>
+  _i15.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i15.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -4702,8 +4738,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_37(
+        returnValue: _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_38(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4712,8 +4748,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_37(
+            _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_38(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4721,10 +4757,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i15.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i14.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i15.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -4742,8 +4778,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_38(
+        returnValue: _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_39(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4757,8 +4793,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_38(
+            _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_39(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4771,10 +4807,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i15.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i15.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -4798,8 +4834,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i14.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_39(
+        returnValue: _i15.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_40(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4817,8 +4853,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_39(
+            _i15.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_40(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4835,10 +4871,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i15.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -4866,8 +4902,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_40(
+                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_41(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4886,8 +4922,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_40(
+                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_41(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -4905,10 +4941,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i15.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -4937,9 +4973,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i14.Future<
+            returnValue: _i15.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -4958,9 +4994,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i14.Future<
+            returnValueForMissingStub: _i15.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_41(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -4979,11 +5015,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i14
+          ) as _i15
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i14.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i15.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -4999,8 +5035,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i14.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_42(
+        returnValue: _i15.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_43(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5013,8 +5049,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_42(
+            _i15.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_43(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5026,10 +5062,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetThreadRootsResponse>);
+      ) as _i15.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i14.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i15.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -5043,8 +5079,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i14.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_43(
+        returnValue: _i15.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_44(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5056,8 +5092,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_43(
+            _i15.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_44(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5068,33 +5104,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i15.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i15.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i14.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i15.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i14.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i15.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i14.Future<Uri?>.value(),
-        returnValueForMissingStub: _i14.Future<Uri?>.value(),
-      ) as _i14.Future<Uri?>);
+        returnValue: _i15.Future<Uri?>.value(),
+        returnValueForMissingStub: _i15.Future<Uri?>.value(),
+      ) as _i15.Future<Uri?>);
 
   @override
-  _i14.Future<void> add3PID(
+  _i15.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -5108,12 +5144,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> bind3PID(
+  _i15.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5129,12 +5165,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i15.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5148,14 +5184,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5177,8 +5213,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5194,8 +5230,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5211,10 +5247,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5238,8 +5274,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5256,8 +5292,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5274,10 +5310,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i15.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5291,14 +5327,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i15.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -5313,14 +5349,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5342,8 +5378,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5359,8 +5395,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5376,10 +5412,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5403,8 +5439,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5421,8 +5457,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5439,16 +5475,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i15.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_45(
+            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -5456,22 +5492,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_45(
+            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.TokenOwnerInfo>);
+      ) as _i15.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i14.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i15.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_46(
+        returnValue: _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_47(
           this,
           Invocation.method(
             #getWhoIs,
@@ -5479,22 +5515,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_46(
+            _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_47(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i14.Future<_i4.WhoIsInfo>);
+      ) as _i15.Future<_i4.WhoIsInfo>);
 
   @override
-  _i14.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i15.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_47(
+        returnValue: _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_48(
           this,
           Invocation.method(
             #getCapabilities,
@@ -5502,17 +5538,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_47(
+            _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_48(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.Capabilities>);
+      ) as _i15.Future<_i4.Capabilities>);
 
   @override
-  _i14.Future<String> createRoom({
+  _i15.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -5545,7 +5581,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5567,7 +5603,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5588,10 +5624,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> deleteDevices(
+  _i15.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5601,22 +5637,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.Device>?>.value(),
-      ) as _i14.Future<List<_i4.Device>?>);
+        returnValue: _i15.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.Device>?>.value(),
+      ) as _i15.Future<List<_i4.Device>?>);
 
   @override
-  _i14.Future<void> deleteDevice(
+  _i15.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5626,34 +5662,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i15.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i14.Future<_i4.Device>.value(_FakeDevice_48(
+        returnValue: _i15.Future<_i4.Device>.value(_FakeDevice_49(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Device>.value(_FakeDevice_48(
+        returnValueForMissingStub: _i15.Future<_i4.Device>.value(_FakeDevice_49(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i14.Future<_i4.Device>);
+      ) as _i15.Future<_i4.Device>);
 
   @override
-  _i14.Future<void> updateDevice(
+  _i15.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -5663,12 +5699,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i15.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -5683,24 +5719,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i15.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i14.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Visibility?>.value(),
-      ) as _i14.Future<_i4.Visibility?>);
+        returnValue: _i15.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Visibility?>.value(),
+      ) as _i15.Future<_i4.Visibility?>);
 
   @override
-  _i14.Future<void> setRoomVisibilityOnDirectory(
+  _i15.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -5710,30 +5746,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i15.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i15.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_49(
+        returnValue: _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_50(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -5741,18 +5777,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_49(
+            _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_50(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i15.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i14.Future<void> setRoomAlias(
+  _i15.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -5764,12 +5800,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetEventsResponse> getEvents({
+  _i15.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -5783,7 +5819,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_50(
+            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_51(
           this,
           Invocation.method(
             #getEvents,
@@ -5795,7 +5831,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_50(
+            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_51(
           this,
           Invocation.method(
             #getEvents,
@@ -5806,10 +5842,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetEventsResponse>);
+      ) as _i15.Future<_i4.GetEventsResponse>);
 
   @override
-  _i14.Future<_i4.PeekEventsResponse> peekEvents({
+  _i15.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -5824,8 +5860,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i14.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_51(
+        returnValue: _i15.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_52(
           this,
           Invocation.method(
             #peekEvents,
@@ -5837,8 +5873,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_51(
+        returnValueForMissingStub: _i15.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_52(
           this,
           Invocation.method(
             #peekEvents,
@@ -5850,16 +5886,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.PeekEventsResponse>);
+      ) as _i15.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i14.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i15.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
+        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
           this,
           Invocation.method(
             #getOneEvent,
@@ -5867,27 +5903,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
+            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i14.Future<_i4.MatrixEvent>);
+      ) as _i15.Future<_i4.MatrixEvent>);
 
   @override
-  _i14.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i15.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 
   @override
-  _i14.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i15.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -5899,8 +5935,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i14.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_53(
+        returnValue: _i15.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_54(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5911,8 +5947,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_53(
+            _i15.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_54(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -5922,10 +5958,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.GetKeysChangesResponse>);
+      ) as _i15.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i14.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i15.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -5936,7 +5972,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_54(
+            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
           this,
           Invocation.method(
             #claimKeys,
@@ -5945,7 +5981,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_54(
+            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
           this,
           Invocation.method(
             #claimKeys,
@@ -5953,10 +5989,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i14.Future<_i4.ClaimKeysResponse>);
+      ) as _i15.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i14.Future<void> uploadCrossSigningKeys({
+  _i15.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -5973,12 +6009,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.QueryKeysResponse> queryKeys(
+  _i15.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -5989,7 +6025,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_55(
+            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
           this,
           Invocation.method(
             #queryKeys,
@@ -5998,7 +6034,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_55(
+            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
           this,
           Invocation.method(
             #queryKeys,
@@ -6006,10 +6042,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i14.Future<_i4.QueryKeysResponse>);
+      ) as _i15.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -6017,14 +6053,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i14.Future<
+            returnValue: _i15.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i14.Future<
+            returnValueForMissingStub: _i15.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i14.Future<Map<String, int>> uploadKeys({
+  _i15.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -6039,13 +6075,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i14.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i15.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i14.Future<Map<String, int>>);
+            _i15.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i15.Future<Map<String, int>>);
 
   @override
-  _i14.Future<String> knockRoom(
+  _i15.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -6059,7 +6095,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6071,7 +6107,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6082,20 +6118,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i15.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i14.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i15.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i15.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i14.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i15.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6110,8 +6146,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i14.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_56(
+        returnValue: _i15.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_57(
           this,
           Invocation.method(
             #getNotifications,
@@ -6124,8 +6160,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_56(
+            _i15.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_57(
           this,
           Invocation.method(
             #getNotifications,
@@ -6137,35 +6173,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetNotificationsResponse>);
+      ) as _i15.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i14.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i15.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i14.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_57(
+        returnValue: _i15.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_58(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_57(
+        returnValueForMissingStub: _i15.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_58(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i14.Future<_i4.GetPresenceResponse>);
+      ) as _i15.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i14.Future<void> setPresence(
+  _i15.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -6179,12 +6215,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, Object?>> deleteProfileField(
+  _i15.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6197,13 +6233,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getProfileField(
+  _i15.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6216,13 +6252,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<Map<String, Object?>> setProfileField(
+  _i15.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6237,13 +6273,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i15.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6258,8 +6294,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i14.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_58(
+        returnValue: _i15.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_59(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6272,8 +6308,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_58(
+            _i15.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_59(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6285,10 +6321,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i15.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i14.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i15.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -6309,8 +6345,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i14.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_59(
+        returnValue: _i15.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_60(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6326,8 +6362,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_59(
+            _i15.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_60(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6342,25 +6378,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i15.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i14.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.Pusher>?>.value(),
-      ) as _i14.Future<List<_i4.Pusher>?>);
+        returnValue: _i15.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.Pusher>?>.value(),
+      ) as _i15.Future<List<_i4.Pusher>?>);
 
   @override
-  _i14.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i15.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_60(
+        returnValue: _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_61(
           this,
           Invocation.method(
             #getPushRules,
@@ -6368,24 +6404,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_60(
+            _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_61(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.PushRuleSet>);
+      ) as _i15.Future<_i4.PushRuleSet>);
 
   @override
-  _i14.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i15.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_61(
+        returnValue: _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_62(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -6393,18 +6429,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_61(
+            _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_62(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i15.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i14.Future<void> deletePushRule(
+  _i15.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6416,12 +6452,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.PushRule> getPushRule(
+  _i15.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6433,7 +6469,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<_i4.PushRule>.value(_FakePushRule_62(
+        returnValue: _i15.Future<_i4.PushRule>.value(_FakePushRule_63(
           this,
           Invocation.method(
             #getPushRule,
@@ -6444,7 +6480,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PushRule>.value(_FakePushRule_62(
+            _i15.Future<_i4.PushRule>.value(_FakePushRule_63(
           this,
           Invocation.method(
             #getPushRule,
@@ -6454,10 +6490,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.PushRule>);
+      ) as _i15.Future<_i4.PushRule>);
 
   @override
-  _i14.Future<void> setPushRule(
+  _i15.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -6481,12 +6517,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<Object?>> getPushRuleActions(
+  _i15.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6498,13 +6534,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i15.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i14.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i14.Future<List<Object?>>);
+            _i15.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i15.Future<List<Object?>>);
 
   @override
-  _i14.Future<void> setPushRuleActions(
+  _i15.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -6518,12 +6554,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> isPushRuleEnabled(
+  _i15.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6535,12 +6571,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> setPushRuleEnabled(
+  _i15.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -6554,19 +6590,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i15.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_63(
+            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_64(
           this,
           Invocation.method(
             #refresh,
@@ -6574,28 +6610,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_63(
+            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_64(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i14.Future<_i4.RefreshResponse>);
+      ) as _i15.Future<_i4.RefreshResponse>);
 
   @override
-  _i14.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i15.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i14.Future<bool?>.value(),
-        returnValueForMissingStub: _i14.Future<bool?>.value(),
-      ) as _i14.Future<bool?>);
+        returnValue: _i15.Future<bool?>.value(),
+        returnValueForMissingStub: _i15.Future<bool?>.value(),
+      ) as _i15.Future<bool?>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6617,8 +6653,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6634,8 +6670,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6651,10 +6687,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6678,8 +6714,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6696,8 +6732,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_44(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_45(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6714,17 +6750,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -6732,23 +6768,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i15.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_64(
+        returnValue: _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_65(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -6756,17 +6792,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_64(
+            _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_65(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeys>);
+      ) as _i15.Future<_i4.RoomKeys>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -6778,8 +6814,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6790,8 +6826,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6801,10 +6837,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6816,8 +6852,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6828,8 +6864,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6839,10 +6875,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6854,7 +6890,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_65(
+        returnValue: _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6865,7 +6901,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_65(
+            _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -6875,10 +6911,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeyBackup>);
+      ) as _i15.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -6892,8 +6928,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6905,8 +6941,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -6917,10 +6953,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6934,8 +6970,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -6947,8 +6983,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -6959,10 +6995,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i15.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6976,7 +7012,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
+        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -6988,7 +7024,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_34(
+            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -6999,10 +7035,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.KeyBackupData>);
+      ) as _i15.Future<_i4.KeyBackupData>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7018,8 +7054,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_33(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7032,8 +7068,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_33(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_34(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7045,18 +7081,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_66(
+                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_67(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -7064,18 +7100,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_66(
+                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_67(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i14.Future<String> postRoomKeysVersion(
+  _i15.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -7087,7 +7123,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7098,7 +7134,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7108,29 +7144,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i15.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i15.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_67(
+        returnValue: _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_68(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7138,18 +7174,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_67(
+            _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_68(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i15.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i15.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -7164,24 +7200,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i15.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 
   @override
-  _i14.Future<void> ban(
+  _i15.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7195,12 +7231,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.EventContext> getEventContext(
+  _i15.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7218,7 +7254,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i4.EventContext>.value(_FakeEventContext_68(
+        returnValue: _i15.Future<_i4.EventContext>.value(_FakeEventContext_69(
           this,
           Invocation.method(
             #getEventContext,
@@ -7233,7 +7269,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.EventContext>.value(_FakeEventContext_68(
+            _i15.Future<_i4.EventContext>.value(_FakeEventContext_69(
           this,
           Invocation.method(
             #getEventContext,
@@ -7247,10 +7283,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.EventContext>);
+      ) as _i15.Future<_i4.EventContext>);
 
   @override
-  _i14.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i15.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7262,7 +7298,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
+        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7273,7 +7309,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_52(
+            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7283,20 +7319,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.MatrixEvent>);
+      ) as _i15.Future<_i4.MatrixEvent>);
 
   @override
-  _i14.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> inviteBy3PID(
+  _i15.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -7308,12 +7344,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> inviteUser(
+  _i15.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7327,12 +7363,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> joinRoomById(
+  _i15.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -7346,7 +7382,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7358,7 +7394,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7369,23 +7405,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i15.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i15.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i14.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i14.Future<Map<String, _i4.RoomMember>?>);
+            _i15.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i15.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i14.Future<void> kick(
+  _i15.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7399,12 +7435,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> leaveRoom(
+  _i15.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -7414,12 +7450,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i15.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -7435,12 +7471,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i14.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i14.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i15.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i15.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i14.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i15.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -7462,8 +7498,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_69(
+        returnValue: _i15.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_70(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7479,8 +7515,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_69(
+        returnValueForMissingStub: _i15.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_70(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7496,10 +7532,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomEventsResponse>);
+      ) as _i15.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i14.Future<void> setReadMarker(
+  _i15.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -7515,12 +7551,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> postReceipt(
+  _i15.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -7536,12 +7572,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEvent(
+  _i15.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -7557,12 +7593,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> reportRoom(
+  _i15.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -7574,12 +7610,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> reportEvent(
+  _i15.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -7597,12 +7633,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> sendMessage(
+  _i15.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -7618,7 +7654,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7631,7 +7667,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7643,23 +7679,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i15.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i14.Future<List<_i4.MatrixEvent>>);
+            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i15.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i15.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -7676,13 +7712,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<String> setRoomStateWithKey(
+  _i15.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -7698,7 +7734,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7711,7 +7747,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7723,10 +7759,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> unban(
+  _i15.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7740,12 +7776,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> upgradeRoom(
+  _i15.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -7759,7 +7795,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7771,7 +7807,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7782,10 +7818,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.SearchResults> search(
+  _i15.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -7795,7 +7831,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_70(
+        returnValue: _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_71(
           this,
           Invocation.method(
             #search,
@@ -7804,7 +7840,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_70(
+            _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_71(
           this,
           Invocation.method(
             #search,
@@ -7812,10 +7848,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i14.Future<_i4.SearchResults>);
+      ) as _i15.Future<_i4.SearchResults>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> sync({
+  _i15.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -7836,7 +7872,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.method(
             #sync,
@@ -7852,7 +7888,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.method(
             #sync,
@@ -7867,22 +7903,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i15.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i14.Future<List<_i4.Location>>);
+            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i15.Future<List<_i4.Location>>);
 
   @override
-  _i14.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i15.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -7892,21 +7928,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i14.Future<List<_i4.Location>>);
+            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i15.Future<List<_i4.Location>>);
 
   @override
-  _i14.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i15.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_71(
+        returnValue: _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_72(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -7914,45 +7950,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_71(
+            _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_72(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i14.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i15.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i14.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i15.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -7963,13 +7999,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getAccountData(
+  _i15.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -7982,13 +8018,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> setAccountData(
+  _i15.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -8002,12 +8038,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> defineFilter(
+  _i15.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -8019,7 +8055,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8030,7 +8066,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8040,10 +8076,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.Filter> getFilter(
+  _i15.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -8055,7 +8091,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i14.Future<_i4.Filter>.value(_FakeFilter_11(
+        returnValue: _i15.Future<_i4.Filter>.value(_FakeFilter_12(
           this,
           Invocation.method(
             #getFilter,
@@ -8065,7 +8101,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Filter>.value(_FakeFilter_11(
+        returnValueForMissingStub: _i15.Future<_i4.Filter>.value(_FakeFilter_12(
           this,
           Invocation.method(
             #getFilter,
@@ -8075,10 +8111,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.Filter>);
+      ) as _i15.Future<_i4.Filter>);
 
   @override
-  _i14.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i15.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8091,7 +8127,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_72(
+            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8102,7 +8138,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_72(
+            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8112,10 +8148,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.OpenIdCredentials>);
+      ) as _i15.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i14.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i15.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8130,13 +8166,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> setAccountDataPerRoom(
+  _i15.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8152,12 +8188,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i15.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8169,12 +8205,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i14.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i14.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i14.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i15.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i15.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i15.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i14.Future<void> deleteRoomTag(
+  _i15.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8188,12 +8224,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setRoomTag(
+  _i15.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8209,12 +8245,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i15.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8224,8 +8260,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i14.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_73(
+        returnValue: _i15.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_74(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8234,8 +8270,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_73(
+            _i15.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_74(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8243,10 +8279,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i14.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i15.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> reportUser(
+  _i15.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8259,40 +8295,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i15.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i14.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_74(
+        returnValue: _i15.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_75(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_74(
+        returnValueForMissingStub: _i15.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_75(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.CreateContentResponse>);
+      ) as _i15.Future<_i4.CreateContentResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> uploadContentToMXC(
+  _i15.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i22.Uint8List? body, {
+    _i23.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8310,10 +8346,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [Room].
@@ -8323,11 +8359,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8357,11 +8393,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_75(
+        returnValue: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_75(
+        returnValueForMissingStub: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
@@ -8391,11 +8427,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i14.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i15.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i14.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i14.Completer<dynamic>>[],
-      ) as List<_i14.Completer<dynamic>>);
+        returnValue: <_i15.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i15.Completer<dynamic>>[],
+      ) as List<_i15.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -8414,51 +8450,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i12.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i13.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_16<String>(
+        returnValue: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i12.CachedStreamController<String> get onSessionKeyReceived =>
+  _i13.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_16<String>(
+        returnValue: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_16<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_17<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8474,11 +8510,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8487,11 +8523,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8534,11 +8570,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8547,11 +8583,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_17(
+        returnValue: _FakeDateTime_18(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_17(
+        returnValueForMissingStub: _FakeDateTime_18(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -8581,11 +8617,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_76(
+        returnValue: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_76(
+        returnValueForMissingStub: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8606,18 +8642,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i14.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i15.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -8804,18 +8840,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i23.SpaceParent>[],
-        returnValueForMissingStub: <_i23.SpaceParent>[],
-      ) as List<_i23.SpaceParent>);
+        returnValue: <_i24.SpaceParent>[],
+        returnValueForMissingStub: <_i24.SpaceParent>[],
+      ) as List<_i24.SpaceParent>);
 
   @override
-  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i23.SpaceChild>[],
-        returnValueForMissingStub: <_i23.SpaceChild>[],
-      ) as List<_i23.SpaceChild>);
+        returnValue: <_i24.SpaceChild>[],
+        returnValueForMissingStub: <_i24.SpaceChild>[],
+      ) as List<_i24.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -8928,14 +8964,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i14.Future<void> postLoad() => (super.noSuchMethod(
+  _i15.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -8963,15 +8999,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i14.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i15.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i14.Future<List<_i4.User>>);
+            _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i15.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -8982,14 +9018,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -8999,18 +9035,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i14.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i15.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Event?> refreshLastEvent(
+  _i15.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9018,9 +9054,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -9032,12 +9068,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i14.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i15.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9045,22 +9081,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i15.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9068,17 +9104,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> addTag(
+  _i15.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -9088,27 +9124,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i15.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i15.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -9116,53 +9152,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_25(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i15.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i15.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+  _i15.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
         Invocation.method(
           #setLowPriority,
           [lowPriority],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i15.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9170,14 +9206,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -9189,7 +9225,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i14.Future<String?> sendTextEvent(
+  _i15.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -9221,12 +9257,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendReaction(
+  _i15.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -9240,12 +9276,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendLocation(
+  _i15.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -9259,12 +9295,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendFileEvent(
+  _i15.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -9292,25 +9328,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i15.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i14.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i15.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i14.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i15.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i14.Future<_i4.EncryptionHealthState>);
+      ) as _i15.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i14.Future<String?> sendEvent(
+  _i15.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -9334,73 +9370,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i15.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> leave() => (super.noSuchMethod(
+  _i15.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> forget() => (super.noSuchMethod(
+  _i15.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> setPower(
+  _i15.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -9412,7 +9448,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9423,7 +9459,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9433,10 +9469,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> invite(
+  _i15.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -9446,12 +9482,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<int> requestHistory({
+  _i15.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -9468,32 +9504,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<int>.value(0),
-        returnValueForMissingStub: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+        returnValueForMissingStub: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
-  _i14.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i15.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setReadMarker(
+  _i15.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -9507,23 +9543,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
+  _i15.Future<_i25.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i14.Future<_i24.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i14.Future<_i24.TimelineChunk?>.value(),
-      ) as _i14.Future<_i24.TimelineChunk?>);
+        returnValue: _i15.Future<_i25.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i15.Future<_i25.TimelineChunk?>.value(),
+      ) as _i15.Future<_i25.TimelineChunk?>);
 
   @override
-  _i14.Future<void> postReceipt(
+  _i15.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -9533,12 +9569,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Timeline> getTimeline({
+  _i15.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -9561,7 +9597,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i14.Future<_i4.Timeline>.value(_FakeTimeline_77(
+        returnValue: _i15.Future<_i4.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9578,7 +9614,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Timeline>.value(_FakeTimeline_77(
+            _i15.Future<_i4.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9594,7 +9630,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Timeline>);
+      ) as _i15.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -9613,7 +9649,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i14.Future<List<_i4.User>> requestParticipants([
+  _i15.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -9631,10 +9667,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i14.Future<List<_i4.User>>);
+            _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i15.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -9642,14 +9678,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9665,14 +9701,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9682,7 +9718,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i14.Future<_i4.User?> requestUser(
+  _i15.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -9698,19 +9734,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i14.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.User?>.value(),
-      ) as _i14.Future<_i4.User?>);
+        returnValue: _i15.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.User?>.value(),
+      ) as _i15.Future<_i4.User?>);
 
   @override
-  _i14.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i15.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -9723,12 +9759,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i14.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i15.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9736,14 +9772,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -9766,14 +9802,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i14.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i15.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -9812,18 +9848,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i14.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i15.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEvent(
+  _i15.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -9837,12 +9873,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> setTyping(
+  _i15.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -9852,12 +9888,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setJoinRules(
+  _i15.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -9871,59 +9907,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i15.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setHistoryVisibility(
+  _i15.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i15.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i15.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i15.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i14.Future<List<_i4.DeviceKeys>>);
+            _i15.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i15.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i14.Future<void> requestSessionKey(
+  _i15.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -9935,12 +9971,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setSpaceChild(
+  _i15.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -9956,44 +9992,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i15.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i14.Future<Uri>.value(_FakeUri_30(
+        returnValue: _i15.Future<Uri>.value(_FakeUri_31(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_30(
+        returnValueForMissingStub: _i15.Future<Uri>.value(_FakeUri_31(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i14.Future<Uri>);
+      ) as _i15.Future<Uri>);
 
   @override
-  _i14.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<
+  _i15.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -10020,21 +10056,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i14.Future<
+        returnValue: _i15.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i14.Future<
+        returnValueForMissingStub: _i15.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i14.Future<
+      ) as _i15.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -10046,13 +10082,13 @@ class MockRoom extends _i1.Mock implements _i4.Room {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockFlutterLocalNotificationsPlugin extends _i1.Mock
-    implements _i25.FlutterLocalNotificationsPlugin {
+    implements _i26.FlutterLocalNotificationsPlugin {
   @override
-  _i14.Future<bool?> initialize({
-    required _i26.InitializationSettings? settings,
-    _i27.DidReceiveNotificationResponseCallback?
+  _i15.Future<bool?> initialize({
+    required _i27.InitializationSettings? settings,
+    _i28.DidReceiveNotificationResponseCallback?
         onDidReceiveNotificationResponse,
-    _i27.DidReceiveBackgroundNotificationResponseCallback?
+    _i28.DidReceiveBackgroundNotificationResponseCallback?
         onDidReceiveBackgroundNotificationResponse,
   }) =>
       (super.noSuchMethod(
@@ -10066,29 +10102,29 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
                 onDidReceiveBackgroundNotificationResponse,
           },
         ),
-        returnValue: _i14.Future<bool?>.value(),
-        returnValueForMissingStub: _i14.Future<bool?>.value(),
-      ) as _i14.Future<bool?>);
+        returnValue: _i15.Future<bool?>.value(),
+        returnValueForMissingStub: _i15.Future<bool?>.value(),
+      ) as _i15.Future<bool?>);
 
   @override
-  _i14.Future<_i27.NotificationAppLaunchDetails?>
+  _i15.Future<_i28.NotificationAppLaunchDetails?>
       getNotificationAppLaunchDetails() => (super.noSuchMethod(
             Invocation.method(
               #getNotificationAppLaunchDetails,
               [],
             ),
             returnValue:
-                _i14.Future<_i27.NotificationAppLaunchDetails?>.value(),
+                _i15.Future<_i28.NotificationAppLaunchDetails?>.value(),
             returnValueForMissingStub:
-                _i14.Future<_i27.NotificationAppLaunchDetails?>.value(),
-          ) as _i14.Future<_i27.NotificationAppLaunchDetails?>);
+                _i15.Future<_i28.NotificationAppLaunchDetails?>.value(),
+          ) as _i15.Future<_i28.NotificationAppLaunchDetails?>);
 
   @override
-  _i14.Future<void> show({
+  _i15.Future<void> show({
     required int? id,
     String? title,
     String? body,
-    _i28.NotificationDetails? notificationDetails,
+    _i29.NotificationDetails? notificationDetails,
     String? payload,
   }) =>
       (super.noSuchMethod(
@@ -10103,12 +10139,12 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #payload: payload,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> cancel({
+  _i15.Future<void> cancel({
     required int? id,
     String? tag,
   }) =>
@@ -10121,40 +10157,40 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #tag: tag,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> cancelAll() => (super.noSuchMethod(
+  _i15.Future<void> cancelAll() => (super.noSuchMethod(
         Invocation.method(
           #cancelAll,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> cancelAllPendingNotifications() => (super.noSuchMethod(
+  _i15.Future<void> cancelAllPendingNotifications() => (super.noSuchMethod(
         Invocation.method(
           #cancelAllPendingNotifications,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> zonedSchedule({
+  _i15.Future<void> zonedSchedule({
     required int? id,
-    required _i29.TZDateTime? scheduledDate,
-    required _i28.NotificationDetails? notificationDetails,
-    required _i30.AndroidScheduleMode? androidScheduleMode,
+    required _i30.TZDateTime? scheduledDate,
+    required _i29.NotificationDetails? notificationDetails,
+    required _i31.AndroidScheduleMode? androidScheduleMode,
     String? title,
     String? body,
     String? payload,
-    _i31.DateTimeComponents? matchDateTimeComponents,
+    _i32.DateTimeComponents? matchDateTimeComponents,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -10171,16 +10207,16 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #matchDateTimeComponents: matchDateTimeComponents,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> periodicallyShow({
+  _i15.Future<void> periodicallyShow({
     required int? id,
-    required _i27.RepeatInterval? repeatInterval,
-    required _i28.NotificationDetails? notificationDetails,
-    required _i30.AndroidScheduleMode? androidScheduleMode,
+    required _i28.RepeatInterval? repeatInterval,
+    required _i29.NotificationDetails? notificationDetails,
+    required _i31.AndroidScheduleMode? androidScheduleMode,
     String? title,
     String? body,
     String? payload,
@@ -10199,19 +10235,19 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #payload: payload,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> periodicallyShowWithDuration({
+  _i15.Future<void> periodicallyShowWithDuration({
     required int? id,
     required Duration? repeatDurationInterval,
-    required _i28.NotificationDetails? notificationDetails,
+    required _i29.NotificationDetails? notificationDetails,
     String? title,
     String? body,
-    _i30.AndroidScheduleMode? androidScheduleMode =
-        _i30.AndroidScheduleMode.exact,
+    _i31.AndroidScheduleMode? androidScheduleMode =
+        _i31.AndroidScheduleMode.exact,
     String? payload,
   }) =>
       (super.noSuchMethod(
@@ -10228,36 +10264,36 @@ class MockFlutterLocalNotificationsPlugin extends _i1.Mock
             #payload: payload,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i27.PendingNotificationRequest>>
+  _i15.Future<List<_i28.PendingNotificationRequest>>
       pendingNotificationRequests() => (super.noSuchMethod(
             Invocation.method(
               #pendingNotificationRequests,
               [],
             ),
             returnValue:
-                _i14.Future<List<_i27.PendingNotificationRequest>>.value(
-                    <_i27.PendingNotificationRequest>[]),
+                _i15.Future<List<_i28.PendingNotificationRequest>>.value(
+                    <_i28.PendingNotificationRequest>[]),
             returnValueForMissingStub:
-                _i14.Future<List<_i27.PendingNotificationRequest>>.value(
-                    <_i27.PendingNotificationRequest>[]),
-          ) as _i14.Future<List<_i27.PendingNotificationRequest>>);
+                _i15.Future<List<_i28.PendingNotificationRequest>>.value(
+                    <_i28.PendingNotificationRequest>[]),
+          ) as _i15.Future<List<_i28.PendingNotificationRequest>>);
 
   @override
-  _i14.Future<List<_i27.ActiveNotification>> getActiveNotifications() =>
+  _i15.Future<List<_i28.ActiveNotification>> getActiveNotifications() =>
       (super.noSuchMethod(
         Invocation.method(
           #getActiveNotifications,
           [],
         ),
-        returnValue: _i14.Future<List<_i27.ActiveNotification>>.value(
-            <_i27.ActiveNotification>[]),
+        returnValue: _i15.Future<List<_i28.ActiveNotification>>.value(
+            <_i28.ActiveNotification>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i27.ActiveNotification>>.value(
-                <_i27.ActiveNotification>[]),
-      ) as _i14.Future<List<_i27.ActiveNotification>>);
+            _i15.Future<List<_i28.ActiveNotification>>.value(
+                <_i28.ActiveNotification>[]),
+      ) as _i15.Future<List<_i28.ActiveNotification>>);
 }

--- a/test/widgets/add_existing_rooms_dialog_test.mocks.dart
+++ b/test/widgets/add_existing_rooms_dialog_test.mocks.dart
@@ -3,14 +3,15 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i14;
-import 'dart:typed_data' as _i24;
-import 'dart:ui' as _i18;
+import 'dart:async' as _i15;
+import 'dart:typed_data' as _i25;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
-import 'package:http/http.dart' as _i13;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
+import 'package:http/http.dart' as _i14;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i12;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -25,14 +26,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i23;
+import 'package:matrix/encryption.dart' as _i24;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i15;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i12;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i16;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i23;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i13;
+import 'package:matrix/src/utils/space_child.dart' as _i22;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -154,8 +155,9 @@ class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
         );
 }
 
-class _FakeRoomSummary_10 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_10(
+class _FakeStickerPackService_10 extends _i1.SmartFake
+    implements _i12.StickerPackService {
+  _FakeStickerPackService_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -164,9 +166,8 @@ class _FakeRoomSummary_10 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_11<T> extends _i1.SmartFake
-    implements _i12.CachedStreamController<T> {
-  _FakeCachedStreamController_11(
+class _FakeRoomSummary_11 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -175,8 +176,9 @@ class _FakeCachedStreamController_11<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_12 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_12(
+class _FakeCachedStreamController_12<T> extends _i1.SmartFake
+    implements _i13.CachedStreamController<T> {
+  _FakeCachedStreamController_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -185,9 +187,19 @@ class _FakeDateTime_12 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_13 extends _i1.SmartFake
+class _FakeDateTime_13 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_13(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_14 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_13(
+  _FakeLatestReceiptState_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -196,8 +208,8 @@ class _FakeLatestReceiptState_13 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_14 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_14(
+class _FakeSyncUpdate_15 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -206,8 +218,8 @@ class _FakeSyncUpdate_14 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeTimeline_15 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_15(
+class _FakeTimeline_16 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -216,8 +228,8 @@ class _FakeTimeline_15 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_16 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_16(
+class _FakeUser_17 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -226,8 +238,8 @@ class _FakeUser_16 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeUri_17 extends _i1.SmartFake implements Uri {
-  _FakeUri_17(
+class _FakeUri_18 extends _i1.SmartFake implements Uri {
+  _FakeUri_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -236,8 +248,8 @@ class _FakeUri_17 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_18 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_18(
+class _FakeDatabaseApi_19 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -246,8 +258,8 @@ class _FakeDatabaseApi_18 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_19 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_19(
+class _FakeFilter_20 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -256,9 +268,9 @@ class _FakeFilter_19 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_20 extends _i1.SmartFake
+class _FakeNativeImplementations_21 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_20(
+  _FakeNativeImplementations_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -267,8 +279,8 @@ class _FakeNativeImplementations_20 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_21 extends _i1.SmartFake implements Duration {
-  _FakeDuration_21(
+class _FakeDuration_22 extends _i1.SmartFake implements Duration {
+  _FakeDuration_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -277,9 +289,9 @@ class _FakeDuration_21 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_22 extends _i1.SmartFake
+class _FakePushruleEvaluator_23 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_22(
+  _FakePushruleEvaluator_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -288,8 +300,8 @@ class _FakePushruleEvaluator_22 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_23 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_23(
+class _FakeProfile_24 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -298,8 +310,8 @@ class _FakeProfile_23 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeClient_24 extends _i1.SmartFake implements _i13.Client {
-  _FakeClient_24(
+class _FakeClient_25 extends _i1.SmartFake implements _i14.Client {
+  _FakeClient_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -308,9 +320,9 @@ class _FakeClient_24 extends _i1.SmartFake implements _i13.Client {
         );
 }
 
-class _FakeDiscoveryInformation_25 extends _i1.SmartFake
+class _FakeDiscoveryInformation_26 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_25(
+  _FakeDiscoveryInformation_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -319,9 +331,9 @@ class _FakeDiscoveryInformation_25 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_26 extends _i1.SmartFake
+class _FakeGetVersionsResponse_27 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_26(
+  _FakeGetVersionsResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -330,9 +342,9 @@ class _FakeGetVersionsResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_27 extends _i1.SmartFake
+class _FakeRegisterResponse_28 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_27(
+  _FakeRegisterResponse_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -341,8 +353,8 @@ class _FakeRegisterResponse_27 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_28 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_28(
+class _FakeLoginResponse_29 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -351,9 +363,9 @@ class _FakeLoginResponse_28 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_29 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_30 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_29(
+  _FakeGetAuthMetadataResponse_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -362,8 +374,8 @@ class _FakeGetAuthMetadataResponse_29 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_30<T1> extends _i1.SmartFake implements _i14.Future<T1> {
-  _FakeFuture_30(
+class _FakeFuture_31<T1> extends _i1.SmartFake implements _i15.Future<T1> {
+  _FakeFuture_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -372,9 +384,9 @@ class _FakeFuture_30<T1> extends _i1.SmartFake implements _i14.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_31 extends _i1.SmartFake
+class _FakeCachedProfileInformation_32 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_31(
+  _FakeCachedProfileInformation_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -383,8 +395,8 @@ class _FakeCachedProfileInformation_31 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_32 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_32(
+class _FakeMediaConfig_33 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -393,8 +405,8 @@ class _FakeMediaConfig_32 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_33 extends _i1.SmartFake implements _i15.FileResponse {
-  _FakeFileResponse_33(
+class _FakeFileResponse_34 extends _i1.SmartFake implements _i16.FileResponse {
+  _FakeFileResponse_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -403,8 +415,8 @@ class _FakeFileResponse_33 extends _i1.SmartFake implements _i15.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_34 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_34(
+class _FakePreviewForUrl_35 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -413,9 +425,9 @@ class _FakePreviewForUrl_34 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_35 extends _i1.SmartFake
+class _FakeCachedPresence_36 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_35(
+  _FakeCachedPresence_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -424,9 +436,9 @@ class _FakeCachedPresence_35 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_36 extends _i1.SmartFake
+class _FakeTurnServerCredentials_37 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_36(
+  _FakeTurnServerCredentials_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -435,9 +447,9 @@ class _FakeTurnServerCredentials_36 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_37 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_38 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_37(
+  _FakeRoomKeysUpdateResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -446,8 +458,8 @@ class _FakeRoomKeysUpdateResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_38 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_38(
+class _FakeKeyBackupData_39 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -456,9 +468,9 @@ class _FakeKeyBackupData_38 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_39 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_40 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_39(
+  _FakeGetWellknownSupportResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -467,9 +479,9 @@ class _FakeGetWellknownSupportResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_40 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_41 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_40(
+  _FakeGenerateLoginTokenResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -478,9 +490,9 @@ class _FakeGenerateLoginTokenResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_41 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_42 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_41(
+  _FakeGetRoomSummaryResponse$3_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -489,9 +501,9 @@ class _FakeGetRoomSummaryResponse$3_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_42 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_43 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_42(
+  _FakeGetSpaceHierarchyResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -500,9 +512,9 @@ class _FakeGetSpaceHierarchyResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_43 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_44 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_43(
+  _FakeGetRelatingEventsResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -511,9 +523,9 @@ class _FakeGetRelatingEventsResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_44 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_45 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_44(
+  _FakeGetRelatingEventsWithRelTypeResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -522,9 +534,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -533,9 +545,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_46 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_47 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_46(
+  _FakeGetThreadRootsResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -544,9 +556,9 @@ class _FakeGetThreadRootsResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_47 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_48 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_47(
+  _FakeGetEventByTimestampResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -555,9 +567,9 @@ class _FakeGetEventByTimestampResponse_47 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_48 extends _i1.SmartFake
+class _FakeRequestTokenResponse_49 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_48(
+  _FakeRequestTokenResponse_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -566,9 +578,9 @@ class _FakeRequestTokenResponse_48 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_49 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_50 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_49(
+  _FakeTokenOwnerInfo_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -577,8 +589,8 @@ class _FakeTokenOwnerInfo_49 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_50 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_50(
+class _FakeWhoIsInfo_51 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -587,8 +599,8 @@ class _FakeWhoIsInfo_50 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_51 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_51(
+class _FakeCapabilities_52 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -597,8 +609,8 @@ class _FakeCapabilities_51 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_52 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_52(
+class _FakeDevice_53 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -607,9 +619,9 @@ class _FakeDevice_52 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_53 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_54 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_53(
+  _FakeGetRoomIdByAliasResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -618,9 +630,9 @@ class _FakeGetRoomIdByAliasResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_54 extends _i1.SmartFake
+class _FakeGetEventsResponse_55 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_54(
+  _FakeGetEventsResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -629,9 +641,9 @@ class _FakeGetEventsResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_55 extends _i1.SmartFake
+class _FakePeekEventsResponse_56 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_55(
+  _FakePeekEventsResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -640,8 +652,8 @@ class _FakePeekEventsResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_56 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_56(
+class _FakeMatrixEvent_57 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -650,9 +662,9 @@ class _FakeMatrixEvent_56 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_57 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_58 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_57(
+  _FakeGetKeysChangesResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -661,9 +673,9 @@ class _FakeGetKeysChangesResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_58 extends _i1.SmartFake
+class _FakeClaimKeysResponse_59 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_58(
+  _FakeClaimKeysResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -672,9 +684,9 @@ class _FakeClaimKeysResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_59 extends _i1.SmartFake
+class _FakeQueryKeysResponse_60 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_59(
+  _FakeQueryKeysResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -683,9 +695,9 @@ class _FakeQueryKeysResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_60 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_61 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_60(
+  _FakeGetNotificationsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -694,9 +706,9 @@ class _FakeGetNotificationsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_61 extends _i1.SmartFake
+class _FakeGetPresenceResponse_62 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_61(
+  _FakeGetPresenceResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -705,9 +717,9 @@ class _FakeGetPresenceResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_62 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_63 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_62(
+  _FakeGetPublicRoomsResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -716,9 +728,9 @@ class _FakeGetPublicRoomsResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_63 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_64 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_63(
+  _FakeQueryPublicRoomsResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -727,8 +739,8 @@ class _FakeQueryPublicRoomsResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_64 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_64(
+class _FakePushRuleSet_65 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -737,9 +749,9 @@ class _FakePushRuleSet_64 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_65 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_66 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_65(
+  _FakeGetPushRulesGlobalResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -748,8 +760,8 @@ class _FakeGetPushRulesGlobalResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_66 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_66(
+class _FakePushRule_67 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -758,9 +770,9 @@ class _FakePushRule_66 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_67 extends _i1.SmartFake
+class _FakeRefreshResponse_68 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_67(
+  _FakeRefreshResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -769,8 +781,8 @@ class _FakeRefreshResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_68 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_68(
+class _FakeRoomKeys_69 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -779,8 +791,8 @@ class _FakeRoomKeys_68 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_69 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_69(
+class _FakeRoomKeyBackup_70 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -789,9 +801,9 @@ class _FakeRoomKeyBackup_69 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_70 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_71 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_70(
+  _FakeGetRoomKeysVersionCurrentResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -800,9 +812,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_71 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_72 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_71(
+  _FakeGetRoomKeysVersionResponse_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -811,8 +823,8 @@ class _FakeGetRoomKeysVersionResponse_71 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_72 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_72(
+class _FakeEventContext_73 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -821,9 +833,9 @@ class _FakeEventContext_72 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_73 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_74 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_73(
+  _FakeGetRoomEventsResponse_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -832,8 +844,8 @@ class _FakeGetRoomEventsResponse_73 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_74 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_74(
+class _FakeSearchResults_75 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,9 +854,9 @@ class _FakeSearchResults_74 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_75 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_76 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_75(
+  _FakeGetProtocolMetadataResponse$2_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -853,9 +865,9 @@ class _FakeGetProtocolMetadataResponse$2_75 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_76 extends _i1.SmartFake
+class _FakeOpenIdCredentials_77 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_76(
+  _FakeOpenIdCredentials_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -864,9 +876,9 @@ class _FakeOpenIdCredentials_76 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_77 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_78 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_77(
+  _FakeSearchUserDirectoryResponse_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -875,9 +887,9 @@ class _FakeSearchUserDirectoryResponse_77 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_78 extends _i1.SmartFake
+class _FakeCreateContentResponse_79 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_78(
+  _FakeCreateContentResponse_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -889,7 +901,7 @@ class _FakeCreateContentResponse_78 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -919,11 +931,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1048,6 +1060,19 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i11.OutboxService);
 
   @override
+  _i12.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i12.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -1145,6 +1170,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set stickerPacks(_i12.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -1152,14 +1186,14 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i15.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1189,7 +1223,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1199,21 +1233,22 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i15.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> login({
+  _i15.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1223,14 +1258,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> completeSsoLogin({
+  _i15.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1243,12 +1279,12 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> completeRegistration(
+  _i15.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1258,32 +1294,32 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i15.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1292,7 +1328,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1301,17 +1337,17 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i15.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1322,7 +1358,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1359,26 +1395,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i15.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+  _i15.Future<bool> didPushRouteInformation(
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1408,7 +1444,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1417,7 +1453,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1426,16 +1462,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i15.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i15.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i14.Future<_i18.AppExitResponse>);
+            _i15.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i15.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1463,11 +1499,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1497,11 +1533,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_10(
+        returnValue: _FakeRoomSummary_11(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_10(
+        returnValueForMissingStub: _FakeRoomSummary_11(
           this,
           Invocation.getter(#summary),
         ),
@@ -1531,11 +1567,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i14.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i15.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i14.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i14.Completer<dynamic>>[],
-      ) as List<_i14.Completer<dynamic>>);
+        returnValue: <_i15.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i15.Completer<dynamic>>[],
+      ) as List<_i15.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1554,51 +1590,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i12.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i13.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_11<String>(
+        returnValue: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i12.CachedStreamController<String> get onSessionKeyReceived =>
+  _i13.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_11<String>(
+        returnValue: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1614,11 +1650,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1627,11 +1663,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1674,11 +1710,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1687,11 +1723,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_12(
+        returnValue: _FakeDateTime_13(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_12(
+        returnValueForMissingStub: _FakeDateTime_13(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -1721,11 +1757,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_13(
+        returnValue: _FakeLatestReceiptState_14(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_13(
+        returnValueForMissingStub: _FakeLatestReceiptState_14(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -1746,18 +1782,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i14.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i15.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -1944,18 +1980,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i22.SpaceParent>[],
+        returnValueForMissingStub: <_i22.SpaceParent>[],
+      ) as List<_i22.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i22.SpaceChild>[],
+        returnValueForMissingStub: <_i22.SpaceChild>[],
+      ) as List<_i22.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -2068,14 +2104,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i14.Future<void> postLoad() => (super.noSuchMethod(
+  _i15.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -2103,15 +2139,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i14.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i15.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i14.Future<List<_i4.User>>);
+            _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i15.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -2122,14 +2158,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2139,18 +2175,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i14.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i15.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Event?> refreshLastEvent(
+  _i15.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2158,9 +2194,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -2172,12 +2208,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i14.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i15.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2185,22 +2221,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i15.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2208,17 +2244,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> addTag(
+  _i15.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2228,27 +2264,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i15.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i15.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2256,53 +2292,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i15.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i15.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+  _i15.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
         Invocation.method(
           #setLowPriority,
           [lowPriority],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i15.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2310,14 +2346,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2329,7 +2365,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i14.Future<String?> sendTextEvent(
+  _i15.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2361,12 +2397,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendReaction(
+  _i15.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2380,12 +2416,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendLocation(
+  _i15.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2399,12 +2435,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendFileEvent(
+  _i15.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2432,25 +2468,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i15.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i14.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i15.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i14.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i15.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i14.Future<_i4.EncryptionHealthState>);
+      ) as _i15.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i14.Future<String?> sendEvent(
+  _i15.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -2474,73 +2510,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i15.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> leave() => (super.noSuchMethod(
+  _i15.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> forget() => (super.noSuchMethod(
+  _i15.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> setPower(
+  _i15.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2552,7 +2588,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2563,7 +2599,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2573,10 +2609,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> invite(
+  _i15.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2586,12 +2622,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<int> requestHistory({
+  _i15.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -2608,32 +2644,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<int>.value(0),
-        returnValueForMissingStub: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+        returnValueForMissingStub: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
-  _i14.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i15.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setReadMarker(
+  _i15.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2647,23 +2683,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
+  _i15.Future<_i23.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i14.Future<_i22.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i14.Future<_i22.TimelineChunk?>.value(),
-      ) as _i14.Future<_i22.TimelineChunk?>);
+        returnValue: _i15.Future<_i23.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i15.Future<_i23.TimelineChunk?>.value(),
+      ) as _i15.Future<_i23.TimelineChunk?>);
 
   @override
-  _i14.Future<void> postReceipt(
+  _i15.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -2673,12 +2709,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Timeline> getTimeline({
+  _i15.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2701,7 +2737,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i14.Future<_i4.Timeline>.value(_FakeTimeline_15(
+        returnValue: _i15.Future<_i4.Timeline>.value(_FakeTimeline_16(
           this,
           Invocation.method(
             #getTimeline,
@@ -2718,7 +2754,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Timeline>.value(_FakeTimeline_15(
+            _i15.Future<_i4.Timeline>.value(_FakeTimeline_16(
           this,
           Invocation.method(
             #getTimeline,
@@ -2734,7 +2770,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Timeline>);
+      ) as _i15.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -2753,7 +2789,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i14.Future<List<_i4.User>> requestParticipants([
+  _i15.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -2771,10 +2807,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i14.Future<List<_i4.User>>);
+            _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i15.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -2782,14 +2818,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_16(
+        returnValue: _FakeUser_17(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_16(
+        returnValueForMissingStub: _FakeUser_17(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -2805,14 +2841,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_16(
+        returnValue: _FakeUser_17(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_16(
+        returnValueForMissingStub: _FakeUser_17(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -2822,7 +2858,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i14.Future<_i4.User?> requestUser(
+  _i15.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2838,19 +2874,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i14.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.User?>.value(),
-      ) as _i14.Future<_i4.User?>);
+        returnValue: _i15.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.User?>.value(),
+      ) as _i15.Future<_i4.User?>);
 
   @override
-  _i14.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i15.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2863,12 +2899,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i14.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i15.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2876,14 +2912,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2906,14 +2942,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i14.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i15.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -2952,18 +2988,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i14.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i15.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEvent(
+  _i15.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -2977,12 +3013,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> setTyping(
+  _i15.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -2992,12 +3028,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setJoinRules(
+  _i15.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -3011,59 +3047,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i15.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setHistoryVisibility(
+  _i15.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i15.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i15.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i15.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i14.Future<List<_i4.DeviceKeys>>);
+            _i15.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i15.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i14.Future<void> requestSessionKey(
+  _i15.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -3075,12 +3111,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setSpaceChild(
+  _i15.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3096,44 +3132,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i15.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i14.Future<Uri>.value(_FakeUri_17(
+        returnValue: _i15.Future<Uri>.value(_FakeUri_18(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_17(
+        returnValueForMissingStub: _i15.Future<Uri>.value(_FakeUri_18(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i14.Future<Uri>);
+      ) as _i15.Future<Uri>);
 
   @override
-  _i14.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<
+  _i15.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -3160,21 +3196,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i14.Future<
+        returnValue: _i15.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i14.Future<
+        returnValueForMissingStub: _i15.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i14.Future<
+      ) as _i15.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -3189,23 +3225,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_18(
+        returnValue: _FakeDatabaseApi_19(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_18(
+        returnValueForMissingStub: _FakeDatabaseApi_19(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i23.KeyVerificationMethod> get verificationMethods =>
+  Set<_i24.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i23.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i23.KeyVerificationMethod>{},
-      ) as Set<_i23.KeyVerificationMethod>);
+        returnValue: <_i24.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i24.KeyVerificationMethod>{},
+      ) as Set<_i24.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3266,11 +3302,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_19(
+        returnValue: _FakeFilter_20(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_19(
+        returnValueForMissingStub: _FakeFilter_20(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -3279,11 +3315,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_20(
+        returnValue: _FakeNativeImplementations_21(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_20(
+        returnValueForMissingStub: _FakeNativeImplementations_21(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -3299,11 +3335,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_21(
+        returnValue: _FakeDuration_22(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_21(
+        returnValueForMissingStub: _FakeDuration_22(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3312,11 +3348,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_21(
+        returnValue: _FakeDuration_22(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_21(
+        returnValueForMissingStub: _FakeDuration_22(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3325,11 +3361,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -3366,11 +3402,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3400,11 +3436,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3413,11 +3449,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3440,11 +3476,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_22(
+        returnValue: _FakePushruleEvaluator_23(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_22(
+        returnValueForMissingStub: _FakePushruleEvaluator_23(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -3465,332 +3501,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i14.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i15.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i12.CachedStreamController<String> get onUserProfileUpdate =>
+  _i13.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_11<String>(
+        returnValue: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i14.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i15.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i14.Future<List<_i4.Room>>);
+            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i15.Future<List<_i4.Room>>);
 
   @override
-  _i12.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i13.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_11<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_12<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.EventUpdate>(
+            _FakeCachedStreamController_12<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.EventUpdate>);
+      ) as _i13.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i13.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_11<_i4.Event>(
+        returnValue: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i13.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_11<_i4.Event>(
+        returnValue: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onNotification =>
+  _i13.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_11<_i4.Event>(
+        returnValue: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i13.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_11<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_12<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_12<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i13.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i12.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i13.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_11<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_12<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_11<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_12<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i12.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i13.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i12.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i13.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_11<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_12<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.LoginState>(
+            _FakeCachedStreamController_12<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i12.CachedStreamController<_i4.LoginState>);
+      ) as _i13.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i12.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i13.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_11<bool>(
+        returnValue: _FakeCachedStreamController_12<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i12.CachedStreamController<bool>);
+      ) as _i13.CachedStreamController<bool>);
 
   @override
-  _i12.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i13.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_11<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_12<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i12.CachedStreamController<_i4.SdkError>);
+      ) as _i13.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i12.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i13.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_11<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_12<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.SyncUpdate>(
+            _FakeCachedStreamController_12<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i12.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i13.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i13.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_11<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_12<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_12<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i12.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i13.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.Presence> get onPresence =>
+  _i13.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_11<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_12<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i12.CachedStreamController<_i4.Presence>);
+      ) as _i13.CachedStreamController<_i4.Presence>);
 
   @override
-  _i12.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i13.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_11<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_12<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.CachedPresence>(
+            _FakeCachedStreamController_12<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i12.CachedStreamController<_i4.CachedPresence>);
+      ) as _i13.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i12.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i13.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_11<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_12<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.BasicEvent>(
+            _FakeCachedStreamController_12<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i12.CachedStreamController<_i4.BasicEvent>);
+      ) as _i13.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i12.CachedStreamController<_i23.RoomKeyRequest> get onRoomKeyRequest =>
+  _i13.CachedStreamController<_i24.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_11<_i23.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_12<_i24.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i23.RoomKeyRequest>(
+            _FakeCachedStreamController_12<_i24.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i12.CachedStreamController<_i23.RoomKeyRequest>);
+      ) as _i13.CachedStreamController<_i24.RoomKeyRequest>);
 
   @override
-  _i12.CachedStreamController<_i23.KeyVerification>
+  _i13.CachedStreamController<_i24.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_11<_i23.KeyVerification>(
+            returnValue: _FakeCachedStreamController_12<_i24.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_11<_i23.KeyVerification>(
+                _FakeCachedStreamController_12<_i24.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i12.CachedStreamController<_i23.KeyVerification>);
+          ) as _i13.CachedStreamController<_i24.KeyVerification>);
 
   @override
-  _i12.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i13.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_11<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_12<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_12<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i12.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i13.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i13.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_11<_i4.Event>(
+        returnValue: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<String> get onCancelSendEvent =>
+  _i13.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_11<String>(
+        returnValue: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i12.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i13.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_11<
+            returnValue: _FakeCachedStreamController_12<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_11<
+            returnValueForMissingStub: _FakeCachedStreamController_12<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i12.CachedStreamController<
+          ) as _i13.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -3810,11 +3846,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_12(
+        returnValue: _FakeDateTime_13(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_12(
+        returnValueForMissingStub: _FakeDateTime_13(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3887,7 +3923,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i23.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i24.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3942,7 +3978,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i14.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i15.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -3953,7 +3989,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i14.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i15.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -4064,7 +4100,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -4073,7 +4109,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -4082,7 +4118,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4109,20 +4145,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Client get httpClient => (super.noSuchMethod(
+  _i14.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_24(
+        returnValue: _FakeClient_25(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_24(
+        returnValueForMissingStub: _FakeClient_25(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i13.Client);
+      ) as _i14.Client);
 
   @override
-  set httpClient(_i13.Client? value) => super.noSuchMethod(
+  set httpClient(_i14.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4149,7 +4185,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<void> refreshAccessToken(
+  _i15.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4157,9 +4193,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4177,14 +4213,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4221,33 +4257,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i14.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i15.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_25(
+        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_26(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_25(
+        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_26(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i14.Future<_i4.DiscoveryInformation>);
+      ) as _i15.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i14.Future<
+  _i15.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -4269,7 +4305,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i14.Future<
+        returnValue: _i15.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4277,7 +4313,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_26(
+          _FakeGetVersionsResponse_27(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4292,7 +4328,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i14.Future<
+        returnValueForMissingStub: _i15.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4300,7 +4336,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_26(
+          _FakeGetVersionsResponse_27(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4315,7 +4351,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i14.Future<
+      ) as _i15.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -4324,7 +4360,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i14.Future<_i4.DiscoveryInformation> getWellknown({
+  _i15.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4337,8 +4373,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_25(
+        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_26(
           this,
           Invocation.method(
             #getWellknown,
@@ -4349,8 +4385,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_25(
+        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_26(
           this,
           Invocation.method(
             #getWellknown,
@@ -4361,10 +4397,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.DiscoveryInformation>);
+      ) as _i15.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i14.Future<_i4.RegisterResponse> register({
+  _i15.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -4392,7 +4428,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
+            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_28(
           this,
           Invocation.method(
             #register,
@@ -4411,7 +4447,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
+            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_28(
           this,
           Invocation.method(
             #register,
@@ -4429,10 +4465,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RegisterResponse>);
+      ) as _i15.Future<_i4.RegisterResponse>);
 
   @override
-  _i14.Future<_i4.LoginResponse> login(
+  _i15.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -4462,7 +4498,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
+        returnValue: _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_29(
           this,
           Invocation.method(
             #login,
@@ -4482,7 +4518,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
+            _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_29(
           this,
           Invocation.method(
             #login,
@@ -4501,10 +4537,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.LoginResponse>);
+      ) as _i15.Future<_i4.LoginResponse>);
 
   @override
-  _i14.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i15.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4517,8 +4553,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_29(
+        returnValue: _i15.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_30(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4530,8 +4566,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_29(
+            _i15.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_30(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4542,74 +4578,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i15.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logoutAll() => (super.noSuchMethod(
+  _i15.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<T> uiaRequestBackground<T>(
-          _i14.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i15.Future<T> uiaRequestBackground<T>(
+          _i15.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i14.Future<T>.value(v),
+              (T v) => _i15.Future<T>.value(v),
             ) ??
-            _FakeFuture_30<T>(
+            _FakeFuture_31<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i14.Future<T>.value(v),
+              (T v) => _i15.Future<T>.value(v),
             ) ??
-            _FakeFuture_30<T>(
+            _FakeFuture_31<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i14.Future<T>);
+      ) as _i15.Future<T>);
 
   @override
-  _i14.Future<String> startDirectChat(
+  _i15.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -4631,7 +4667,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4647,7 +4683,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4662,10 +4698,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> createGroupChat({
+  _i15.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -4696,7 +4732,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4717,7 +4753,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4737,10 +4773,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i15.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4756,7 +4792,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4769,7 +4805,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4781,21 +4817,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i15.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<String> createSpace({
+  _i15.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -4820,7 +4856,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4838,7 +4874,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4855,10 +4891,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i15.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4866,7 +4902,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4875,7 +4911,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4883,10 +4919,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i14.Future<_i4.Profile> fetchOwnProfile({
+  _i15.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4899,7 +4935,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4911,7 +4947,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4922,10 +4958,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i14.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i15.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4939,8 +4975,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i14.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_31(
+        returnValue: _i15.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_32(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4952,8 +4988,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_31(
+            _i15.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_32(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4964,10 +5000,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.CachedProfileInformation>);
+      ) as _i15.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i14.Future<_i4.Profile> getProfileFromUserId(
+  _i15.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -4985,7 +5021,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4999,7 +5035,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -5012,7 +5048,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -5034,31 +5070,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i14.Future<List<_i4.Room>>);
+            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i15.Future<List<_i4.Room>>);
 
   @override
-  _i14.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i15.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i14.Future<List<_i4.ArchivedRoom>>);
+            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i15.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i14.Future<_i4.GetVersionsResponse> getVersions({
+  _i15.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5071,8 +5107,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_26(
+        returnValue: _i15.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_27(
           this,
           Invocation.method(
             #getVersions,
@@ -5083,8 +5119,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_26(
+        returnValueForMissingStub: _i15.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_27(
           this,
           Invocation.method(
             #getVersions,
@@ -5095,20 +5131,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetVersionsResponse>);
+      ) as _i15.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i14.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i15.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.MediaConfig> getConfig({
+  _i15.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5121,7 +5157,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfig,
@@ -5133,7 +5169,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfig,
@@ -5144,10 +5180,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.MediaConfig>);
+      ) as _i15.Future<_i4.MediaConfig>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContent(
+  _i15.Future<_i16.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5167,7 +5203,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContent,
@@ -5183,7 +5219,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContent,
@@ -5198,10 +5234,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentOverrideName(
+  _i15.Future<_i16.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5223,7 +5259,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5240,7 +5276,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5256,10 +5292,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentThumbnail(
+  _i15.Future<_i16.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5287,7 +5323,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5307,7 +5343,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5326,10 +5362,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i15.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5339,7 +5375,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5348,7 +5384,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5356,11 +5392,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i14.Future<_i4.PreviewForUrl>);
+      ) as _i15.Future<_i4.PreviewForUrl>);
 
   @override
-  _i14.Future<Uri> uploadContent(
-    _i24.Uint8List? file, {
+  _i15.Future<Uri> uploadContent(
+    _i25.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5373,7 +5409,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i14.Future<Uri>.value(_FakeUri_17(
+        returnValue: _i15.Future<Uri>.value(_FakeUri_18(
           this,
           Invocation.method(
             #uploadContent,
@@ -5384,7 +5420,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_17(
+        returnValueForMissingStub: _i15.Future<Uri>.value(_FakeUri_18(
           this,
           Invocation.method(
             #uploadContent,
@@ -5395,10 +5431,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<Uri>);
+      ) as _i15.Future<Uri>);
 
   @override
-  _i14.Future<void> setTyping(
+  _i15.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5414,42 +5450,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> exportDump() => (super.noSuchMethod(
+  _i15.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i15.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i15.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Event?> getEventByPushNotification(
+  _i15.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -5465,12 +5501,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
-  _i14.Future<void> init({
+  _i15.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5505,9 +5541,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5519,40 +5555,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<void> clear() => (super.noSuchMethod(
+  _i15.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i15.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ensureNotSoftLoggedOut(
+  _i15.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSync(
+  _i15.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -5562,9 +5598,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -5577,29 +5613,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i14.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i15.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i15.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDevice(
+  _i15.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5613,12 +5649,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDevicesOfUserIds(
+  _i15.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5634,12 +5670,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDeviceEncrypted(
+  _i15.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5659,12 +5695,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDeviceEncryptedChunked(
+  _i15.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -5678,23 +5714,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i15.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> joinRoom(
+  _i15.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -5712,7 +5748,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5726,7 +5762,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5739,10 +5775,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> changePassword(
+  _i15.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -5758,22 +5794,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> clearCache() => (super.noSuchMethod(
+  _i15.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ignoreUser(
+  _i15.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5783,22 +5819,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i15.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i15.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5809,7 +5845,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_36(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5818,7 +5854,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_36(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5826,32 +5862,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i14.Future<_i4.CachedPresence>);
+      ) as _i15.Future<_i4.CachedPresence>);
 
   @override
-  _i14.Future<void> abortSync() => (super.noSuchMethod(
+  _i15.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i15.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEventWithMetadata(
+  _i15.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5871,14 +5907,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i13.BaseResponse? response,
-    _i24.Uint8List? body,
+    _i14.BaseResponse? response,
+    _i25.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5910,7 +5946,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i14.Future<Map<String, Object?>> request(
+  _i15.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -5931,13 +5967,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> postPusher(
+  _i15.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -5947,57 +5983,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i15.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i15.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i15.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i14.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_36(
+        returnValue: _i15.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_37(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_36(
+        returnValueForMissingStub: _i15.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_37(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.TurnServerCredentials>);
+      ) as _i15.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6011,8 +6047,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6024,8 +6060,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6036,10 +6072,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6055,8 +6091,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6069,8 +6105,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6082,10 +6118,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i15.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6099,7 +6135,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
+        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6111,7 +6147,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
+            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6122,17 +6158,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.KeyBackupData>);
+      ) as _i15.Future<_i4.KeyBackupData>);
 
   @override
-  _i14.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i15.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i14.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_39(
+        returnValue: _i15.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_40(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6140,18 +6176,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_39(
+            _i15.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_40(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i15.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i14.Future<int> pingAppservice(
+  _i15.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6161,12 +6197,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i14.Future<int>.value(0),
-        returnValueForMissingStub: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+        returnValueForMissingStub: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
-  _i14.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i15.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6174,8 +6210,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_40(
+        returnValue: _i15.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_41(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6184,8 +6220,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_40(
+            _i15.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_41(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6193,15 +6229,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i14.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i15.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i14.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i15.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6209,17 +6245,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.MediaConfig>);
+      ) as _i15.Future<_i4.MediaConfig>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentAuthed(
+  _i15.Future<_i16.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6233,7 +6269,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6245,7 +6281,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6256,10 +6292,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentOverrideNameAuthed(
+  _i15.Future<_i16.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6275,7 +6311,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6288,7 +6324,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6300,10 +6336,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i15.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6313,7 +6349,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6322,7 +6358,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6330,10 +6366,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i14.Future<_i4.PreviewForUrl>);
+      ) as _i15.Future<_i4.PreviewForUrl>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentThumbnailAuthed(
+  _i15.Future<_i16.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -6357,7 +6393,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6375,7 +6411,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6392,21 +6428,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<bool> registrationTokenValidity(String? token) =>
+  _i15.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i15.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6416,8 +6452,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_41(
+        returnValue: _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_42(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6426,8 +6462,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_41(
+            _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_42(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6435,10 +6471,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i15.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i14.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i15.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6456,8 +6492,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_42(
+        returnValue: _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_43(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6471,8 +6507,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_42(
+            _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_43(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6485,10 +6521,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i15.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i15.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -6512,8 +6548,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i14.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_43(
+        returnValue: _i15.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_44(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6531,8 +6567,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_43(
+            _i15.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_44(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6549,10 +6585,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i15.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6580,8 +6616,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_44(
+                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6600,8 +6636,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_44(
+                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6619,10 +6655,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i15.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6651,9 +6687,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i14.Future<
+            returnValue: _i15.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6672,9 +6708,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i14.Future<
+            returnValueForMissingStub: _i15.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6693,11 +6729,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i14
+          ) as _i15
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i14.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i15.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -6713,8 +6749,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i14.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_46(
+        returnValue: _i15.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_47(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6727,8 +6763,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_46(
+            _i15.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_47(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6740,10 +6776,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetThreadRootsResponse>);
+      ) as _i15.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i14.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i15.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -6757,8 +6793,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i14.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_47(
+        returnValue: _i15.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_48(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6770,8 +6806,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_47(
+            _i15.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_48(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6782,33 +6818,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i15.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i15.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i14.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i15.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i14.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i15.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i14.Future<Uri?>.value(),
-        returnValueForMissingStub: _i14.Future<Uri?>.value(),
-      ) as _i14.Future<Uri?>);
+        returnValue: _i15.Future<Uri?>.value(),
+        returnValueForMissingStub: _i15.Future<Uri?>.value(),
+      ) as _i15.Future<Uri?>);
 
   @override
-  _i14.Future<void> add3PID(
+  _i15.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -6822,12 +6858,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> bind3PID(
+  _i15.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6843,12 +6879,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i15.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6862,14 +6898,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6891,8 +6927,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6908,8 +6944,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6925,10 +6961,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6952,8 +6988,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6970,8 +7006,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6988,10 +7024,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i15.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -7005,14 +7041,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i15.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -7027,14 +7063,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7056,8 +7092,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7073,8 +7109,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7090,10 +7126,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7117,8 +7153,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7135,8 +7171,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7153,16 +7189,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i15.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
+            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_50(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7170,22 +7206,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
+            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_50(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.TokenOwnerInfo>);
+      ) as _i15.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i14.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i15.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
+        returnValue: _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_51(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7193,22 +7229,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
+            _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_51(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i14.Future<_i4.WhoIsInfo>);
+      ) as _i15.Future<_i4.WhoIsInfo>);
 
   @override
-  _i14.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i15.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
+        returnValue: _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_52(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7216,17 +7252,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
+            _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_52(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.Capabilities>);
+      ) as _i15.Future<_i4.Capabilities>);
 
   @override
-  _i14.Future<String> createRoom({
+  _i15.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -7259,7 +7295,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7281,7 +7317,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7302,10 +7338,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> deleteDevices(
+  _i15.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7315,22 +7351,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.Device>?>.value(),
-      ) as _i14.Future<List<_i4.Device>?>);
+        returnValue: _i15.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.Device>?>.value(),
+      ) as _i15.Future<List<_i4.Device>?>);
 
   @override
-  _i14.Future<void> deleteDevice(
+  _i15.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7340,34 +7376,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i15.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i14.Future<_i4.Device>.value(_FakeDevice_52(
+        returnValue: _i15.Future<_i4.Device>.value(_FakeDevice_53(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Device>.value(_FakeDevice_52(
+        returnValueForMissingStub: _i15.Future<_i4.Device>.value(_FakeDevice_53(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i14.Future<_i4.Device>);
+      ) as _i15.Future<_i4.Device>);
 
   @override
-  _i14.Future<void> updateDevice(
+  _i15.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7377,12 +7413,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i15.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -7397,24 +7433,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i15.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i14.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Visibility?>.value(),
-      ) as _i14.Future<_i4.Visibility?>);
+        returnValue: _i15.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Visibility?>.value(),
+      ) as _i15.Future<_i4.Visibility?>);
 
   @override
-  _i14.Future<void> setRoomVisibilityOnDirectory(
+  _i15.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -7424,30 +7460,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i15.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i15.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_53(
+        returnValue: _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_54(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7455,18 +7491,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_53(
+            _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_54(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i15.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i14.Future<void> setRoomAlias(
+  _i15.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7478,12 +7514,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetEventsResponse> getEvents({
+  _i15.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7497,7 +7533,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
+            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_55(
           this,
           Invocation.method(
             #getEvents,
@@ -7509,7 +7545,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
+            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_55(
           this,
           Invocation.method(
             #getEvents,
@@ -7520,10 +7556,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetEventsResponse>);
+      ) as _i15.Future<_i4.GetEventsResponse>);
 
   @override
-  _i14.Future<_i4.PeekEventsResponse> peekEvents({
+  _i15.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7538,8 +7574,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i14.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_55(
+        returnValue: _i15.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_56(
           this,
           Invocation.method(
             #peekEvents,
@@ -7551,8 +7587,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_55(
+        returnValueForMissingStub: _i15.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_56(
           this,
           Invocation.method(
             #peekEvents,
@@ -7564,16 +7600,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.PeekEventsResponse>);
+      ) as _i15.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i14.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i15.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
+        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7581,27 +7617,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
+            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i14.Future<_i4.MatrixEvent>);
+      ) as _i15.Future<_i4.MatrixEvent>);
 
   @override
-  _i14.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i15.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 
   @override
-  _i14.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i15.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7613,8 +7649,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i14.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_57(
+        returnValue: _i15.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_58(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7625,8 +7661,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_57(
+            _i15.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_58(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7636,10 +7672,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.GetKeysChangesResponse>);
+      ) as _i15.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i14.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i15.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7650,7 +7686,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
+            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_59(
           this,
           Invocation.method(
             #claimKeys,
@@ -7659,7 +7695,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
+            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_59(
           this,
           Invocation.method(
             #claimKeys,
@@ -7667,10 +7703,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i14.Future<_i4.ClaimKeysResponse>);
+      ) as _i15.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i14.Future<void> uploadCrossSigningKeys({
+  _i15.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -7687,12 +7723,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.QueryKeysResponse> queryKeys(
+  _i15.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7703,7 +7739,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
+            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_60(
           this,
           Invocation.method(
             #queryKeys,
@@ -7712,7 +7748,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
+            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_60(
           this,
           Invocation.method(
             #queryKeys,
@@ -7720,10 +7756,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i14.Future<_i4.QueryKeysResponse>);
+      ) as _i15.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7731,14 +7767,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i14.Future<
+            returnValue: _i15.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i14.Future<
+            returnValueForMissingStub: _i15.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i14.Future<Map<String, int>> uploadKeys({
+  _i15.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -7753,13 +7789,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i14.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i15.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i14.Future<Map<String, int>>);
+            _i15.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i15.Future<Map<String, int>>);
 
   @override
-  _i14.Future<String> knockRoom(
+  _i15.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7773,7 +7809,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7785,7 +7821,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7796,20 +7832,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i15.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i14.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i15.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i15.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i14.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i15.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7824,8 +7860,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i14.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_60(
+        returnValue: _i15.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_61(
           this,
           Invocation.method(
             #getNotifications,
@@ -7838,8 +7874,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_60(
+            _i15.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_61(
           this,
           Invocation.method(
             #getNotifications,
@@ -7851,35 +7887,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetNotificationsResponse>);
+      ) as _i15.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i14.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i15.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i14.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_61(
+        returnValue: _i15.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_62(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_61(
+        returnValueForMissingStub: _i15.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_62(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i14.Future<_i4.GetPresenceResponse>);
+      ) as _i15.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i14.Future<void> setPresence(
+  _i15.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -7893,12 +7929,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, Object?>> deleteProfileField(
+  _i15.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7911,13 +7947,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getProfileField(
+  _i15.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7930,13 +7966,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<Map<String, Object?>> setProfileField(
+  _i15.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7951,13 +7987,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i15.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -7972,8 +8008,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i14.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_62(
+        returnValue: _i15.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_63(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7986,8 +8022,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_62(
+            _i15.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_63(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7999,10 +8035,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i15.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i14.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i15.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -8023,8 +8059,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i14.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_63(
+        returnValue: _i15.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_64(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8040,8 +8076,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_63(
+            _i15.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_64(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8056,25 +8092,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i15.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i14.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.Pusher>?>.value(),
-      ) as _i14.Future<List<_i4.Pusher>?>);
+        returnValue: _i15.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.Pusher>?>.value(),
+      ) as _i15.Future<List<_i4.Pusher>?>);
 
   @override
-  _i14.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i15.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
+        returnValue: _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_65(
           this,
           Invocation.method(
             #getPushRules,
@@ -8082,24 +8118,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
+            _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_65(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.PushRuleSet>);
+      ) as _i15.Future<_i4.PushRuleSet>);
 
   @override
-  _i14.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i15.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_65(
+        returnValue: _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_66(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8107,18 +8143,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_65(
+            _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_66(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i15.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i14.Future<void> deletePushRule(
+  _i15.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8130,12 +8166,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.PushRule> getPushRule(
+  _i15.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8147,7 +8183,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<_i4.PushRule>.value(_FakePushRule_66(
+        returnValue: _i15.Future<_i4.PushRule>.value(_FakePushRule_67(
           this,
           Invocation.method(
             #getPushRule,
@@ -8158,7 +8194,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PushRule>.value(_FakePushRule_66(
+            _i15.Future<_i4.PushRule>.value(_FakePushRule_67(
           this,
           Invocation.method(
             #getPushRule,
@@ -8168,10 +8204,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.PushRule>);
+      ) as _i15.Future<_i4.PushRule>);
 
   @override
-  _i14.Future<void> setPushRule(
+  _i15.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -8195,12 +8231,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<Object?>> getPushRuleActions(
+  _i15.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8212,13 +8248,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i15.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i14.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i14.Future<List<Object?>>);
+            _i15.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i15.Future<List<Object?>>);
 
   @override
-  _i14.Future<void> setPushRuleActions(
+  _i15.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -8232,12 +8268,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> isPushRuleEnabled(
+  _i15.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8249,12 +8285,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> setPushRuleEnabled(
+  _i15.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -8268,19 +8304,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i15.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
+            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_68(
           this,
           Invocation.method(
             #refresh,
@@ -8288,28 +8324,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
+            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_68(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i14.Future<_i4.RefreshResponse>);
+      ) as _i15.Future<_i4.RefreshResponse>);
 
   @override
-  _i14.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i15.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i14.Future<bool?>.value(),
-        returnValueForMissingStub: _i14.Future<bool?>.value(),
-      ) as _i14.Future<bool?>);
+        returnValue: _i15.Future<bool?>.value(),
+        returnValueForMissingStub: _i15.Future<bool?>.value(),
+      ) as _i15.Future<bool?>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8331,8 +8367,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8348,8 +8384,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8365,10 +8401,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8392,8 +8428,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8410,8 +8446,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8428,17 +8464,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8446,23 +8482,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i15.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
+        returnValue: _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_69(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8470,17 +8506,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
+            _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_69(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeys>);
+      ) as _i15.Future<_i4.RoomKeys>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -8492,8 +8528,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8504,8 +8540,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8515,10 +8551,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8530,8 +8566,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8542,8 +8578,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8553,10 +8589,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8568,7 +8604,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
+        returnValue: _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_70(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8579,7 +8615,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
+            _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_70(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8589,10 +8625,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeyBackup>);
+      ) as _i15.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -8606,8 +8642,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8619,8 +8655,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8631,10 +8667,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8648,8 +8684,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8661,8 +8697,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8673,10 +8709,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i15.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8690,7 +8726,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
+        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8702,7 +8738,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
+            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8713,10 +8749,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.KeyBackupData>);
+      ) as _i15.Future<_i4.KeyBackupData>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8732,8 +8768,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8746,8 +8782,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8759,18 +8795,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_70(
+                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_71(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8778,18 +8814,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_70(
+                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_71(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i14.Future<String> postRoomKeysVersion(
+  _i15.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -8801,7 +8837,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8812,7 +8848,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8822,29 +8858,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i15.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i15.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_71(
+        returnValue: _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_72(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8852,18 +8888,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_71(
+            _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_72(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i15.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i15.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -8878,24 +8914,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i15.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 
   @override
-  _i14.Future<void> ban(
+  _i15.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8909,12 +8945,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.EventContext> getEventContext(
+  _i15.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -8932,7 +8968,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i4.EventContext>.value(_FakeEventContext_72(
+        returnValue: _i15.Future<_i4.EventContext>.value(_FakeEventContext_73(
           this,
           Invocation.method(
             #getEventContext,
@@ -8947,7 +8983,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.EventContext>.value(_FakeEventContext_72(
+            _i15.Future<_i4.EventContext>.value(_FakeEventContext_73(
           this,
           Invocation.method(
             #getEventContext,
@@ -8961,10 +8997,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.EventContext>);
+      ) as _i15.Future<_i4.EventContext>);
 
   @override
-  _i14.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i15.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -8976,7 +9012,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
+        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8987,7 +9023,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
+            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8997,20 +9033,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.MatrixEvent>);
+      ) as _i15.Future<_i4.MatrixEvent>);
 
   @override
-  _i14.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> inviteBy3PID(
+  _i15.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -9022,12 +9058,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> inviteUser(
+  _i15.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9041,12 +9077,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> joinRoomById(
+  _i15.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -9060,7 +9096,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9072,7 +9108,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9083,23 +9119,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i15.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i15.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i14.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i14.Future<Map<String, _i4.RoomMember>?>);
+            _i15.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i15.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i14.Future<void> kick(
+  _i15.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9113,12 +9149,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> leaveRoom(
+  _i15.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9128,12 +9164,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i15.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -9149,12 +9185,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i14.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i14.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i15.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i15.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i14.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i15.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -9176,8 +9212,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_73(
+        returnValue: _i15.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_74(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9193,8 +9229,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_73(
+        returnValueForMissingStub: _i15.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_74(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9210,10 +9246,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomEventsResponse>);
+      ) as _i15.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i14.Future<void> setReadMarker(
+  _i15.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9229,12 +9265,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> postReceipt(
+  _i15.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -9250,12 +9286,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEvent(
+  _i15.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9271,12 +9307,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> reportRoom(
+  _i15.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9288,12 +9324,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> reportEvent(
+  _i15.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9311,12 +9347,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> sendMessage(
+  _i15.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9332,7 +9368,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9345,7 +9381,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9357,23 +9393,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i15.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i14.Future<List<_i4.MatrixEvent>>);
+            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i15.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i15.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -9390,13 +9426,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<String> setRoomStateWithKey(
+  _i15.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9412,7 +9448,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9425,7 +9461,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9437,10 +9473,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> unban(
+  _i15.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9454,12 +9490,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> upgradeRoom(
+  _i15.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9473,7 +9509,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9485,7 +9521,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9496,10 +9532,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.SearchResults> search(
+  _i15.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -9509,7 +9545,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
+        returnValue: _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_75(
           this,
           Invocation.method(
             #search,
@@ -9518,7 +9554,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
+            _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_75(
           this,
           Invocation.method(
             #search,
@@ -9526,10 +9562,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i14.Future<_i4.SearchResults>);
+      ) as _i15.Future<_i4.SearchResults>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> sync({
+  _i15.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -9550,7 +9586,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #sync,
@@ -9566,7 +9602,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #sync,
@@ -9581,22 +9617,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i15.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i14.Future<List<_i4.Location>>);
+            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i15.Future<List<_i4.Location>>);
 
   @override
-  _i14.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i15.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9606,21 +9642,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i14.Future<List<_i4.Location>>);
+            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i15.Future<List<_i4.Location>>);
 
   @override
-  _i14.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i15.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_75(
+        returnValue: _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_76(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9628,45 +9664,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_75(
+            _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_76(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i14.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i15.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i14.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i15.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9677,13 +9713,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getAccountData(
+  _i15.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9696,13 +9732,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> setAccountData(
+  _i15.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9716,12 +9752,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> defineFilter(
+  _i15.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -9733,7 +9769,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9744,7 +9780,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9754,10 +9790,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.Filter> getFilter(
+  _i15.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9769,7 +9805,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i14.Future<_i4.Filter>.value(_FakeFilter_19(
+        returnValue: _i15.Future<_i4.Filter>.value(_FakeFilter_20(
           this,
           Invocation.method(
             #getFilter,
@@ -9779,7 +9815,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Filter>.value(_FakeFilter_19(
+        returnValueForMissingStub: _i15.Future<_i4.Filter>.value(_FakeFilter_20(
           this,
           Invocation.method(
             #getFilter,
@@ -9789,10 +9825,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.Filter>);
+      ) as _i15.Future<_i4.Filter>);
 
   @override
-  _i14.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i15.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9805,7 +9841,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
+            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_77(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9816,7 +9852,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
+            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_77(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9826,10 +9862,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.OpenIdCredentials>);
+      ) as _i15.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i14.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i15.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9844,13 +9880,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> setAccountDataPerRoom(
+  _i15.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9866,12 +9902,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i15.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9883,12 +9919,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i14.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i14.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i14.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i15.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i15.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i15.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i14.Future<void> deleteRoomTag(
+  _i15.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9902,12 +9938,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setRoomTag(
+  _i15.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9923,12 +9959,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i15.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9938,8 +9974,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i14.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_77(
+        returnValue: _i15.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_78(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9948,8 +9984,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_77(
+            _i15.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_78(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9957,10 +9993,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i14.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i15.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> reportUser(
+  _i15.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -9973,40 +10009,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i15.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i14.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_78(
+        returnValue: _i15.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_79(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_78(
+        returnValueForMissingStub: _i15.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_79(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.CreateContentResponse>);
+      ) as _i15.Future<_i4.CreateContentResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> uploadContentToMXC(
+  _i15.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i24.Uint8List? body, {
+    _i25.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -10024,8 +10060,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 }

--- a/test/widgets/add_room_to_space_dialog_test.mocks.dart
+++ b/test/widgets/add_room_to_space_dialog_test.mocks.dart
@@ -3,14 +3,15 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i14;
-import 'dart:typed_data' as _i24;
-import 'dart:ui' as _i18;
+import 'dart:async' as _i15;
+import 'dart:typed_data' as _i25;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
-import 'package:http/http.dart' as _i13;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
+import 'package:http/http.dart' as _i14;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i12;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -25,14 +26,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i23;
+import 'package:matrix/encryption.dart' as _i24;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i15;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i12;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i16;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i23;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i13;
+import 'package:matrix/src/utils/space_child.dart' as _i22;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -154,8 +155,9 @@ class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
         );
 }
 
-class _FakeRoomSummary_10 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_10(
+class _FakeStickerPackService_10 extends _i1.SmartFake
+    implements _i12.StickerPackService {
+  _FakeStickerPackService_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -164,9 +166,8 @@ class _FakeRoomSummary_10 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_11<T> extends _i1.SmartFake
-    implements _i12.CachedStreamController<T> {
-  _FakeCachedStreamController_11(
+class _FakeRoomSummary_11 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -175,8 +176,9 @@ class _FakeCachedStreamController_11<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_12 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_12(
+class _FakeCachedStreamController_12<T> extends _i1.SmartFake
+    implements _i13.CachedStreamController<T> {
+  _FakeCachedStreamController_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -185,9 +187,19 @@ class _FakeDateTime_12 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_13 extends _i1.SmartFake
+class _FakeDateTime_13 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_13(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_14 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_13(
+  _FakeLatestReceiptState_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -196,8 +208,8 @@ class _FakeLatestReceiptState_13 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_14 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_14(
+class _FakeSyncUpdate_15 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -206,8 +218,8 @@ class _FakeSyncUpdate_14 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeTimeline_15 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_15(
+class _FakeTimeline_16 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -216,8 +228,8 @@ class _FakeTimeline_15 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_16 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_16(
+class _FakeUser_17 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -226,8 +238,8 @@ class _FakeUser_16 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeUri_17 extends _i1.SmartFake implements Uri {
-  _FakeUri_17(
+class _FakeUri_18 extends _i1.SmartFake implements Uri {
+  _FakeUri_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -236,8 +248,8 @@ class _FakeUri_17 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_18 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_18(
+class _FakeDatabaseApi_19 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -246,8 +258,8 @@ class _FakeDatabaseApi_18 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_19 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_19(
+class _FakeFilter_20 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -256,9 +268,9 @@ class _FakeFilter_19 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_20 extends _i1.SmartFake
+class _FakeNativeImplementations_21 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_20(
+  _FakeNativeImplementations_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -267,8 +279,8 @@ class _FakeNativeImplementations_20 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_21 extends _i1.SmartFake implements Duration {
-  _FakeDuration_21(
+class _FakeDuration_22 extends _i1.SmartFake implements Duration {
+  _FakeDuration_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -277,9 +289,9 @@ class _FakeDuration_21 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_22 extends _i1.SmartFake
+class _FakePushruleEvaluator_23 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_22(
+  _FakePushruleEvaluator_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -288,8 +300,8 @@ class _FakePushruleEvaluator_22 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_23 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_23(
+class _FakeProfile_24 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -298,8 +310,8 @@ class _FakeProfile_23 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeClient_24 extends _i1.SmartFake implements _i13.Client {
-  _FakeClient_24(
+class _FakeClient_25 extends _i1.SmartFake implements _i14.Client {
+  _FakeClient_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -308,9 +320,9 @@ class _FakeClient_24 extends _i1.SmartFake implements _i13.Client {
         );
 }
 
-class _FakeDiscoveryInformation_25 extends _i1.SmartFake
+class _FakeDiscoveryInformation_26 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_25(
+  _FakeDiscoveryInformation_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -319,9 +331,9 @@ class _FakeDiscoveryInformation_25 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_26 extends _i1.SmartFake
+class _FakeGetVersionsResponse_27 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_26(
+  _FakeGetVersionsResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -330,9 +342,9 @@ class _FakeGetVersionsResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_27 extends _i1.SmartFake
+class _FakeRegisterResponse_28 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_27(
+  _FakeRegisterResponse_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -341,8 +353,8 @@ class _FakeRegisterResponse_27 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_28 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_28(
+class _FakeLoginResponse_29 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -351,9 +363,9 @@ class _FakeLoginResponse_28 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_29 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_30 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_29(
+  _FakeGetAuthMetadataResponse_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -362,8 +374,8 @@ class _FakeGetAuthMetadataResponse_29 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_30<T1> extends _i1.SmartFake implements _i14.Future<T1> {
-  _FakeFuture_30(
+class _FakeFuture_31<T1> extends _i1.SmartFake implements _i15.Future<T1> {
+  _FakeFuture_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -372,9 +384,9 @@ class _FakeFuture_30<T1> extends _i1.SmartFake implements _i14.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_31 extends _i1.SmartFake
+class _FakeCachedProfileInformation_32 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_31(
+  _FakeCachedProfileInformation_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -383,8 +395,8 @@ class _FakeCachedProfileInformation_31 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_32 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_32(
+class _FakeMediaConfig_33 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -393,8 +405,8 @@ class _FakeMediaConfig_32 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_33 extends _i1.SmartFake implements _i15.FileResponse {
-  _FakeFileResponse_33(
+class _FakeFileResponse_34 extends _i1.SmartFake implements _i16.FileResponse {
+  _FakeFileResponse_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -403,8 +415,8 @@ class _FakeFileResponse_33 extends _i1.SmartFake implements _i15.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_34 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_34(
+class _FakePreviewForUrl_35 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -413,9 +425,9 @@ class _FakePreviewForUrl_34 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_35 extends _i1.SmartFake
+class _FakeCachedPresence_36 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_35(
+  _FakeCachedPresence_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -424,9 +436,9 @@ class _FakeCachedPresence_35 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_36 extends _i1.SmartFake
+class _FakeTurnServerCredentials_37 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_36(
+  _FakeTurnServerCredentials_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -435,9 +447,9 @@ class _FakeTurnServerCredentials_36 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_37 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_38 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_37(
+  _FakeRoomKeysUpdateResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -446,8 +458,8 @@ class _FakeRoomKeysUpdateResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_38 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_38(
+class _FakeKeyBackupData_39 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -456,9 +468,9 @@ class _FakeKeyBackupData_38 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_39 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_40 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_39(
+  _FakeGetWellknownSupportResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -467,9 +479,9 @@ class _FakeGetWellknownSupportResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_40 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_41 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_40(
+  _FakeGenerateLoginTokenResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -478,9 +490,9 @@ class _FakeGenerateLoginTokenResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_41 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_42 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_41(
+  _FakeGetRoomSummaryResponse$3_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -489,9 +501,9 @@ class _FakeGetRoomSummaryResponse$3_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_42 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_43 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_42(
+  _FakeGetSpaceHierarchyResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -500,9 +512,9 @@ class _FakeGetSpaceHierarchyResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_43 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_44 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_43(
+  _FakeGetRelatingEventsResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -511,9 +523,9 @@ class _FakeGetRelatingEventsResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_44 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_45 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_44(
+  _FakeGetRelatingEventsWithRelTypeResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -522,9 +534,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -533,9 +545,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_46 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_47 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_46(
+  _FakeGetThreadRootsResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -544,9 +556,9 @@ class _FakeGetThreadRootsResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_47 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_48 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_47(
+  _FakeGetEventByTimestampResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -555,9 +567,9 @@ class _FakeGetEventByTimestampResponse_47 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_48 extends _i1.SmartFake
+class _FakeRequestTokenResponse_49 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_48(
+  _FakeRequestTokenResponse_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -566,9 +578,9 @@ class _FakeRequestTokenResponse_48 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_49 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_50 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_49(
+  _FakeTokenOwnerInfo_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -577,8 +589,8 @@ class _FakeTokenOwnerInfo_49 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_50 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_50(
+class _FakeWhoIsInfo_51 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -587,8 +599,8 @@ class _FakeWhoIsInfo_50 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_51 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_51(
+class _FakeCapabilities_52 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -597,8 +609,8 @@ class _FakeCapabilities_51 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_52 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_52(
+class _FakeDevice_53 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -607,9 +619,9 @@ class _FakeDevice_52 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_53 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_54 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_53(
+  _FakeGetRoomIdByAliasResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -618,9 +630,9 @@ class _FakeGetRoomIdByAliasResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_54 extends _i1.SmartFake
+class _FakeGetEventsResponse_55 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_54(
+  _FakeGetEventsResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -629,9 +641,9 @@ class _FakeGetEventsResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_55 extends _i1.SmartFake
+class _FakePeekEventsResponse_56 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_55(
+  _FakePeekEventsResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -640,8 +652,8 @@ class _FakePeekEventsResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_56 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_56(
+class _FakeMatrixEvent_57 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -650,9 +662,9 @@ class _FakeMatrixEvent_56 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_57 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_58 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_57(
+  _FakeGetKeysChangesResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -661,9 +673,9 @@ class _FakeGetKeysChangesResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_58 extends _i1.SmartFake
+class _FakeClaimKeysResponse_59 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_58(
+  _FakeClaimKeysResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -672,9 +684,9 @@ class _FakeClaimKeysResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_59 extends _i1.SmartFake
+class _FakeQueryKeysResponse_60 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_59(
+  _FakeQueryKeysResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -683,9 +695,9 @@ class _FakeQueryKeysResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_60 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_61 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_60(
+  _FakeGetNotificationsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -694,9 +706,9 @@ class _FakeGetNotificationsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_61 extends _i1.SmartFake
+class _FakeGetPresenceResponse_62 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_61(
+  _FakeGetPresenceResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -705,9 +717,9 @@ class _FakeGetPresenceResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_62 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_63 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_62(
+  _FakeGetPublicRoomsResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -716,9 +728,9 @@ class _FakeGetPublicRoomsResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_63 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_64 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_63(
+  _FakeQueryPublicRoomsResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -727,8 +739,8 @@ class _FakeQueryPublicRoomsResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_64 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_64(
+class _FakePushRuleSet_65 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -737,9 +749,9 @@ class _FakePushRuleSet_64 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_65 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_66 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_65(
+  _FakeGetPushRulesGlobalResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -748,8 +760,8 @@ class _FakeGetPushRulesGlobalResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_66 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_66(
+class _FakePushRule_67 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -758,9 +770,9 @@ class _FakePushRule_66 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_67 extends _i1.SmartFake
+class _FakeRefreshResponse_68 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_67(
+  _FakeRefreshResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -769,8 +781,8 @@ class _FakeRefreshResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_68 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_68(
+class _FakeRoomKeys_69 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -779,8 +791,8 @@ class _FakeRoomKeys_68 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_69 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_69(
+class _FakeRoomKeyBackup_70 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -789,9 +801,9 @@ class _FakeRoomKeyBackup_69 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_70 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_71 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_70(
+  _FakeGetRoomKeysVersionCurrentResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -800,9 +812,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_71 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_72 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_71(
+  _FakeGetRoomKeysVersionResponse_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -811,8 +823,8 @@ class _FakeGetRoomKeysVersionResponse_71 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_72 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_72(
+class _FakeEventContext_73 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -821,9 +833,9 @@ class _FakeEventContext_72 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_73 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_74 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_73(
+  _FakeGetRoomEventsResponse_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -832,8 +844,8 @@ class _FakeGetRoomEventsResponse_73 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_74 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_74(
+class _FakeSearchResults_75 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,9 +854,9 @@ class _FakeSearchResults_74 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_75 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_76 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_75(
+  _FakeGetProtocolMetadataResponse$2_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -853,9 +865,9 @@ class _FakeGetProtocolMetadataResponse$2_75 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_76 extends _i1.SmartFake
+class _FakeOpenIdCredentials_77 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_76(
+  _FakeOpenIdCredentials_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -864,9 +876,9 @@ class _FakeOpenIdCredentials_76 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_77 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_78 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_77(
+  _FakeSearchUserDirectoryResponse_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -875,9 +887,9 @@ class _FakeSearchUserDirectoryResponse_77 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_78 extends _i1.SmartFake
+class _FakeCreateContentResponse_79 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_78(
+  _FakeCreateContentResponse_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -889,7 +901,7 @@ class _FakeCreateContentResponse_78 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -919,11 +931,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1048,6 +1060,19 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i11.OutboxService);
 
   @override
+  _i12.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i12.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -1145,6 +1170,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set stickerPacks(_i12.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -1152,14 +1186,14 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i15.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1189,7 +1223,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1199,21 +1233,22 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i15.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> login({
+  _i15.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1223,14 +1258,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> completeSsoLogin({
+  _i15.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1243,12 +1279,12 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> completeRegistration(
+  _i15.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1258,32 +1294,32 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i15.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1292,7 +1328,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1301,17 +1337,17 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i15.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1322,7 +1358,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1359,26 +1395,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i15.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+  _i15.Future<bool> didPushRouteInformation(
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1408,7 +1444,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1417,7 +1453,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1426,16 +1462,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i15.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i15.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i14.Future<_i18.AppExitResponse>);
+            _i15.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i15.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1463,11 +1499,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1497,11 +1533,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_10(
+        returnValue: _FakeRoomSummary_11(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_10(
+        returnValueForMissingStub: _FakeRoomSummary_11(
           this,
           Invocation.getter(#summary),
         ),
@@ -1531,11 +1567,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i14.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i15.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i14.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i14.Completer<dynamic>>[],
-      ) as List<_i14.Completer<dynamic>>);
+        returnValue: <_i15.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i15.Completer<dynamic>>[],
+      ) as List<_i15.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1554,51 +1590,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i12.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i13.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_11<String>(
+        returnValue: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i12.CachedStreamController<String> get onSessionKeyReceived =>
+  _i13.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_11<String>(
+        returnValue: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1614,11 +1650,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1627,11 +1663,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1674,11 +1710,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1687,11 +1723,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_12(
+        returnValue: _FakeDateTime_13(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_12(
+        returnValueForMissingStub: _FakeDateTime_13(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -1721,11 +1757,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_13(
+        returnValue: _FakeLatestReceiptState_14(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_13(
+        returnValueForMissingStub: _FakeLatestReceiptState_14(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -1746,18 +1782,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i14.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i15.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -1944,18 +1980,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i22.SpaceParent>[],
+        returnValueForMissingStub: <_i22.SpaceParent>[],
+      ) as List<_i22.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i22.SpaceChild>[],
+        returnValueForMissingStub: <_i22.SpaceChild>[],
+      ) as List<_i22.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -2068,14 +2104,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i14.Future<void> postLoad() => (super.noSuchMethod(
+  _i15.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -2103,15 +2139,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i14.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i15.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i14.Future<List<_i4.User>>);
+            _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i15.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -2122,14 +2158,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2139,18 +2175,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i14.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i15.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Event?> refreshLastEvent(
+  _i15.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2158,9 +2194,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -2172,12 +2208,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i14.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i15.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2185,22 +2221,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i15.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2208,17 +2244,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> addTag(
+  _i15.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2228,27 +2264,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i15.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i15.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2256,53 +2292,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i15.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i15.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+  _i15.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
         Invocation.method(
           #setLowPriority,
           [lowPriority],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i15.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2310,14 +2346,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2329,7 +2365,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i14.Future<String?> sendTextEvent(
+  _i15.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2361,12 +2397,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendReaction(
+  _i15.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2380,12 +2416,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendLocation(
+  _i15.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2399,12 +2435,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendFileEvent(
+  _i15.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2432,25 +2468,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i15.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i14.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i15.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i14.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i15.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i14.Future<_i4.EncryptionHealthState>);
+      ) as _i15.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i14.Future<String?> sendEvent(
+  _i15.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -2474,73 +2510,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i15.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> leave() => (super.noSuchMethod(
+  _i15.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> forget() => (super.noSuchMethod(
+  _i15.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> setPower(
+  _i15.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2552,7 +2588,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2563,7 +2599,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2573,10 +2609,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> invite(
+  _i15.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2586,12 +2622,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<int> requestHistory({
+  _i15.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -2608,32 +2644,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<int>.value(0),
-        returnValueForMissingStub: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+        returnValueForMissingStub: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
-  _i14.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i15.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setReadMarker(
+  _i15.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2647,23 +2683,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
+  _i15.Future<_i23.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i14.Future<_i22.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i14.Future<_i22.TimelineChunk?>.value(),
-      ) as _i14.Future<_i22.TimelineChunk?>);
+        returnValue: _i15.Future<_i23.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i15.Future<_i23.TimelineChunk?>.value(),
+      ) as _i15.Future<_i23.TimelineChunk?>);
 
   @override
-  _i14.Future<void> postReceipt(
+  _i15.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -2673,12 +2709,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Timeline> getTimeline({
+  _i15.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2701,7 +2737,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i14.Future<_i4.Timeline>.value(_FakeTimeline_15(
+        returnValue: _i15.Future<_i4.Timeline>.value(_FakeTimeline_16(
           this,
           Invocation.method(
             #getTimeline,
@@ -2718,7 +2754,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Timeline>.value(_FakeTimeline_15(
+            _i15.Future<_i4.Timeline>.value(_FakeTimeline_16(
           this,
           Invocation.method(
             #getTimeline,
@@ -2734,7 +2770,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Timeline>);
+      ) as _i15.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -2753,7 +2789,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i14.Future<List<_i4.User>> requestParticipants([
+  _i15.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -2771,10 +2807,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i14.Future<List<_i4.User>>);
+            _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i15.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -2782,14 +2818,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_16(
+        returnValue: _FakeUser_17(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_16(
+        returnValueForMissingStub: _FakeUser_17(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -2805,14 +2841,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_16(
+        returnValue: _FakeUser_17(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_16(
+        returnValueForMissingStub: _FakeUser_17(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -2822,7 +2858,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i14.Future<_i4.User?> requestUser(
+  _i15.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2838,19 +2874,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i14.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.User?>.value(),
-      ) as _i14.Future<_i4.User?>);
+        returnValue: _i15.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.User?>.value(),
+      ) as _i15.Future<_i4.User?>);
 
   @override
-  _i14.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i15.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2863,12 +2899,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i14.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i15.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2876,14 +2912,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2906,14 +2942,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i14.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i15.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -2952,18 +2988,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i14.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i15.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEvent(
+  _i15.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -2977,12 +3013,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> setTyping(
+  _i15.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -2992,12 +3028,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setJoinRules(
+  _i15.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -3011,59 +3047,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i15.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setHistoryVisibility(
+  _i15.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i15.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i15.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i15.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i14.Future<List<_i4.DeviceKeys>>);
+            _i15.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i15.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i14.Future<void> requestSessionKey(
+  _i15.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -3075,12 +3111,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setSpaceChild(
+  _i15.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3096,44 +3132,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i15.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i14.Future<Uri>.value(_FakeUri_17(
+        returnValue: _i15.Future<Uri>.value(_FakeUri_18(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_17(
+        returnValueForMissingStub: _i15.Future<Uri>.value(_FakeUri_18(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i14.Future<Uri>);
+      ) as _i15.Future<Uri>);
 
   @override
-  _i14.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<
+  _i15.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -3160,21 +3196,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i14.Future<
+        returnValue: _i15.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i14.Future<
+        returnValueForMissingStub: _i15.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i14.Future<
+      ) as _i15.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -3189,23 +3225,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_18(
+        returnValue: _FakeDatabaseApi_19(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_18(
+        returnValueForMissingStub: _FakeDatabaseApi_19(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i23.KeyVerificationMethod> get verificationMethods =>
+  Set<_i24.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i23.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i23.KeyVerificationMethod>{},
-      ) as Set<_i23.KeyVerificationMethod>);
+        returnValue: <_i24.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i24.KeyVerificationMethod>{},
+      ) as Set<_i24.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3266,11 +3302,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_19(
+        returnValue: _FakeFilter_20(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_19(
+        returnValueForMissingStub: _FakeFilter_20(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -3279,11 +3315,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_20(
+        returnValue: _FakeNativeImplementations_21(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_20(
+        returnValueForMissingStub: _FakeNativeImplementations_21(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -3299,11 +3335,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_21(
+        returnValue: _FakeDuration_22(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_21(
+        returnValueForMissingStub: _FakeDuration_22(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3312,11 +3348,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_21(
+        returnValue: _FakeDuration_22(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_21(
+        returnValueForMissingStub: _FakeDuration_22(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3325,11 +3361,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -3366,11 +3402,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3400,11 +3436,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3413,11 +3449,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3440,11 +3476,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_22(
+        returnValue: _FakePushruleEvaluator_23(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_22(
+        returnValueForMissingStub: _FakePushruleEvaluator_23(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -3465,332 +3501,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i14.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i15.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i12.CachedStreamController<String> get onUserProfileUpdate =>
+  _i13.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_11<String>(
+        returnValue: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i14.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i15.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i14.Future<List<_i4.Room>>);
+            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i15.Future<List<_i4.Room>>);
 
   @override
-  _i12.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i13.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_11<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_12<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.EventUpdate>(
+            _FakeCachedStreamController_12<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.EventUpdate>);
+      ) as _i13.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i13.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_11<_i4.Event>(
+        returnValue: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i13.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_11<_i4.Event>(
+        returnValue: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onNotification =>
+  _i13.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_11<_i4.Event>(
+        returnValue: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i13.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_11<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_12<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_12<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i13.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i12.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i13.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_11<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_12<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_11<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_12<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i12.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i13.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i12.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i13.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_11<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_12<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.LoginState>(
+            _FakeCachedStreamController_12<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i12.CachedStreamController<_i4.LoginState>);
+      ) as _i13.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i12.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i13.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_11<bool>(
+        returnValue: _FakeCachedStreamController_12<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i12.CachedStreamController<bool>);
+      ) as _i13.CachedStreamController<bool>);
 
   @override
-  _i12.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i13.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_11<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_12<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i12.CachedStreamController<_i4.SdkError>);
+      ) as _i13.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i12.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i13.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_11<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_12<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.SyncUpdate>(
+            _FakeCachedStreamController_12<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i12.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i13.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i13.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_11<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_12<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_12<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i12.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i13.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.Presence> get onPresence =>
+  _i13.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_11<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_12<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i12.CachedStreamController<_i4.Presence>);
+      ) as _i13.CachedStreamController<_i4.Presence>);
 
   @override
-  _i12.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i13.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_11<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_12<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.CachedPresence>(
+            _FakeCachedStreamController_12<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i12.CachedStreamController<_i4.CachedPresence>);
+      ) as _i13.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i12.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i13.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_11<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_12<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.BasicEvent>(
+            _FakeCachedStreamController_12<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i12.CachedStreamController<_i4.BasicEvent>);
+      ) as _i13.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i12.CachedStreamController<_i23.RoomKeyRequest> get onRoomKeyRequest =>
+  _i13.CachedStreamController<_i24.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_11<_i23.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_12<_i24.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i23.RoomKeyRequest>(
+            _FakeCachedStreamController_12<_i24.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i12.CachedStreamController<_i23.RoomKeyRequest>);
+      ) as _i13.CachedStreamController<_i24.RoomKeyRequest>);
 
   @override
-  _i12.CachedStreamController<_i23.KeyVerification>
+  _i13.CachedStreamController<_i24.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_11<_i23.KeyVerification>(
+            returnValue: _FakeCachedStreamController_12<_i24.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_11<_i23.KeyVerification>(
+                _FakeCachedStreamController_12<_i24.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i12.CachedStreamController<_i23.KeyVerification>);
+          ) as _i13.CachedStreamController<_i24.KeyVerification>);
 
   @override
-  _i12.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i13.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_11<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_12<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_12<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i12.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i13.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i13.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_11<_i4.Event>(
+        returnValue: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<String> get onCancelSendEvent =>
+  _i13.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_11<String>(
+        returnValue: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i12.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i13.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_11<
+            returnValue: _FakeCachedStreamController_12<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_11<
+            returnValueForMissingStub: _FakeCachedStreamController_12<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i12.CachedStreamController<
+          ) as _i13.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -3810,11 +3846,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_12(
+        returnValue: _FakeDateTime_13(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_12(
+        returnValueForMissingStub: _FakeDateTime_13(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3887,7 +3923,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i23.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i24.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3942,7 +3978,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i14.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i15.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -3953,7 +3989,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i14.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i15.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -4064,7 +4100,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -4073,7 +4109,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -4082,7 +4118,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4109,20 +4145,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Client get httpClient => (super.noSuchMethod(
+  _i14.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_24(
+        returnValue: _FakeClient_25(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_24(
+        returnValueForMissingStub: _FakeClient_25(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i13.Client);
+      ) as _i14.Client);
 
   @override
-  set httpClient(_i13.Client? value) => super.noSuchMethod(
+  set httpClient(_i14.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4149,7 +4185,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<void> refreshAccessToken(
+  _i15.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4157,9 +4193,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4177,14 +4213,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4221,33 +4257,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i14.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i15.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_25(
+        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_26(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_25(
+        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_26(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i14.Future<_i4.DiscoveryInformation>);
+      ) as _i15.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i14.Future<
+  _i15.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -4269,7 +4305,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i14.Future<
+        returnValue: _i15.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4277,7 +4313,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_26(
+          _FakeGetVersionsResponse_27(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4292,7 +4328,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i14.Future<
+        returnValueForMissingStub: _i15.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4300,7 +4336,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_26(
+          _FakeGetVersionsResponse_27(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4315,7 +4351,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i14.Future<
+      ) as _i15.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -4324,7 +4360,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i14.Future<_i4.DiscoveryInformation> getWellknown({
+  _i15.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4337,8 +4373,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_25(
+        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_26(
           this,
           Invocation.method(
             #getWellknown,
@@ -4349,8 +4385,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_25(
+        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_26(
           this,
           Invocation.method(
             #getWellknown,
@@ -4361,10 +4397,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.DiscoveryInformation>);
+      ) as _i15.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i14.Future<_i4.RegisterResponse> register({
+  _i15.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -4392,7 +4428,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
+            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_28(
           this,
           Invocation.method(
             #register,
@@ -4411,7 +4447,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
+            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_28(
           this,
           Invocation.method(
             #register,
@@ -4429,10 +4465,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RegisterResponse>);
+      ) as _i15.Future<_i4.RegisterResponse>);
 
   @override
-  _i14.Future<_i4.LoginResponse> login(
+  _i15.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -4462,7 +4498,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
+        returnValue: _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_29(
           this,
           Invocation.method(
             #login,
@@ -4482,7 +4518,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
+            _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_29(
           this,
           Invocation.method(
             #login,
@@ -4501,10 +4537,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.LoginResponse>);
+      ) as _i15.Future<_i4.LoginResponse>);
 
   @override
-  _i14.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i15.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4517,8 +4553,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_29(
+        returnValue: _i15.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_30(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4530,8 +4566,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_29(
+            _i15.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_30(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4542,74 +4578,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i15.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logoutAll() => (super.noSuchMethod(
+  _i15.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<T> uiaRequestBackground<T>(
-          _i14.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i15.Future<T> uiaRequestBackground<T>(
+          _i15.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i14.Future<T>.value(v),
+              (T v) => _i15.Future<T>.value(v),
             ) ??
-            _FakeFuture_30<T>(
+            _FakeFuture_31<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i14.Future<T>.value(v),
+              (T v) => _i15.Future<T>.value(v),
             ) ??
-            _FakeFuture_30<T>(
+            _FakeFuture_31<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i14.Future<T>);
+      ) as _i15.Future<T>);
 
   @override
-  _i14.Future<String> startDirectChat(
+  _i15.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -4631,7 +4667,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4647,7 +4683,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4662,10 +4698,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> createGroupChat({
+  _i15.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -4696,7 +4732,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4717,7 +4753,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4737,10 +4773,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i15.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4756,7 +4792,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4769,7 +4805,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4781,21 +4817,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i15.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<String> createSpace({
+  _i15.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -4820,7 +4856,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4838,7 +4874,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4855,10 +4891,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i15.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4866,7 +4902,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4875,7 +4911,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4883,10 +4919,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i14.Future<_i4.Profile> fetchOwnProfile({
+  _i15.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4899,7 +4935,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4911,7 +4947,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4922,10 +4958,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i14.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i15.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4939,8 +4975,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i14.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_31(
+        returnValue: _i15.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_32(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4952,8 +4988,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_31(
+            _i15.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_32(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4964,10 +5000,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.CachedProfileInformation>);
+      ) as _i15.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i14.Future<_i4.Profile> getProfileFromUserId(
+  _i15.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -4985,7 +5021,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4999,7 +5035,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -5012,7 +5048,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -5034,31 +5070,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i14.Future<List<_i4.Room>>);
+            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i15.Future<List<_i4.Room>>);
 
   @override
-  _i14.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i15.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i14.Future<List<_i4.ArchivedRoom>>);
+            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i15.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i14.Future<_i4.GetVersionsResponse> getVersions({
+  _i15.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5071,8 +5107,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_26(
+        returnValue: _i15.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_27(
           this,
           Invocation.method(
             #getVersions,
@@ -5083,8 +5119,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_26(
+        returnValueForMissingStub: _i15.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_27(
           this,
           Invocation.method(
             #getVersions,
@@ -5095,20 +5131,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetVersionsResponse>);
+      ) as _i15.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i14.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i15.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.MediaConfig> getConfig({
+  _i15.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5121,7 +5157,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfig,
@@ -5133,7 +5169,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfig,
@@ -5144,10 +5180,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.MediaConfig>);
+      ) as _i15.Future<_i4.MediaConfig>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContent(
+  _i15.Future<_i16.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5167,7 +5203,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContent,
@@ -5183,7 +5219,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContent,
@@ -5198,10 +5234,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentOverrideName(
+  _i15.Future<_i16.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5223,7 +5259,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5240,7 +5276,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5256,10 +5292,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentThumbnail(
+  _i15.Future<_i16.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5287,7 +5323,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5307,7 +5343,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5326,10 +5362,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i15.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5339,7 +5375,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5348,7 +5384,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5356,11 +5392,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i14.Future<_i4.PreviewForUrl>);
+      ) as _i15.Future<_i4.PreviewForUrl>);
 
   @override
-  _i14.Future<Uri> uploadContent(
-    _i24.Uint8List? file, {
+  _i15.Future<Uri> uploadContent(
+    _i25.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5373,7 +5409,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i14.Future<Uri>.value(_FakeUri_17(
+        returnValue: _i15.Future<Uri>.value(_FakeUri_18(
           this,
           Invocation.method(
             #uploadContent,
@@ -5384,7 +5420,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_17(
+        returnValueForMissingStub: _i15.Future<Uri>.value(_FakeUri_18(
           this,
           Invocation.method(
             #uploadContent,
@@ -5395,10 +5431,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<Uri>);
+      ) as _i15.Future<Uri>);
 
   @override
-  _i14.Future<void> setTyping(
+  _i15.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5414,42 +5450,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> exportDump() => (super.noSuchMethod(
+  _i15.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i15.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i15.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Event?> getEventByPushNotification(
+  _i15.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -5465,12 +5501,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
-  _i14.Future<void> init({
+  _i15.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5505,9 +5541,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5519,40 +5555,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<void> clear() => (super.noSuchMethod(
+  _i15.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i15.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ensureNotSoftLoggedOut(
+  _i15.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSync(
+  _i15.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -5562,9 +5598,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -5577,29 +5613,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i14.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i15.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i15.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDevice(
+  _i15.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5613,12 +5649,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDevicesOfUserIds(
+  _i15.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5634,12 +5670,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDeviceEncrypted(
+  _i15.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5659,12 +5695,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDeviceEncryptedChunked(
+  _i15.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -5678,23 +5714,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i15.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> joinRoom(
+  _i15.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -5712,7 +5748,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5726,7 +5762,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5739,10 +5775,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> changePassword(
+  _i15.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -5758,22 +5794,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> clearCache() => (super.noSuchMethod(
+  _i15.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ignoreUser(
+  _i15.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5783,22 +5819,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i15.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i15.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5809,7 +5845,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_36(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5818,7 +5854,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_36(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5826,32 +5862,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i14.Future<_i4.CachedPresence>);
+      ) as _i15.Future<_i4.CachedPresence>);
 
   @override
-  _i14.Future<void> abortSync() => (super.noSuchMethod(
+  _i15.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i15.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEventWithMetadata(
+  _i15.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5871,14 +5907,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i13.BaseResponse? response,
-    _i24.Uint8List? body,
+    _i14.BaseResponse? response,
+    _i25.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5910,7 +5946,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i14.Future<Map<String, Object?>> request(
+  _i15.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -5931,13 +5967,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> postPusher(
+  _i15.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -5947,57 +5983,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i15.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i15.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i15.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i14.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_36(
+        returnValue: _i15.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_37(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_36(
+        returnValueForMissingStub: _i15.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_37(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.TurnServerCredentials>);
+      ) as _i15.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6011,8 +6047,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6024,8 +6060,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6036,10 +6072,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6055,8 +6091,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6069,8 +6105,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6082,10 +6118,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i15.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6099,7 +6135,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
+        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6111,7 +6147,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
+            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6122,17 +6158,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.KeyBackupData>);
+      ) as _i15.Future<_i4.KeyBackupData>);
 
   @override
-  _i14.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i15.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i14.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_39(
+        returnValue: _i15.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_40(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6140,18 +6176,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_39(
+            _i15.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_40(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i15.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i14.Future<int> pingAppservice(
+  _i15.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6161,12 +6197,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i14.Future<int>.value(0),
-        returnValueForMissingStub: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+        returnValueForMissingStub: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
-  _i14.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i15.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6174,8 +6210,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_40(
+        returnValue: _i15.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_41(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6184,8 +6220,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_40(
+            _i15.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_41(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6193,15 +6229,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i14.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i15.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i14.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i15.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6209,17 +6245,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.MediaConfig>);
+      ) as _i15.Future<_i4.MediaConfig>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentAuthed(
+  _i15.Future<_i16.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6233,7 +6269,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6245,7 +6281,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6256,10 +6292,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentOverrideNameAuthed(
+  _i15.Future<_i16.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6275,7 +6311,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6288,7 +6324,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6300,10 +6336,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i15.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6313,7 +6349,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6322,7 +6358,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6330,10 +6366,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i14.Future<_i4.PreviewForUrl>);
+      ) as _i15.Future<_i4.PreviewForUrl>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentThumbnailAuthed(
+  _i15.Future<_i16.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -6357,7 +6393,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6375,7 +6411,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6392,21 +6428,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<bool> registrationTokenValidity(String? token) =>
+  _i15.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i15.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6416,8 +6452,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_41(
+        returnValue: _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_42(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6426,8 +6462,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_41(
+            _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_42(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6435,10 +6471,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i15.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i14.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i15.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6456,8 +6492,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_42(
+        returnValue: _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_43(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6471,8 +6507,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_42(
+            _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_43(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6485,10 +6521,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i15.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i15.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -6512,8 +6548,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i14.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_43(
+        returnValue: _i15.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_44(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6531,8 +6567,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_43(
+            _i15.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_44(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6549,10 +6585,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i15.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6580,8 +6616,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_44(
+                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6600,8 +6636,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_44(
+                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6619,10 +6655,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i15.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6651,9 +6687,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i14.Future<
+            returnValue: _i15.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6672,9 +6708,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i14.Future<
+            returnValueForMissingStub: _i15.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6693,11 +6729,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i14
+          ) as _i15
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i14.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i15.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -6713,8 +6749,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i14.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_46(
+        returnValue: _i15.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_47(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6727,8 +6763,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_46(
+            _i15.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_47(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6740,10 +6776,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetThreadRootsResponse>);
+      ) as _i15.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i14.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i15.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -6757,8 +6793,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i14.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_47(
+        returnValue: _i15.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_48(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6770,8 +6806,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_47(
+            _i15.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_48(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6782,33 +6818,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i15.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i15.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i14.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i15.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i14.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i15.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i14.Future<Uri?>.value(),
-        returnValueForMissingStub: _i14.Future<Uri?>.value(),
-      ) as _i14.Future<Uri?>);
+        returnValue: _i15.Future<Uri?>.value(),
+        returnValueForMissingStub: _i15.Future<Uri?>.value(),
+      ) as _i15.Future<Uri?>);
 
   @override
-  _i14.Future<void> add3PID(
+  _i15.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -6822,12 +6858,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> bind3PID(
+  _i15.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6843,12 +6879,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i15.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6862,14 +6898,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6891,8 +6927,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6908,8 +6944,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6925,10 +6961,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6952,8 +6988,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6970,8 +7006,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6988,10 +7024,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i15.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -7005,14 +7041,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i15.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -7027,14 +7063,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7056,8 +7092,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7073,8 +7109,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7090,10 +7126,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7117,8 +7153,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7135,8 +7171,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7153,16 +7189,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i15.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
+            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_50(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7170,22 +7206,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
+            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_50(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.TokenOwnerInfo>);
+      ) as _i15.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i14.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i15.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
+        returnValue: _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_51(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7193,22 +7229,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
+            _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_51(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i14.Future<_i4.WhoIsInfo>);
+      ) as _i15.Future<_i4.WhoIsInfo>);
 
   @override
-  _i14.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i15.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
+        returnValue: _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_52(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7216,17 +7252,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
+            _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_52(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.Capabilities>);
+      ) as _i15.Future<_i4.Capabilities>);
 
   @override
-  _i14.Future<String> createRoom({
+  _i15.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -7259,7 +7295,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7281,7 +7317,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7302,10 +7338,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> deleteDevices(
+  _i15.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7315,22 +7351,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.Device>?>.value(),
-      ) as _i14.Future<List<_i4.Device>?>);
+        returnValue: _i15.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.Device>?>.value(),
+      ) as _i15.Future<List<_i4.Device>?>);
 
   @override
-  _i14.Future<void> deleteDevice(
+  _i15.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7340,34 +7376,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i15.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i14.Future<_i4.Device>.value(_FakeDevice_52(
+        returnValue: _i15.Future<_i4.Device>.value(_FakeDevice_53(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Device>.value(_FakeDevice_52(
+        returnValueForMissingStub: _i15.Future<_i4.Device>.value(_FakeDevice_53(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i14.Future<_i4.Device>);
+      ) as _i15.Future<_i4.Device>);
 
   @override
-  _i14.Future<void> updateDevice(
+  _i15.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7377,12 +7413,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i15.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -7397,24 +7433,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i15.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i14.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Visibility?>.value(),
-      ) as _i14.Future<_i4.Visibility?>);
+        returnValue: _i15.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Visibility?>.value(),
+      ) as _i15.Future<_i4.Visibility?>);
 
   @override
-  _i14.Future<void> setRoomVisibilityOnDirectory(
+  _i15.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -7424,30 +7460,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i15.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i15.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_53(
+        returnValue: _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_54(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7455,18 +7491,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_53(
+            _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_54(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i15.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i14.Future<void> setRoomAlias(
+  _i15.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7478,12 +7514,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetEventsResponse> getEvents({
+  _i15.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7497,7 +7533,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
+            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_55(
           this,
           Invocation.method(
             #getEvents,
@@ -7509,7 +7545,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
+            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_55(
           this,
           Invocation.method(
             #getEvents,
@@ -7520,10 +7556,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetEventsResponse>);
+      ) as _i15.Future<_i4.GetEventsResponse>);
 
   @override
-  _i14.Future<_i4.PeekEventsResponse> peekEvents({
+  _i15.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7538,8 +7574,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i14.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_55(
+        returnValue: _i15.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_56(
           this,
           Invocation.method(
             #peekEvents,
@@ -7551,8 +7587,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_55(
+        returnValueForMissingStub: _i15.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_56(
           this,
           Invocation.method(
             #peekEvents,
@@ -7564,16 +7600,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.PeekEventsResponse>);
+      ) as _i15.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i14.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i15.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
+        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7581,27 +7617,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
+            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i14.Future<_i4.MatrixEvent>);
+      ) as _i15.Future<_i4.MatrixEvent>);
 
   @override
-  _i14.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i15.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 
   @override
-  _i14.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i15.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7613,8 +7649,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i14.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_57(
+        returnValue: _i15.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_58(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7625,8 +7661,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_57(
+            _i15.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_58(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7636,10 +7672,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.GetKeysChangesResponse>);
+      ) as _i15.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i14.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i15.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7650,7 +7686,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
+            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_59(
           this,
           Invocation.method(
             #claimKeys,
@@ -7659,7 +7695,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
+            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_59(
           this,
           Invocation.method(
             #claimKeys,
@@ -7667,10 +7703,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i14.Future<_i4.ClaimKeysResponse>);
+      ) as _i15.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i14.Future<void> uploadCrossSigningKeys({
+  _i15.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -7687,12 +7723,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.QueryKeysResponse> queryKeys(
+  _i15.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7703,7 +7739,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
+            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_60(
           this,
           Invocation.method(
             #queryKeys,
@@ -7712,7 +7748,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
+            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_60(
           this,
           Invocation.method(
             #queryKeys,
@@ -7720,10 +7756,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i14.Future<_i4.QueryKeysResponse>);
+      ) as _i15.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7731,14 +7767,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i14.Future<
+            returnValue: _i15.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i14.Future<
+            returnValueForMissingStub: _i15.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i14.Future<Map<String, int>> uploadKeys({
+  _i15.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -7753,13 +7789,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i14.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i15.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i14.Future<Map<String, int>>);
+            _i15.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i15.Future<Map<String, int>>);
 
   @override
-  _i14.Future<String> knockRoom(
+  _i15.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7773,7 +7809,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7785,7 +7821,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7796,20 +7832,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i15.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i14.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i15.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i15.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i14.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i15.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7824,8 +7860,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i14.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_60(
+        returnValue: _i15.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_61(
           this,
           Invocation.method(
             #getNotifications,
@@ -7838,8 +7874,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_60(
+            _i15.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_61(
           this,
           Invocation.method(
             #getNotifications,
@@ -7851,35 +7887,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetNotificationsResponse>);
+      ) as _i15.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i14.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i15.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i14.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_61(
+        returnValue: _i15.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_62(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_61(
+        returnValueForMissingStub: _i15.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_62(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i14.Future<_i4.GetPresenceResponse>);
+      ) as _i15.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i14.Future<void> setPresence(
+  _i15.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -7893,12 +7929,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, Object?>> deleteProfileField(
+  _i15.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7911,13 +7947,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getProfileField(
+  _i15.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7930,13 +7966,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<Map<String, Object?>> setProfileField(
+  _i15.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7951,13 +7987,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i15.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -7972,8 +8008,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i14.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_62(
+        returnValue: _i15.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_63(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7986,8 +8022,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_62(
+            _i15.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_63(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7999,10 +8035,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i15.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i14.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i15.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -8023,8 +8059,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i14.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_63(
+        returnValue: _i15.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_64(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8040,8 +8076,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_63(
+            _i15.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_64(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8056,25 +8092,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i15.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i14.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.Pusher>?>.value(),
-      ) as _i14.Future<List<_i4.Pusher>?>);
+        returnValue: _i15.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.Pusher>?>.value(),
+      ) as _i15.Future<List<_i4.Pusher>?>);
 
   @override
-  _i14.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i15.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
+        returnValue: _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_65(
           this,
           Invocation.method(
             #getPushRules,
@@ -8082,24 +8118,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
+            _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_65(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.PushRuleSet>);
+      ) as _i15.Future<_i4.PushRuleSet>);
 
   @override
-  _i14.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i15.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_65(
+        returnValue: _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_66(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8107,18 +8143,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_65(
+            _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_66(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i15.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i14.Future<void> deletePushRule(
+  _i15.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8130,12 +8166,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.PushRule> getPushRule(
+  _i15.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8147,7 +8183,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<_i4.PushRule>.value(_FakePushRule_66(
+        returnValue: _i15.Future<_i4.PushRule>.value(_FakePushRule_67(
           this,
           Invocation.method(
             #getPushRule,
@@ -8158,7 +8194,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PushRule>.value(_FakePushRule_66(
+            _i15.Future<_i4.PushRule>.value(_FakePushRule_67(
           this,
           Invocation.method(
             #getPushRule,
@@ -8168,10 +8204,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.PushRule>);
+      ) as _i15.Future<_i4.PushRule>);
 
   @override
-  _i14.Future<void> setPushRule(
+  _i15.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -8195,12 +8231,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<Object?>> getPushRuleActions(
+  _i15.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8212,13 +8248,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i15.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i14.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i14.Future<List<Object?>>);
+            _i15.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i15.Future<List<Object?>>);
 
   @override
-  _i14.Future<void> setPushRuleActions(
+  _i15.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -8232,12 +8268,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> isPushRuleEnabled(
+  _i15.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8249,12 +8285,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> setPushRuleEnabled(
+  _i15.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -8268,19 +8304,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i15.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
+            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_68(
           this,
           Invocation.method(
             #refresh,
@@ -8288,28 +8324,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
+            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_68(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i14.Future<_i4.RefreshResponse>);
+      ) as _i15.Future<_i4.RefreshResponse>);
 
   @override
-  _i14.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i15.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i14.Future<bool?>.value(),
-        returnValueForMissingStub: _i14.Future<bool?>.value(),
-      ) as _i14.Future<bool?>);
+        returnValue: _i15.Future<bool?>.value(),
+        returnValueForMissingStub: _i15.Future<bool?>.value(),
+      ) as _i15.Future<bool?>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8331,8 +8367,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8348,8 +8384,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8365,10 +8401,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8392,8 +8428,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8410,8 +8446,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8428,17 +8464,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8446,23 +8482,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i15.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
+        returnValue: _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_69(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8470,17 +8506,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
+            _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_69(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeys>);
+      ) as _i15.Future<_i4.RoomKeys>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -8492,8 +8528,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8504,8 +8540,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8515,10 +8551,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8530,8 +8566,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8542,8 +8578,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8553,10 +8589,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8568,7 +8604,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
+        returnValue: _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_70(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8579,7 +8615,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
+            _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_70(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8589,10 +8625,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeyBackup>);
+      ) as _i15.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -8606,8 +8642,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8619,8 +8655,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8631,10 +8667,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8648,8 +8684,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8661,8 +8697,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8673,10 +8709,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i15.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8690,7 +8726,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
+        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8702,7 +8738,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
+            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8713,10 +8749,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.KeyBackupData>);
+      ) as _i15.Future<_i4.KeyBackupData>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8732,8 +8768,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8746,8 +8782,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8759,18 +8795,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_70(
+                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_71(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8778,18 +8814,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_70(
+                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_71(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i14.Future<String> postRoomKeysVersion(
+  _i15.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -8801,7 +8837,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8812,7 +8848,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8822,29 +8858,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i15.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i15.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_71(
+        returnValue: _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_72(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8852,18 +8888,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_71(
+            _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_72(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i15.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i15.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -8878,24 +8914,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i15.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 
   @override
-  _i14.Future<void> ban(
+  _i15.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8909,12 +8945,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.EventContext> getEventContext(
+  _i15.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -8932,7 +8968,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i4.EventContext>.value(_FakeEventContext_72(
+        returnValue: _i15.Future<_i4.EventContext>.value(_FakeEventContext_73(
           this,
           Invocation.method(
             #getEventContext,
@@ -8947,7 +8983,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.EventContext>.value(_FakeEventContext_72(
+            _i15.Future<_i4.EventContext>.value(_FakeEventContext_73(
           this,
           Invocation.method(
             #getEventContext,
@@ -8961,10 +8997,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.EventContext>);
+      ) as _i15.Future<_i4.EventContext>);
 
   @override
-  _i14.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i15.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -8976,7 +9012,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
+        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8987,7 +9023,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
+            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8997,20 +9033,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.MatrixEvent>);
+      ) as _i15.Future<_i4.MatrixEvent>);
 
   @override
-  _i14.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> inviteBy3PID(
+  _i15.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -9022,12 +9058,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> inviteUser(
+  _i15.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9041,12 +9077,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> joinRoomById(
+  _i15.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -9060,7 +9096,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9072,7 +9108,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9083,23 +9119,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i15.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i15.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i14.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i14.Future<Map<String, _i4.RoomMember>?>);
+            _i15.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i15.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i14.Future<void> kick(
+  _i15.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9113,12 +9149,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> leaveRoom(
+  _i15.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9128,12 +9164,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i15.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -9149,12 +9185,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i14.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i14.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i15.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i15.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i14.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i15.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -9176,8 +9212,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_73(
+        returnValue: _i15.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_74(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9193,8 +9229,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_73(
+        returnValueForMissingStub: _i15.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_74(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9210,10 +9246,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomEventsResponse>);
+      ) as _i15.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i14.Future<void> setReadMarker(
+  _i15.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9229,12 +9265,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> postReceipt(
+  _i15.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -9250,12 +9286,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEvent(
+  _i15.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9271,12 +9307,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> reportRoom(
+  _i15.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9288,12 +9324,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> reportEvent(
+  _i15.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9311,12 +9347,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> sendMessage(
+  _i15.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9332,7 +9368,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9345,7 +9381,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9357,23 +9393,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i15.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i14.Future<List<_i4.MatrixEvent>>);
+            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i15.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i15.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -9390,13 +9426,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<String> setRoomStateWithKey(
+  _i15.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9412,7 +9448,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9425,7 +9461,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9437,10 +9473,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> unban(
+  _i15.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9454,12 +9490,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> upgradeRoom(
+  _i15.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9473,7 +9509,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9485,7 +9521,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9496,10 +9532,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.SearchResults> search(
+  _i15.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -9509,7 +9545,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
+        returnValue: _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_75(
           this,
           Invocation.method(
             #search,
@@ -9518,7 +9554,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
+            _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_75(
           this,
           Invocation.method(
             #search,
@@ -9526,10 +9562,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i14.Future<_i4.SearchResults>);
+      ) as _i15.Future<_i4.SearchResults>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> sync({
+  _i15.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -9550,7 +9586,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #sync,
@@ -9566,7 +9602,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #sync,
@@ -9581,22 +9617,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i15.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i14.Future<List<_i4.Location>>);
+            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i15.Future<List<_i4.Location>>);
 
   @override
-  _i14.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i15.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9606,21 +9642,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i14.Future<List<_i4.Location>>);
+            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i15.Future<List<_i4.Location>>);
 
   @override
-  _i14.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i15.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_75(
+        returnValue: _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_76(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9628,45 +9664,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_75(
+            _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_76(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i14.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i15.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i14.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i15.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9677,13 +9713,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getAccountData(
+  _i15.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9696,13 +9732,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> setAccountData(
+  _i15.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9716,12 +9752,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> defineFilter(
+  _i15.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -9733,7 +9769,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9744,7 +9780,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9754,10 +9790,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.Filter> getFilter(
+  _i15.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9769,7 +9805,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i14.Future<_i4.Filter>.value(_FakeFilter_19(
+        returnValue: _i15.Future<_i4.Filter>.value(_FakeFilter_20(
           this,
           Invocation.method(
             #getFilter,
@@ -9779,7 +9815,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Filter>.value(_FakeFilter_19(
+        returnValueForMissingStub: _i15.Future<_i4.Filter>.value(_FakeFilter_20(
           this,
           Invocation.method(
             #getFilter,
@@ -9789,10 +9825,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.Filter>);
+      ) as _i15.Future<_i4.Filter>);
 
   @override
-  _i14.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i15.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9805,7 +9841,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
+            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_77(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9816,7 +9852,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
+            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_77(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9826,10 +9862,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.OpenIdCredentials>);
+      ) as _i15.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i14.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i15.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9844,13 +9880,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> setAccountDataPerRoom(
+  _i15.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9866,12 +9902,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i15.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9883,12 +9919,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i14.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i14.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i14.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i15.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i15.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i15.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i14.Future<void> deleteRoomTag(
+  _i15.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9902,12 +9938,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setRoomTag(
+  _i15.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9923,12 +9959,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i15.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9938,8 +9974,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i14.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_77(
+        returnValue: _i15.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_78(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9948,8 +9984,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_77(
+            _i15.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_78(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9957,10 +9993,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i14.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i15.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> reportUser(
+  _i15.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -9973,40 +10009,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i15.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i14.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_78(
+        returnValue: _i15.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_79(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_78(
+        returnValueForMissingStub: _i15.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_79(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.CreateContentResponse>);
+      ) as _i15.Future<_i4.CreateContentResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> uploadContentToMXC(
+  _i15.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i24.Uint8List? body, {
+    _i25.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -10024,8 +10060,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 }

--- a/test/widgets/admin_settings_section_test.mocks.dart
+++ b/test/widgets/admin_settings_section_test.mocks.dart
@@ -4,14 +4,15 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i20;
-import 'dart:ui' as _i22;
+import 'dart:typed_data' as _i21;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/models/join_mode.dart' as _i25;
-import 'package:kohera/core/services/matrix_service.dart' as _i21;
+import 'package:kohera/core/models/join_mode.dart' as _i26;
+import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -26,14 +27,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i19;
+import 'package:matrix/encryption.dart' as _i20;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i18;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i19;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i17;
+import 'package:matrix/src/utils/space_child.dart' as _i18;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i16;
+import 'package:mockito/src/dummies.dart' as _i17;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -888,8 +889,19 @@ class _FakeOutboxService_78 extends _i1.SmartFake
         );
 }
 
-class _FakeStateEvent_79 extends _i1.SmartFake implements _i2.StateEvent {
-  _FakeStateEvent_79(
+class _FakeStickerPackService_79 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_79(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeStateEvent_80 extends _i1.SmartFake implements _i2.StateEvent {
+  _FakeStateEvent_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -905,11 +917,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -996,11 +1008,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -1036,11 +1048,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1056,11 +1068,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1069,11 +1081,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1116,11 +1128,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1386,18 +1398,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i17.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i18.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i17.SpaceParent>[],
-        returnValueForMissingStub: <_i17.SpaceParent>[],
-      ) as List<_i17.SpaceParent>);
+        returnValue: <_i18.SpaceParent>[],
+        returnValueForMissingStub: <_i18.SpaceParent>[],
+      ) as List<_i18.SpaceParent>);
 
   @override
-  List<_i17.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i18.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i17.SpaceChild>[],
-        returnValueForMissingStub: <_i17.SpaceChild>[],
-      ) as List<_i17.SpaceChild>);
+        returnValue: <_i18.SpaceChild>[],
+        returnValueForMissingStub: <_i18.SpaceChild>[],
+      ) as List<_i18.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -1564,14 +1576,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -1619,7 +1631,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -1627,7 +1639,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -1642,7 +1654,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -1650,7 +1662,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -1744,7 +1756,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -1752,7 +1764,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -1994,7 +2006,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2005,7 +2017,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2094,15 +2106,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i18.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i19.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i18.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i18.TimelineChunk?>.value(),
-      ) as _i5.Future<_i18.TimelineChunk?>);
+        returnValue: _i5.Future<_i19.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i19.TimelineChunk?>.value(),
+      ) as _i5.Future<_i19.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -2310,7 +2322,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2318,7 +2330,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2641,12 +2653,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i19.KeyVerificationMethod> get verificationMethods =>
+  Set<_i20.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i19.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i19.KeyVerificationMethod>{},
-      ) as Set<_i19.KeyVerificationMethod>);
+        returnValue: <_i20.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i20.KeyVerificationMethod>{},
+      ) as Set<_i20.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -2766,11 +2778,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -2807,11 +2819,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -2841,11 +2853,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -2854,11 +2866,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3145,34 +3157,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i19.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i20.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_1<_i19.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_1<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_1<_i19.RoomKeyRequest>(
+            _FakeCachedStreamController_1<_i20.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i19.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i20.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i19.KeyVerification>
+  _i3.CachedStreamController<_i20.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_1<_i19.KeyVerification>(
+            returnValue: _FakeCachedStreamController_1<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_1<_i19.KeyVerification>(
+                _FakeCachedStreamController_1<_i20.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i19.KeyVerification>);
+          ) as _i3.CachedStreamController<_i20.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -3328,7 +3340,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i19.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i20.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3617,14 +3629,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4012,8 +4024,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValue: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -4029,8 +4041,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i16.ifNotNull(
-              _i16.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i17.ifNotNull(
+              _i17.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -4071,7 +4083,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4087,7 +4099,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4136,7 +4148,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4157,7 +4169,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4260,7 +4272,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4278,7 +4290,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4800,7 +4812,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i20.Uint8List? file, {
+    _i21.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5152,7 +5164,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5166,7 +5178,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5317,7 +5329,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i20.Uint8List? body,
+    _i21.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6695,7 +6707,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -6717,7 +6729,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7211,7 +7223,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7223,7 +7235,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -8231,7 +8243,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8242,7 +8254,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8490,7 +8502,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8502,7 +8514,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8762,7 +8774,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -8775,7 +8787,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -8842,7 +8854,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -8855,7 +8867,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -8903,7 +8915,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -8915,7 +8927,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9163,7 +9175,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9174,7 +9186,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9436,7 +9448,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i20.Uint8List? body, {
+    _i21.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -9463,7 +9475,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -9493,11 +9505,11 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i16.dummyValue<String>(
+        returnValue: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i16.dummyValue<String>(
+        returnValueForMissingStub: _i17.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -9622,6 +9634,19 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_79(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_79(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -9719,6 +9744,15 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -9763,7 +9797,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -9788,6 +9822,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9797,6 +9832,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -9857,7 +9893,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -9866,7 +9902,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -9885,7 +9921,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -9896,7 +9932,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -9944,7 +9980,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -9982,7 +10018,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -9991,7 +10027,7 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -10000,16 +10036,16 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
       );
 
   @override
-  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i5.Future<_i22.AppExitResponse>);
+            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i5.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -10036,14 +10072,14 @@ class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
 class MockSpaceAccessService extends _i1.Mock
     implements _i12.SpaceAccessService {
   @override
-  _i25.JoinMode getJoinMode(_i2.Room? room) => (super.noSuchMethod(
+  _i26.JoinMode getJoinMode(_i2.Room? room) => (super.noSuchMethod(
         Invocation.method(
           #getJoinMode,
           [room],
         ),
-        returnValue: _i25.JoinMode.invite,
-        returnValueForMissingStub: _i25.JoinMode.invite,
-      ) as _i25.JoinMode);
+        returnValue: _i26.JoinMode.invite,
+        returnValueForMissingStub: _i26.JoinMode.invite,
+      ) as _i26.JoinMode);
 
   @override
   List<String> allowedSpaceIds(_i2.Room? room) => (super.noSuchMethod(
@@ -10127,7 +10163,7 @@ class MockSpaceAccessService extends _i1.Mock
   @override
   _i5.Future<void> applyJoinMode({
     required String? roomId,
-    required _i25.JoinMode? mode,
+    required _i26.JoinMode? mode,
     List<String>? allowSpaceIds = const [],
   }) =>
       (super.noSuchMethod(
@@ -10146,7 +10182,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   Map<String, Object?> buildJoinRulesPayload(
-    _i25.JoinMode? mode,
+    _i26.JoinMode? mode,
     List<String>? allowSpaceIds, {
     List<Map<String, Object?>>? preserveEntries = const [],
   }) =>
@@ -10165,7 +10201,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   _i2.StateEvent buildJoinRulesStateEvent(
-    _i25.JoinMode? mode,
+    _i26.JoinMode? mode,
     List<String>? allowSpaceIds,
   ) =>
       (super.noSuchMethod(
@@ -10176,7 +10212,7 @@ class MockSpaceAccessService extends _i1.Mock
             allowSpaceIds,
           ],
         ),
-        returnValue: _FakeStateEvent_79(
+        returnValue: _FakeStateEvent_80(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -10186,7 +10222,7 @@ class MockSpaceAccessService extends _i1.Mock
             ],
           ),
         ),
-        returnValueForMissingStub: _FakeStateEvent_79(
+        returnValueForMissingStub: _FakeStateEvent_80(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -10211,7 +10247,7 @@ class MockSpaceAccessService extends _i1.Mock
             newVersion,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i16.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,
@@ -10222,7 +10258,7 @@ class MockSpaceAccessService extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i16.dummyValue<String>(
+            _i5.Future<String>.value(_i17.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,

--- a/test/widgets/bootstrap_controller_test.mocks.dart
+++ b/test/widgets/bootstrap_controller_test.mocks.dart
@@ -4,13 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i21;
-import 'dart:ui' as _i23;
+import 'dart:typed_data' as _i22;
+import 'dart:ui' as _i24;
 
-import 'package:flutter/services.dart' as _i24;
-import 'package:flutter/widgets.dart' as _i25;
+import 'package:flutter/services.dart' as _i25;
+import 'package:flutter/widgets.dart' as _i26;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/matrix_service.dart' as _i23;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -25,15 +26,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
-import 'package:matrix/encryption/cross_signing.dart' as _i19;
-import 'package:matrix/encryption/key_verification_manager.dart' as _i18;
-import 'package:matrix/encryption/olm_manager.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i17;
+import 'package:matrix/encryption/cross_signing.dart' as _i20;
+import 'package:matrix/encryption/key_verification_manager.dart' as _i19;
+import 'package:matrix/encryption/olm_manager.dart' as _i18;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i20;
+import 'package:mockito/src/dummies.dart' as _i21;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -847,8 +848,9 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyManager_75 extends _i1.SmartFake implements _i16.KeyManager {
-  _FakeKeyManager_75(
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -857,8 +859,8 @@ class _FakeKeyManager_75 extends _i1.SmartFake implements _i16.KeyManager {
         );
 }
 
-class _FakeOlmManager_76 extends _i1.SmartFake implements _i17.OlmManager {
-  _FakeOlmManager_76(
+class _FakeKeyManager_76 extends _i1.SmartFake implements _i17.KeyManager {
+  _FakeKeyManager_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,9 +869,8 @@ class _FakeOlmManager_76 extends _i1.SmartFake implements _i17.OlmManager {
         );
 }
 
-class _FakeKeyVerificationManager_77 extends _i1.SmartFake
-    implements _i18.KeyVerificationManager {
-  _FakeKeyVerificationManager_77(
+class _FakeOlmManager_77 extends _i1.SmartFake implements _i18.OlmManager {
+  _FakeOlmManager_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -878,8 +879,9 @@ class _FakeKeyVerificationManager_77 extends _i1.SmartFake
         );
 }
 
-class _FakeCrossSigning_78 extends _i1.SmartFake implements _i19.CrossSigning {
-  _FakeCrossSigning_78(
+class _FakeKeyVerificationManager_78 extends _i1.SmartFake
+    implements _i19.KeyVerificationManager {
+  _FakeKeyVerificationManager_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -888,8 +890,8 @@ class _FakeCrossSigning_78 extends _i1.SmartFake implements _i19.CrossSigning {
         );
 }
 
-class _FakeSSSS_79 extends _i1.SmartFake implements _i16.SSSS {
-  _FakeSSSS_79(
+class _FakeCrossSigning_79 extends _i1.SmartFake implements _i20.CrossSigning {
+  _FakeCrossSigning_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -898,8 +900,8 @@ class _FakeSSSS_79 extends _i1.SmartFake implements _i16.SSSS {
         );
 }
 
-class _FakeBootstrap_80 extends _i1.SmartFake implements _i16.Bootstrap {
-  _FakeBootstrap_80(
+class _FakeSSSS_80 extends _i1.SmartFake implements _i17.SSSS {
+  _FakeSSSS_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -908,8 +910,8 @@ class _FakeBootstrap_80 extends _i1.SmartFake implements _i16.Bootstrap {
         );
 }
 
-class _FakeToDeviceEvent_81 extends _i1.SmartFake implements _i2.ToDeviceEvent {
-  _FakeToDeviceEvent_81(
+class _FakeBootstrap_81 extends _i1.SmartFake implements _i17.Bootstrap {
+  _FakeBootstrap_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -918,8 +920,8 @@ class _FakeToDeviceEvent_81 extends _i1.SmartFake implements _i2.ToDeviceEvent {
         );
 }
 
-class _FakeEvent_82 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_82(
+class _FakeToDeviceEvent_82 extends _i1.SmartFake implements _i2.ToDeviceEvent {
+  _FakeToDeviceEvent_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -928,8 +930,8 @@ class _FakeEvent_82 extends _i1.SmartFake implements _i2.Event {
         );
 }
 
-class _FakeEncryption_83 extends _i1.SmartFake implements _i16.Encryption {
-  _FakeEncryption_83(
+class _FakeEvent_83 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -938,9 +940,19 @@ class _FakeEncryption_83 extends _i1.SmartFake implements _i16.Encryption {
         );
 }
 
-class _FakeSecretStorageKeyContent_84 extends _i1.SmartFake
+class _FakeEncryption_84 extends _i1.SmartFake implements _i17.Encryption {
+  _FakeEncryption_84(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeSecretStorageKeyContent_85 extends _i1.SmartFake
     implements _i2.SecretStorageKeyContent {
-  _FakeSecretStorageKeyContent_84(
+  _FakeSecretStorageKeyContent_85(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -967,12 +979,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1092,11 +1104,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1133,11 +1145,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1167,11 +1179,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1180,11 +1192,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1470,34 +1482,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1653,7 +1665,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1942,14 +1954,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2337,8 +2349,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValue: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2354,8 +2366,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2396,7 +2408,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2412,7 +2424,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2461,7 +2473,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2482,7 +2494,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2585,7 +2597,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2603,7 +2615,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3122,7 +3134,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i21.Uint8List? file, {
+    _i22.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3474,7 +3486,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3488,7 +3500,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3639,7 +3651,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i21.Uint8List? body,
+    _i22.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5017,7 +5029,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5039,7 +5051,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5533,7 +5545,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5545,7 +5557,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6553,7 +6565,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6564,7 +6576,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6812,7 +6824,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6824,7 +6836,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7084,7 +7096,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7097,7 +7109,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7164,7 +7176,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7177,7 +7189,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7225,7 +7237,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7237,7 +7249,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7485,7 +7497,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7496,7 +7508,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7758,7 +7770,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i21.Uint8List? body, {
+    _i22.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7785,7 +7797,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7815,11 +7827,11 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7944,6 +7956,19 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -8041,6 +8066,15 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -8085,7 +8119,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i24.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8110,6 +8144,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8119,6 +8154,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8179,7 +8215,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8188,7 +8224,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8207,7 +8243,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i25.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8218,7 +8254,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i25.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8266,7 +8302,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i25.RouteInformation? routeInformation) =>
+          _i26.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8304,7 +8340,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i24.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8313,7 +8349,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i24.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8322,16 +8358,16 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i24.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+            _i5.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
-      ) as _i5.Future<_i23.AppExitResponse>);
+            _i5.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
+      ) as _i5.Future<_i24.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8417,7 +8453,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> runKeyRecovery({_i16.OpenSSSS? ssssKey}) =>
+  _i5.Future<void> runKeyRecovery({_i17.OpenSSSS? ssssKey}) =>
       (super.noSuchMethod(
         Invocation.method(
           #runKeyRecovery,
@@ -8471,7 +8507,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8480,7 +8516,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       );
 
   @override
-  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8510,7 +8546,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
 /// A class which mocks [Encryption].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEncryption extends _i1.Mock implements _i16.Encryption {
+class MockEncryption extends _i1.Mock implements _i17.Encryption {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -8539,85 +8575,85 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
       ) as bool);
 
   @override
-  _i16.KeyManager get keyManager => (super.noSuchMethod(
+  _i17.KeyManager get keyManager => (super.noSuchMethod(
         Invocation.getter(#keyManager),
-        returnValue: _FakeKeyManager_75(
+        returnValue: _FakeKeyManager_76(
           this,
           Invocation.getter(#keyManager),
         ),
-        returnValueForMissingStub: _FakeKeyManager_75(
+        returnValueForMissingStub: _FakeKeyManager_76(
           this,
           Invocation.getter(#keyManager),
         ),
-      ) as _i16.KeyManager);
+      ) as _i17.KeyManager);
 
   @override
-  _i17.OlmManager get olmManager => (super.noSuchMethod(
+  _i18.OlmManager get olmManager => (super.noSuchMethod(
         Invocation.getter(#olmManager),
-        returnValue: _FakeOlmManager_76(
+        returnValue: _FakeOlmManager_77(
           this,
           Invocation.getter(#olmManager),
         ),
-        returnValueForMissingStub: _FakeOlmManager_76(
+        returnValueForMissingStub: _FakeOlmManager_77(
           this,
           Invocation.getter(#olmManager),
         ),
-      ) as _i17.OlmManager);
+      ) as _i18.OlmManager);
 
   @override
-  _i18.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
+  _i19.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
         Invocation.getter(#keyVerificationManager),
-        returnValue: _FakeKeyVerificationManager_77(
+        returnValue: _FakeKeyVerificationManager_78(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-        returnValueForMissingStub: _FakeKeyVerificationManager_77(
+        returnValueForMissingStub: _FakeKeyVerificationManager_78(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-      ) as _i18.KeyVerificationManager);
+      ) as _i19.KeyVerificationManager);
 
   @override
-  _i19.CrossSigning get crossSigning => (super.noSuchMethod(
+  _i20.CrossSigning get crossSigning => (super.noSuchMethod(
         Invocation.getter(#crossSigning),
-        returnValue: _FakeCrossSigning_78(
+        returnValue: _FakeCrossSigning_79(
           this,
           Invocation.getter(#crossSigning),
         ),
-        returnValueForMissingStub: _FakeCrossSigning_78(
+        returnValueForMissingStub: _FakeCrossSigning_79(
           this,
           Invocation.getter(#crossSigning),
         ),
-      ) as _i19.CrossSigning);
+      ) as _i20.CrossSigning);
 
   @override
-  _i16.SSSS get ssss => (super.noSuchMethod(
+  _i17.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_79(
+        returnValue: _FakeSSSS_80(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_79(
+        returnValueForMissingStub: _FakeSSSS_80(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i16.SSSS);
+      ) as _i17.SSSS);
 
   @override
   String get ourDeviceId => (super.noSuchMethod(
         Invocation.getter(#ourDeviceId),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
       ) as String);
 
   @override
-  set keyManager(_i16.KeyManager? value) => super.noSuchMethod(
+  set keyManager(_i17.KeyManager? value) => super.noSuchMethod(
         Invocation.setter(
           #keyManager,
           value,
@@ -8626,7 +8662,7 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
       );
 
   @override
-  set olmManager(_i17.OlmManager? value) => super.noSuchMethod(
+  set olmManager(_i18.OlmManager? value) => super.noSuchMethod(
         Invocation.setter(
           #olmManager,
           value,
@@ -8635,7 +8671,7 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
       );
 
   @override
-  set keyVerificationManager(_i18.KeyVerificationManager? value) =>
+  set keyVerificationManager(_i19.KeyVerificationManager? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #keyVerificationManager,
@@ -8645,7 +8681,7 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
       );
 
   @override
-  set crossSigning(_i19.CrossSigning? value) => super.noSuchMethod(
+  set crossSigning(_i20.CrossSigning? value) => super.noSuchMethod(
         Invocation.setter(
           #crossSigning,
           value,
@@ -8654,7 +8690,7 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
       );
 
   @override
-  set ssss(_i16.SSSS? value) => super.noSuchMethod(
+  set ssss(_i17.SSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #ssss,
           value,
@@ -8693,14 +8729,14 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
       ) as _i5.Future<void>);
 
   @override
-  _i16.Bootstrap bootstrap({void Function(_i16.Bootstrap)? onUpdate}) =>
+  _i17.Bootstrap bootstrap({void Function(_i17.Bootstrap)? onUpdate}) =>
       (super.noSuchMethod(
         Invocation.method(
           #bootstrap,
           [],
           {#onUpdate: onUpdate},
         ),
-        returnValue: _FakeBootstrap_80(
+        returnValue: _FakeBootstrap_81(
           this,
           Invocation.method(
             #bootstrap,
@@ -8708,7 +8744,7 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-        returnValueForMissingStub: _FakeBootstrap_80(
+        returnValueForMissingStub: _FakeBootstrap_81(
           this,
           Invocation.method(
             #bootstrap,
@@ -8716,7 +8752,7 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-      ) as _i16.Bootstrap);
+      ) as _i17.Bootstrap);
 
   @override
   void handleDeviceOneTimeKeysCount(
@@ -8779,7 +8815,7 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
           #decryptToDeviceEvent,
           [event],
         ),
-        returnValue: _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_81(
+        returnValue: _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_82(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -8787,7 +8823,7 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_81(
+            _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_82(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -8802,14 +8838,14 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
           #decryptRoomEventSync,
           [event],
         ),
-        returnValue: _FakeEvent_82(
+        returnValue: _FakeEvent_83(
           this,
           Invocation.method(
             #decryptRoomEventSync,
             [event],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_82(
+        returnValueForMissingStub: _FakeEvent_83(
           this,
           Invocation.method(
             #decryptRoomEventSync,
@@ -8833,7 +8869,7 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
             #updateType: updateType,
           },
         ),
-        returnValue: _i5.Future<_i2.Event>.value(_FakeEvent_82(
+        returnValue: _i5.Future<_i2.Event>.value(_FakeEvent_83(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -8844,7 +8880,7 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
             },
           ),
         )),
-        returnValueForMissingStub: _i5.Future<_i2.Event>.value(_FakeEvent_82(
+        returnValueForMissingStub: _i5.Future<_i2.Event>.value(_FakeEvent_83(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -8926,19 +8962,19 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
 /// A class which mocks [Bootstrap].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBootstrap extends _i1.Mock implements _i16.Bootstrap {
+class MockBootstrap extends _i1.Mock implements _i17.Bootstrap {
   @override
-  _i16.Encryption get encryption => (super.noSuchMethod(
+  _i17.Encryption get encryption => (super.noSuchMethod(
         Invocation.getter(#encryption),
-        returnValue: _FakeEncryption_83(
+        returnValue: _FakeEncryption_84(
           this,
           Invocation.getter(#encryption),
         ),
-        returnValueForMissingStub: _FakeEncryption_83(
+        returnValueForMissingStub: _FakeEncryption_84(
           this,
           Invocation.getter(#encryption),
         ),
-      ) as _i16.Encryption);
+      ) as _i17.Encryption);
 
   @override
   _i2.Client get client => (super.noSuchMethod(
@@ -8954,14 +8990,14 @@ class MockBootstrap extends _i1.Mock implements _i16.Bootstrap {
       ) as _i2.Client);
 
   @override
-  _i16.BootstrapState get state => (super.noSuchMethod(
+  _i17.BootstrapState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i16.BootstrapState.loading,
-        returnValueForMissingStub: _i16.BootstrapState.loading,
-      ) as _i16.BootstrapState);
+        returnValue: _i17.BootstrapState.loading,
+        returnValueForMissingStub: _i17.BootstrapState.loading,
+      ) as _i17.BootstrapState);
 
   @override
-  set onUpdate(void Function(_i16.Bootstrap)? value) => super.noSuchMethod(
+  set onUpdate(void Function(_i17.Bootstrap)? value) => super.noSuchMethod(
         Invocation.setter(
           #onUpdate,
           value,
@@ -8970,7 +9006,7 @@ class MockBootstrap extends _i1.Mock implements _i16.Bootstrap {
       );
 
   @override
-  set oldSsssKeys(Map<String, _i16.OpenSSSS>? value) => super.noSuchMethod(
+  set oldSsssKeys(Map<String, _i17.OpenSSSS>? value) => super.noSuchMethod(
         Invocation.setter(
           #oldSsssKeys,
           value,
@@ -8979,7 +9015,7 @@ class MockBootstrap extends _i1.Mock implements _i16.Bootstrap {
       );
 
   @override
-  set newSsssKey(_i16.OpenSSSS? value) => super.noSuchMethod(
+  set newSsssKey(_i17.OpenSSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #newSsssKey,
           value,
@@ -8997,7 +9033,7 @@ class MockBootstrap extends _i1.Mock implements _i16.Bootstrap {
       );
 
   @override
-  set state(_i16.BootstrapState? newState) => super.noSuchMethod(
+  set state(_i17.BootstrapState? newState) => super.noSuchMethod(
         Invocation.setter(
           #state,
           newState,
@@ -9031,14 +9067,14 @@ class MockBootstrap extends _i1.Mock implements _i16.Bootstrap {
           #mostUsedKey,
           [secrets],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
             [secrets],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
@@ -9205,28 +9241,28 @@ class MockBootstrap extends _i1.Mock implements _i16.Bootstrap {
 /// A class which mocks [OpenSSSS].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockOpenSSSS extends _i1.Mock implements _i16.OpenSSSS {
+class MockOpenSSSS extends _i1.Mock implements _i17.OpenSSSS {
   @override
-  _i16.SSSS get ssss => (super.noSuchMethod(
+  _i17.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_79(
+        returnValue: _FakeSSSS_80(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_79(
+        returnValueForMissingStub: _FakeSSSS_80(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i16.SSSS);
+      ) as _i17.SSSS);
 
   @override
   String get keyId => (super.noSuchMethod(
         Invocation.getter(#keyId),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#keyId),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#keyId),
         ),
@@ -9235,11 +9271,11 @@ class MockOpenSSSS extends _i1.Mock implements _i16.OpenSSSS {
   @override
   _i2.SecretStorageKeyContent get keyData => (super.noSuchMethod(
         Invocation.getter(#keyData),
-        returnValue: _FakeSecretStorageKeyContent_84(
+        returnValue: _FakeSecretStorageKeyContent_85(
           this,
           Invocation.getter(#keyData),
         ),
-        returnValueForMissingStub: _FakeSecretStorageKeyContent_84(
+        returnValueForMissingStub: _FakeSecretStorageKeyContent_85(
           this,
           Invocation.getter(#keyData),
         ),
@@ -9260,7 +9296,7 @@ class MockOpenSSSS extends _i1.Mock implements _i16.OpenSSSS {
       ) as bool);
 
   @override
-  set privateKey(_i21.Uint8List? value) => super.noSuchMethod(
+  set privateKey(_i22.Uint8List? value) => super.noSuchMethod(
         Invocation.setter(
           #privateKey,
           value,
@@ -9291,7 +9327,7 @@ class MockOpenSSSS extends _i1.Mock implements _i16.OpenSSSS {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setPrivateKey(_i21.Uint8List? key) => (super.noSuchMethod(
+  _i5.Future<void> setPrivateKey(_i22.Uint8List? key) => (super.noSuchMethod(
         Invocation.method(
           #setPrivateKey,
           [key],
@@ -9306,7 +9342,7 @@ class MockOpenSSSS extends _i1.Mock implements _i16.OpenSSSS {
           #getStored,
           [type],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #getStored,
@@ -9314,7 +9350,7 @@ class MockOpenSSSS extends _i1.Mock implements _i16.OpenSSSS {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #getStored,

--- a/test/widgets/bootstrap_driver_test.mocks.dart
+++ b/test/widgets/bootstrap_driver_test.mocks.dart
@@ -4,13 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i21;
-import 'dart:ui' as _i23;
+import 'dart:typed_data' as _i22;
+import 'dart:ui' as _i24;
 
-import 'package:flutter/services.dart' as _i24;
-import 'package:flutter/widgets.dart' as _i25;
+import 'package:flutter/services.dart' as _i25;
+import 'package:flutter/widgets.dart' as _i26;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i22;
+import 'package:kohera/core/services/matrix_service.dart' as _i23;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -25,15 +26,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
-import 'package:matrix/encryption/cross_signing.dart' as _i19;
-import 'package:matrix/encryption/key_verification_manager.dart' as _i18;
-import 'package:matrix/encryption/olm_manager.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i17;
+import 'package:matrix/encryption/cross_signing.dart' as _i20;
+import 'package:matrix/encryption/key_verification_manager.dart' as _i19;
+import 'package:matrix/encryption/olm_manager.dart' as _i18;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i20;
+import 'package:mockito/src/dummies.dart' as _i21;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -847,8 +848,9 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyManager_75 extends _i1.SmartFake implements _i16.KeyManager {
-  _FakeKeyManager_75(
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -857,8 +859,8 @@ class _FakeKeyManager_75 extends _i1.SmartFake implements _i16.KeyManager {
         );
 }
 
-class _FakeOlmManager_76 extends _i1.SmartFake implements _i17.OlmManager {
-  _FakeOlmManager_76(
+class _FakeKeyManager_76 extends _i1.SmartFake implements _i17.KeyManager {
+  _FakeKeyManager_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,9 +869,8 @@ class _FakeOlmManager_76 extends _i1.SmartFake implements _i17.OlmManager {
         );
 }
 
-class _FakeKeyVerificationManager_77 extends _i1.SmartFake
-    implements _i18.KeyVerificationManager {
-  _FakeKeyVerificationManager_77(
+class _FakeOlmManager_77 extends _i1.SmartFake implements _i18.OlmManager {
+  _FakeOlmManager_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -878,8 +879,9 @@ class _FakeKeyVerificationManager_77 extends _i1.SmartFake
         );
 }
 
-class _FakeCrossSigning_78 extends _i1.SmartFake implements _i19.CrossSigning {
-  _FakeCrossSigning_78(
+class _FakeKeyVerificationManager_78 extends _i1.SmartFake
+    implements _i19.KeyVerificationManager {
+  _FakeKeyVerificationManager_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -888,8 +890,8 @@ class _FakeCrossSigning_78 extends _i1.SmartFake implements _i19.CrossSigning {
         );
 }
 
-class _FakeSSSS_79 extends _i1.SmartFake implements _i16.SSSS {
-  _FakeSSSS_79(
+class _FakeCrossSigning_79 extends _i1.SmartFake implements _i20.CrossSigning {
+  _FakeCrossSigning_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -898,8 +900,8 @@ class _FakeSSSS_79 extends _i1.SmartFake implements _i16.SSSS {
         );
 }
 
-class _FakeBootstrap_80 extends _i1.SmartFake implements _i16.Bootstrap {
-  _FakeBootstrap_80(
+class _FakeSSSS_80 extends _i1.SmartFake implements _i17.SSSS {
+  _FakeSSSS_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -908,8 +910,8 @@ class _FakeBootstrap_80 extends _i1.SmartFake implements _i16.Bootstrap {
         );
 }
 
-class _FakeToDeviceEvent_81 extends _i1.SmartFake implements _i2.ToDeviceEvent {
-  _FakeToDeviceEvent_81(
+class _FakeBootstrap_81 extends _i1.SmartFake implements _i17.Bootstrap {
+  _FakeBootstrap_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -918,8 +920,8 @@ class _FakeToDeviceEvent_81 extends _i1.SmartFake implements _i2.ToDeviceEvent {
         );
 }
 
-class _FakeEvent_82 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_82(
+class _FakeToDeviceEvent_82 extends _i1.SmartFake implements _i2.ToDeviceEvent {
+  _FakeToDeviceEvent_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -928,8 +930,18 @@ class _FakeEvent_82 extends _i1.SmartFake implements _i2.Event {
         );
 }
 
-class _FakeEncryption_83 extends _i1.SmartFake implements _i16.Encryption {
-  _FakeEncryption_83(
+class _FakeEvent_83 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_83(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeEncryption_84 extends _i1.SmartFake implements _i17.Encryption {
+  _FakeEncryption_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -956,12 +968,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1081,11 +1093,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1122,11 +1134,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1156,11 +1168,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1169,11 +1181,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1459,34 +1471,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1642,7 +1654,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1931,14 +1943,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2326,8 +2338,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValue: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2343,8 +2355,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i20.ifNotNull(
-              _i20.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i21.ifNotNull(
+              _i21.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2385,7 +2397,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2401,7 +2413,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2450,7 +2462,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2471,7 +2483,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2574,7 +2586,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2592,7 +2604,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3111,7 +3123,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i21.Uint8List? file, {
+    _i22.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3463,7 +3475,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3477,7 +3489,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3628,7 +3640,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i21.Uint8List? body,
+    _i22.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5006,7 +5018,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5028,7 +5040,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5522,7 +5534,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5534,7 +5546,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6542,7 +6554,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6553,7 +6565,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6801,7 +6813,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6813,7 +6825,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7073,7 +7085,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7086,7 +7098,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7153,7 +7165,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7166,7 +7178,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7214,7 +7226,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7226,7 +7238,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7474,7 +7486,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i20.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7485,7 +7497,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i20.dummyValue<String>(
+            _i5.Future<String>.value(_i21.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7747,7 +7759,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i21.Uint8List? body, {
+    _i22.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7774,7 +7786,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i23.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7804,11 +7816,11 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7933,6 +7945,19 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -8030,6 +8055,15 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -8074,7 +8108,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i24.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8099,6 +8133,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8108,6 +8143,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8168,7 +8204,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8177,7 +8213,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i24.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8196,7 +8232,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i25.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8207,7 +8243,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i25.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8255,7 +8291,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i25.RouteInformation? routeInformation) =>
+          _i26.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8293,7 +8329,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i24.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8302,7 +8338,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i24.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8311,16 +8347,16 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
       );
 
   @override
-  _i5.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i24.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+            _i5.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
-      ) as _i5.Future<_i23.AppExitResponse>);
+            _i5.Future<_i24.AppExitResponse>.value(_i24.AppExitResponse.exit),
+      ) as _i5.Future<_i24.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8344,7 +8380,7 @@ class MockMatrixService extends _i1.Mock implements _i22.MatrixService {
 /// A class which mocks [Encryption].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEncryption extends _i1.Mock implements _i16.Encryption {
+class MockEncryption extends _i1.Mock implements _i17.Encryption {
   @override
   _i2.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -8373,85 +8409,85 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
       ) as bool);
 
   @override
-  _i16.KeyManager get keyManager => (super.noSuchMethod(
+  _i17.KeyManager get keyManager => (super.noSuchMethod(
         Invocation.getter(#keyManager),
-        returnValue: _FakeKeyManager_75(
+        returnValue: _FakeKeyManager_76(
           this,
           Invocation.getter(#keyManager),
         ),
-        returnValueForMissingStub: _FakeKeyManager_75(
+        returnValueForMissingStub: _FakeKeyManager_76(
           this,
           Invocation.getter(#keyManager),
         ),
-      ) as _i16.KeyManager);
+      ) as _i17.KeyManager);
 
   @override
-  _i17.OlmManager get olmManager => (super.noSuchMethod(
+  _i18.OlmManager get olmManager => (super.noSuchMethod(
         Invocation.getter(#olmManager),
-        returnValue: _FakeOlmManager_76(
+        returnValue: _FakeOlmManager_77(
           this,
           Invocation.getter(#olmManager),
         ),
-        returnValueForMissingStub: _FakeOlmManager_76(
+        returnValueForMissingStub: _FakeOlmManager_77(
           this,
           Invocation.getter(#olmManager),
         ),
-      ) as _i17.OlmManager);
+      ) as _i18.OlmManager);
 
   @override
-  _i18.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
+  _i19.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
         Invocation.getter(#keyVerificationManager),
-        returnValue: _FakeKeyVerificationManager_77(
+        returnValue: _FakeKeyVerificationManager_78(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-        returnValueForMissingStub: _FakeKeyVerificationManager_77(
+        returnValueForMissingStub: _FakeKeyVerificationManager_78(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-      ) as _i18.KeyVerificationManager);
+      ) as _i19.KeyVerificationManager);
 
   @override
-  _i19.CrossSigning get crossSigning => (super.noSuchMethod(
+  _i20.CrossSigning get crossSigning => (super.noSuchMethod(
         Invocation.getter(#crossSigning),
-        returnValue: _FakeCrossSigning_78(
+        returnValue: _FakeCrossSigning_79(
           this,
           Invocation.getter(#crossSigning),
         ),
-        returnValueForMissingStub: _FakeCrossSigning_78(
+        returnValueForMissingStub: _FakeCrossSigning_79(
           this,
           Invocation.getter(#crossSigning),
         ),
-      ) as _i19.CrossSigning);
+      ) as _i20.CrossSigning);
 
   @override
-  _i16.SSSS get ssss => (super.noSuchMethod(
+  _i17.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_79(
+        returnValue: _FakeSSSS_80(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_79(
+        returnValueForMissingStub: _FakeSSSS_80(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i16.SSSS);
+      ) as _i17.SSSS);
 
   @override
   String get ourDeviceId => (super.noSuchMethod(
         Invocation.getter(#ourDeviceId),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
       ) as String);
 
   @override
-  set keyManager(_i16.KeyManager? value) => super.noSuchMethod(
+  set keyManager(_i17.KeyManager? value) => super.noSuchMethod(
         Invocation.setter(
           #keyManager,
           value,
@@ -8460,7 +8496,7 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
       );
 
   @override
-  set olmManager(_i17.OlmManager? value) => super.noSuchMethod(
+  set olmManager(_i18.OlmManager? value) => super.noSuchMethod(
         Invocation.setter(
           #olmManager,
           value,
@@ -8469,7 +8505,7 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
       );
 
   @override
-  set keyVerificationManager(_i18.KeyVerificationManager? value) =>
+  set keyVerificationManager(_i19.KeyVerificationManager? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #keyVerificationManager,
@@ -8479,7 +8515,7 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
       );
 
   @override
-  set crossSigning(_i19.CrossSigning? value) => super.noSuchMethod(
+  set crossSigning(_i20.CrossSigning? value) => super.noSuchMethod(
         Invocation.setter(
           #crossSigning,
           value,
@@ -8488,7 +8524,7 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
       );
 
   @override
-  set ssss(_i16.SSSS? value) => super.noSuchMethod(
+  set ssss(_i17.SSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #ssss,
           value,
@@ -8527,14 +8563,14 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
       ) as _i5.Future<void>);
 
   @override
-  _i16.Bootstrap bootstrap({void Function(_i16.Bootstrap)? onUpdate}) =>
+  _i17.Bootstrap bootstrap({void Function(_i17.Bootstrap)? onUpdate}) =>
       (super.noSuchMethod(
         Invocation.method(
           #bootstrap,
           [],
           {#onUpdate: onUpdate},
         ),
-        returnValue: _FakeBootstrap_80(
+        returnValue: _FakeBootstrap_81(
           this,
           Invocation.method(
             #bootstrap,
@@ -8542,7 +8578,7 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-        returnValueForMissingStub: _FakeBootstrap_80(
+        returnValueForMissingStub: _FakeBootstrap_81(
           this,
           Invocation.method(
             #bootstrap,
@@ -8550,7 +8586,7 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-      ) as _i16.Bootstrap);
+      ) as _i17.Bootstrap);
 
   @override
   void handleDeviceOneTimeKeysCount(
@@ -8613,7 +8649,7 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
           #decryptToDeviceEvent,
           [event],
         ),
-        returnValue: _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_81(
+        returnValue: _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_82(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -8621,7 +8657,7 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_81(
+            _i5.Future<_i2.ToDeviceEvent>.value(_FakeToDeviceEvent_82(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -8636,14 +8672,14 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
           #decryptRoomEventSync,
           [event],
         ),
-        returnValue: _FakeEvent_82(
+        returnValue: _FakeEvent_83(
           this,
           Invocation.method(
             #decryptRoomEventSync,
             [event],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_82(
+        returnValueForMissingStub: _FakeEvent_83(
           this,
           Invocation.method(
             #decryptRoomEventSync,
@@ -8667,7 +8703,7 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
             #updateType: updateType,
           },
         ),
-        returnValue: _i5.Future<_i2.Event>.value(_FakeEvent_82(
+        returnValue: _i5.Future<_i2.Event>.value(_FakeEvent_83(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -8678,7 +8714,7 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
             },
           ),
         )),
-        returnValueForMissingStub: _i5.Future<_i2.Event>.value(_FakeEvent_82(
+        returnValueForMissingStub: _i5.Future<_i2.Event>.value(_FakeEvent_83(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -8760,19 +8796,19 @@ class MockEncryption extends _i1.Mock implements _i16.Encryption {
 /// A class which mocks [Bootstrap].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBootstrap extends _i1.Mock implements _i16.Bootstrap {
+class MockBootstrap extends _i1.Mock implements _i17.Bootstrap {
   @override
-  _i16.Encryption get encryption => (super.noSuchMethod(
+  _i17.Encryption get encryption => (super.noSuchMethod(
         Invocation.getter(#encryption),
-        returnValue: _FakeEncryption_83(
+        returnValue: _FakeEncryption_84(
           this,
           Invocation.getter(#encryption),
         ),
-        returnValueForMissingStub: _FakeEncryption_83(
+        returnValueForMissingStub: _FakeEncryption_84(
           this,
           Invocation.getter(#encryption),
         ),
-      ) as _i16.Encryption);
+      ) as _i17.Encryption);
 
   @override
   _i2.Client get client => (super.noSuchMethod(
@@ -8788,14 +8824,14 @@ class MockBootstrap extends _i1.Mock implements _i16.Bootstrap {
       ) as _i2.Client);
 
   @override
-  _i16.BootstrapState get state => (super.noSuchMethod(
+  _i17.BootstrapState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i16.BootstrapState.loading,
-        returnValueForMissingStub: _i16.BootstrapState.loading,
-      ) as _i16.BootstrapState);
+        returnValue: _i17.BootstrapState.loading,
+        returnValueForMissingStub: _i17.BootstrapState.loading,
+      ) as _i17.BootstrapState);
 
   @override
-  set onUpdate(void Function(_i16.Bootstrap)? value) => super.noSuchMethod(
+  set onUpdate(void Function(_i17.Bootstrap)? value) => super.noSuchMethod(
         Invocation.setter(
           #onUpdate,
           value,
@@ -8804,7 +8840,7 @@ class MockBootstrap extends _i1.Mock implements _i16.Bootstrap {
       );
 
   @override
-  set oldSsssKeys(Map<String, _i16.OpenSSSS>? value) => super.noSuchMethod(
+  set oldSsssKeys(Map<String, _i17.OpenSSSS>? value) => super.noSuchMethod(
         Invocation.setter(
           #oldSsssKeys,
           value,
@@ -8813,7 +8849,7 @@ class MockBootstrap extends _i1.Mock implements _i16.Bootstrap {
       );
 
   @override
-  set newSsssKey(_i16.OpenSSSS? value) => super.noSuchMethod(
+  set newSsssKey(_i17.OpenSSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #newSsssKey,
           value,
@@ -8831,7 +8867,7 @@ class MockBootstrap extends _i1.Mock implements _i16.Bootstrap {
       );
 
   @override
-  set state(_i16.BootstrapState? newState) => super.noSuchMethod(
+  set state(_i17.BootstrapState? newState) => super.noSuchMethod(
         Invocation.setter(
           #state,
           newState,
@@ -8865,14 +8901,14 @@ class MockBootstrap extends _i1.Mock implements _i16.Bootstrap {
           #mostUsedKey,
           [secrets],
         ),
-        returnValue: _i20.dummyValue<String>(
+        returnValue: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
             [secrets],
           ),
         ),
-        returnValueForMissingStub: _i20.dummyValue<String>(
+        returnValueForMissingStub: _i21.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,

--- a/test/widgets/chat/emoji_autocomplete_controller_test.mocks.dart
+++ b/test/widgets/chat/emoji_autocomplete_controller_test.mocks.dart
@@ -4,16 +4,18 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i6;
-import 'dart:ui' as _i7;
+import 'dart:ui' as _i9;
 
+import 'package:kohera/core/models/emoji_gg_pack.dart' as _i7;
 import 'package:kohera/core/models/sticker_pack.dart' as _i5;
+import 'package:kohera/core/services/emoji_gg_service.dart' as _i8;
 import 'package:kohera/core/services/sticker_pack_service.dart' as _i4;
 import 'package:matrix/matrix.dart' as _i2;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i10;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i12;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i9;
+import 'package:matrix/src/utils/space_child.dart' as _i11;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i8;
+import 'package:mockito/src/dummies.dart' as _i10;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -135,6 +137,20 @@ class MockStickerPackService extends _i1.Mock
       ) as List<_i5.StickerPack>);
 
   @override
+  List<_i5.StickerPack> get importedPacks => (super.noSuchMethod(
+        Invocation.getter(#importedPacks),
+        returnValue: <_i5.StickerPack>[],
+        returnValueForMissingStub: <_i5.StickerPack>[],
+      ) as List<_i5.StickerPack>);
+
+  @override
+  Set<String> get importedEmojiGgSlugs => (super.noSuchMethod(
+        Invocation.getter(#importedEmojiGgSlugs),
+        returnValue: <String>{},
+        returnValueForMissingStub: <String>{},
+      ) as Set<String>);
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -203,7 +219,34 @@ class MockStickerPackService extends _i1.Mock
       ) as _i6.Future<void>);
 
   @override
-  void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+  _i6.Stream<_i4.ImportProgress> importEmojiGgPack(
+    _i7.EmojiGgPack? pack,
+    _i8.EmojiGgService? emojiGgService,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #importEmojiGgPack,
+          [
+            pack,
+            emojiGgService,
+          ],
+        ),
+        returnValue: _i6.Stream<_i4.ImportProgress>.empty(),
+        returnValueForMissingStub: _i6.Stream<_i4.ImportProgress>.empty(),
+      ) as _i6.Stream<_i4.ImportProgress>);
+
+  @override
+  _i6.Future<void> removeImportedPack(String? packId) => (super.noSuchMethod(
+        Invocation.method(
+          #removeImportedPack,
+          [packId],
+        ),
+        returnValue: _i6.Future<void>.value(),
+        returnValueForMissingStub: _i6.Future<void>.value(),
+      ) as _i6.Future<void>);
+
+  @override
+  void addListener(_i9.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -212,7 +255,7 @@ class MockStickerPackService extends _i1.Mock
       );
 
   @override
-  void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i9.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -237,11 +280,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i8.dummyValue<String>(
+        returnValue: _i10.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i8.dummyValue<String>(
+        returnValueForMissingStub: _i10.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -328,11 +371,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i8.dummyValue<String>(
+        returnValue: _i10.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i8.dummyValue<String>(
+        returnValueForMissingStub: _i10.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -368,11 +411,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i8.dummyValue<String>(
+        returnValue: _i10.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i8.dummyValue<String>(
+        returnValueForMissingStub: _i10.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -388,11 +431,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i8.dummyValue<String>(
+        returnValue: _i10.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i8.dummyValue<String>(
+        returnValueForMissingStub: _i10.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -401,11 +444,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i8.dummyValue<String>(
+        returnValue: _i10.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i8.dummyValue<String>(
+        returnValueForMissingStub: _i10.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -448,11 +491,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i8.dummyValue<String>(
+        returnValue: _i10.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i8.dummyValue<String>(
+        returnValueForMissingStub: _i10.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -718,18 +761,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i9.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i11.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i9.SpaceParent>[],
-        returnValueForMissingStub: <_i9.SpaceParent>[],
-      ) as List<_i9.SpaceParent>);
+        returnValue: <_i11.SpaceParent>[],
+        returnValueForMissingStub: <_i11.SpaceParent>[],
+      ) as List<_i11.SpaceParent>);
 
   @override
-  List<_i9.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i11.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i9.SpaceChild>[],
-        returnValueForMissingStub: <_i9.SpaceChild>[],
-      ) as List<_i9.SpaceChild>);
+        returnValue: <_i11.SpaceChild>[],
+        returnValueForMissingStub: <_i11.SpaceChild>[],
+      ) as List<_i11.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -896,14 +939,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i8.dummyValue<String>(
+        returnValue: _i10.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i8.dummyValue<String>(
+        returnValueForMissingStub: _i10.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -951,7 +994,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i6.Future<String>.value(_i8.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -959,7 +1002,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i8.dummyValue<String>(
+            _i6.Future<String>.value(_i10.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -974,7 +1017,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i6.Future<String>.value(_i8.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -982,7 +1025,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i8.dummyValue<String>(
+            _i6.Future<String>.value(_i10.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -1076,7 +1119,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i6.Future<String>.value(_i8.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -1084,7 +1127,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i8.dummyValue<String>(
+            _i6.Future<String>.value(_i10.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -1326,7 +1369,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i6.Future<String>.value(_i8.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -1337,7 +1380,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i8.dummyValue<String>(
+            _i6.Future<String>.value(_i10.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -1426,15 +1469,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i6.Future<void>);
 
   @override
-  _i6.Future<_i10.TimelineChunk?> getEventContext(String? eventId) =>
+  _i6.Future<_i12.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i6.Future<_i10.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i6.Future<_i10.TimelineChunk?>.value(),
-      ) as _i6.Future<_i10.TimelineChunk?>);
+        returnValue: _i6.Future<_i12.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i6.Future<_i12.TimelineChunk?>.value(),
+      ) as _i6.Future<_i12.TimelineChunk?>);
 
   @override
   _i6.Future<void> postReceipt(
@@ -1642,7 +1685,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i6.Future<String>.value(_i8.dummyValue<String>(
+        returnValue: _i6.Future<String>.value(_i10.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -1650,7 +1693,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i6.Future<String>.value(_i8.dummyValue<String>(
+            _i6.Future<String>.value(_i10.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/chat/message_actions_test.mocks.dart
+++ b/test/widgets/chat/message_actions_test.mocks.dart
@@ -4,13 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i19;
-import 'dart:ui' as _i21;
+import 'dart:typed_data' as _i20;
+import 'dart:ui' as _i22;
 
-import 'package:flutter/services.dart' as _i22;
-import 'package:flutter/widgets.dart' as _i23;
+import 'package:flutter/services.dart' as _i23;
+import 'package:flutter/widgets.dart' as _i24;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/matrix_service.dart' as _i21;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -25,14 +26,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i18;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i16;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i17;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i24;
+import 'package:matrix/src/utils/space_child.dart' as _i25;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i18;
+import 'package:mockito/src/dummies.dart' as _i19;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -846,8 +847,9 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_75(
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -856,9 +858,19 @@ class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_76 extends _i1.SmartFake
+class _FakeRoomSummary_76 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_76(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_77 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_76(
+  _FakeLatestReceiptState_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,8 +879,8 @@ class _FakeLatestReceiptState_76 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_77(
+class _FakeTimeline_78 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -877,8 +889,8 @@ class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_78(
+class _FakeUser_79 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -887,8 +899,8 @@ class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_79 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_79(
+class _FakeRoom_80 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -897,9 +909,9 @@ class _FakeRoom_79 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeTimelineChunk_80 extends _i1.SmartFake
-    implements _i16.TimelineChunk {
-  _FakeTimelineChunk_80(
+class _FakeTimelineChunk_81 extends _i1.SmartFake
+    implements _i17.TimelineChunk {
+  _FakeTimelineChunk_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -908,8 +920,8 @@ class _FakeTimelineChunk_80 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixFile_81 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_81(
+class _FakeMatrixFile_82 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -918,8 +930,8 @@ class _FakeMatrixFile_81 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_82 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_82(
+class _FakeEvent_83 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -946,12 +958,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i17.KeyVerificationMethod> get verificationMethods =>
+  Set<_i18.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i17.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
-      ) as Set<_i17.KeyVerificationMethod>);
+        returnValue: <_i18.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
+      ) as Set<_i18.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1071,11 +1083,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1112,11 +1124,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1146,11 +1158,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1159,11 +1171,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1449,34 +1461,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i17.KeyVerification>
+  _i3.CachedStreamController<_i18.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i17.KeyVerification>(
+                _FakeCachedStreamController_6<_i18.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i17.KeyVerification>);
+          ) as _i3.CachedStreamController<_i18.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1632,7 +1644,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1921,14 +1933,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2316,8 +2328,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValue: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2333,8 +2345,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2375,7 +2387,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2391,7 +2403,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2440,7 +2452,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2461,7 +2473,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2564,7 +2576,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2582,7 +2594,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3101,7 +3113,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i19.Uint8List? file, {
+    _i20.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3453,7 +3465,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3467,7 +3479,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3618,7 +3630,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i19.Uint8List? body,
+    _i20.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4996,7 +5008,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5018,7 +5030,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5512,7 +5524,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5524,7 +5536,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6532,7 +6544,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6543,7 +6555,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6791,7 +6803,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6803,7 +6815,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7063,7 +7075,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7076,7 +7088,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7143,7 +7155,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7156,7 +7168,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7204,7 +7216,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7216,7 +7228,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7464,7 +7476,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7475,7 +7487,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7737,7 +7749,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i19.Uint8List? body, {
+    _i20.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7764,7 +7776,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7794,11 +7806,11 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7923,6 +7935,19 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -8020,6 +8045,15 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -8064,7 +8098,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8089,6 +8123,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8098,6 +8133,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8158,7 +8194,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8167,7 +8203,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8186,7 +8222,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8197,7 +8233,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8245,7 +8281,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i23.RouteInformation? routeInformation) =>
+          _i24.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8283,7 +8319,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8292,7 +8328,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8301,16 +8337,16 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
-      ) as _i5.Future<_i21.AppExitResponse>);
+            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+      ) as _i5.Future<_i22.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8338,11 +8374,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8372,11 +8408,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_75(
+        returnValue: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_75(
+        returnValueForMissingStub: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
@@ -8429,11 +8465,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8469,11 +8505,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8489,11 +8525,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8502,11 +8538,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8549,11 +8585,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8596,11 +8632,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_76(
+        returnValue: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_76(
+        returnValueForMissingStub: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8819,18 +8855,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i24.SpaceParent>[],
-        returnValueForMissingStub: <_i24.SpaceParent>[],
-      ) as List<_i24.SpaceParent>);
+        returnValue: <_i25.SpaceParent>[],
+        returnValueForMissingStub: <_i25.SpaceParent>[],
+      ) as List<_i25.SpaceParent>);
 
   @override
-  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i24.SpaceChild>[],
-        returnValueForMissingStub: <_i24.SpaceChild>[],
-      ) as List<_i24.SpaceChild>);
+        returnValue: <_i25.SpaceChild>[],
+        returnValueForMissingStub: <_i25.SpaceChild>[],
+      ) as List<_i25.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8997,14 +9033,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9052,7 +9088,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9060,7 +9096,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9075,7 +9111,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9083,7 +9119,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9177,7 +9213,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9185,7 +9221,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9427,7 +9463,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9438,7 +9474,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9527,15 +9563,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i16.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i17.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i16.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i16.TimelineChunk?>.value(),
-      ) as _i5.Future<_i16.TimelineChunk?>);
+        returnValue: _i5.Future<_i17.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i17.TimelineChunk?>.value(),
+      ) as _i5.Future<_i17.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9576,7 +9612,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9593,7 +9629,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9657,14 +9693,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9680,14 +9716,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9743,7 +9779,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9751,7 +9787,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10063,11 +10099,11 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_79(
+        returnValue: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_79(
+        returnValueForMissingStub: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
@@ -10117,17 +10153,17 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       ) as bool);
 
   @override
-  _i16.TimelineChunk get chunk => (super.noSuchMethod(
+  _i17.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_80(
+        returnValue: _FakeTimelineChunk_81(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_80(
+        returnValueForMissingStub: _FakeTimelineChunk_81(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i16.TimelineChunk);
+      ) as _i17.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10230,7 +10266,7 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       );
 
   @override
-  set chunk(_i16.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i17.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,
@@ -10429,11 +10465,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.getter(#sender),
         ),
@@ -10442,11 +10478,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10455,11 +10491,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_79(
+        returnValue: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_79(
+        returnValueForMissingStub: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
@@ -10482,11 +10518,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10495,11 +10531,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10508,11 +10544,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10521,11 +10557,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10534,11 +10570,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10547,11 +10583,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10616,11 +10652,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10629,11 +10665,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10686,11 +10722,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10775,11 +10811,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10797,11 +10833,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11012,7 +11048,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i19.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i20.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -11027,7 +11063,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_81(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_82(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -11041,7 +11077,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_81(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_82(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -11077,7 +11113,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11092,7 +11128,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11129,7 +11165,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11143,7 +11179,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11180,7 +11216,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11194,7 +11230,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11228,7 +11264,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11241,7 +11277,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11317,14 +11353,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_82(
+        returnValue: _FakeEvent_83(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_82(
+        returnValueForMissingStub: _FakeEvent_83(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -11341,11 +11377,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_79(
+        returnValue: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_79(
+        returnValueForMissingStub: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
@@ -11354,11 +11390,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -11424,11 +11460,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11453,11 +11489,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11475,11 +11511,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11526,7 +11562,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11538,7 +11574,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11608,7 +11644,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11621,7 +11657,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/widgets/chat/pinned_messages_test.mocks.dart
+++ b/test/widgets/chat/pinned_messages_test.mocks.dart
@@ -4,13 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i19;
-import 'dart:ui' as _i21;
+import 'dart:typed_data' as _i20;
+import 'dart:ui' as _i22;
 
-import 'package:flutter/services.dart' as _i22;
-import 'package:flutter/widgets.dart' as _i23;
+import 'package:flutter/services.dart' as _i23;
+import 'package:flutter/widgets.dart' as _i24;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/matrix_service.dart' as _i21;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -25,14 +26,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i18;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i16;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i17;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i24;
+import 'package:matrix/src/utils/space_child.dart' as _i25;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i18;
+import 'package:mockito/src/dummies.dart' as _i19;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -846,8 +847,9 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_75(
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -856,9 +858,19 @@ class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_76 extends _i1.SmartFake
+class _FakeRoomSummary_76 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_76(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_77 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_76(
+  _FakeLatestReceiptState_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,8 +879,8 @@ class _FakeLatestReceiptState_76 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_77(
+class _FakeTimeline_78 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -877,8 +889,8 @@ class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_78(
+class _FakeUser_79 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -887,8 +899,8 @@ class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_79 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_79(
+class _FakeRoom_80 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -897,9 +909,9 @@ class _FakeRoom_79 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeTimelineChunk_80 extends _i1.SmartFake
-    implements _i16.TimelineChunk {
-  _FakeTimelineChunk_80(
+class _FakeTimelineChunk_81 extends _i1.SmartFake
+    implements _i17.TimelineChunk {
+  _FakeTimelineChunk_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -908,8 +920,8 @@ class _FakeTimelineChunk_80 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixFile_81 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_81(
+class _FakeMatrixFile_82 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -918,8 +930,8 @@ class _FakeMatrixFile_81 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_82 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_82(
+class _FakeEvent_83 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -946,12 +958,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i17.KeyVerificationMethod> get verificationMethods =>
+  Set<_i18.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i17.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
-      ) as Set<_i17.KeyVerificationMethod>);
+        returnValue: <_i18.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
+      ) as Set<_i18.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1071,11 +1083,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1112,11 +1124,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1146,11 +1158,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1159,11 +1171,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1449,34 +1461,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i17.KeyVerification>
+  _i3.CachedStreamController<_i18.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i17.KeyVerification>(
+                _FakeCachedStreamController_6<_i18.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i17.KeyVerification>);
+          ) as _i3.CachedStreamController<_i18.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1632,7 +1644,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1921,14 +1933,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2316,8 +2328,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValue: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2333,8 +2345,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2375,7 +2387,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2391,7 +2403,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2440,7 +2452,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2461,7 +2473,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2564,7 +2576,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2582,7 +2594,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3101,7 +3113,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i19.Uint8List? file, {
+    _i20.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3453,7 +3465,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3467,7 +3479,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3618,7 +3630,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i19.Uint8List? body,
+    _i20.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4996,7 +5008,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5018,7 +5030,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5512,7 +5524,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5524,7 +5536,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6532,7 +6544,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6543,7 +6555,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6791,7 +6803,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6803,7 +6815,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7063,7 +7075,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7076,7 +7088,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7143,7 +7155,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7156,7 +7168,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7204,7 +7216,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7216,7 +7228,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7464,7 +7476,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7475,7 +7487,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7737,7 +7749,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i19.Uint8List? body, {
+    _i20.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7764,7 +7776,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7794,11 +7806,11 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7923,6 +7935,19 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -8020,6 +8045,15 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -8064,7 +8098,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8089,6 +8123,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8098,6 +8133,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8158,7 +8194,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8167,7 +8203,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8186,7 +8222,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8197,7 +8233,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8245,7 +8281,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i23.RouteInformation? routeInformation) =>
+          _i24.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8283,7 +8319,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8292,7 +8328,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8301,16 +8337,16 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
-      ) as _i5.Future<_i21.AppExitResponse>);
+            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+      ) as _i5.Future<_i22.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8338,11 +8374,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8372,11 +8408,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_75(
+        returnValue: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_75(
+        returnValueForMissingStub: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
@@ -8429,11 +8465,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8469,11 +8505,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8489,11 +8525,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8502,11 +8538,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8549,11 +8585,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8596,11 +8632,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_76(
+        returnValue: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_76(
+        returnValueForMissingStub: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8819,18 +8855,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i24.SpaceParent>[],
-        returnValueForMissingStub: <_i24.SpaceParent>[],
-      ) as List<_i24.SpaceParent>);
+        returnValue: <_i25.SpaceParent>[],
+        returnValueForMissingStub: <_i25.SpaceParent>[],
+      ) as List<_i25.SpaceParent>);
 
   @override
-  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i24.SpaceChild>[],
-        returnValueForMissingStub: <_i24.SpaceChild>[],
-      ) as List<_i24.SpaceChild>);
+        returnValue: <_i25.SpaceChild>[],
+        returnValueForMissingStub: <_i25.SpaceChild>[],
+      ) as List<_i25.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8997,14 +9033,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9052,7 +9088,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9060,7 +9096,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9075,7 +9111,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9083,7 +9119,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9177,7 +9213,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9185,7 +9221,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9427,7 +9463,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9438,7 +9474,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9527,15 +9563,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i16.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i17.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i16.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i16.TimelineChunk?>.value(),
-      ) as _i5.Future<_i16.TimelineChunk?>);
+        returnValue: _i5.Future<_i17.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i17.TimelineChunk?>.value(),
+      ) as _i5.Future<_i17.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9576,7 +9612,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9593,7 +9629,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9657,14 +9693,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9680,14 +9716,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9743,7 +9779,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9751,7 +9787,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10063,11 +10099,11 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_79(
+        returnValue: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_79(
+        returnValueForMissingStub: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
@@ -10117,17 +10153,17 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       ) as bool);
 
   @override
-  _i16.TimelineChunk get chunk => (super.noSuchMethod(
+  _i17.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_80(
+        returnValue: _FakeTimelineChunk_81(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_80(
+        returnValueForMissingStub: _FakeTimelineChunk_81(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i16.TimelineChunk);
+      ) as _i17.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10230,7 +10266,7 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       );
 
   @override
-  set chunk(_i16.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i17.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,
@@ -10429,11 +10465,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.getter(#sender),
         ),
@@ -10442,11 +10478,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10455,11 +10491,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_79(
+        returnValue: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_79(
+        returnValueForMissingStub: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
@@ -10482,11 +10518,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10495,11 +10531,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10508,11 +10544,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10521,11 +10557,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10534,11 +10570,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10547,11 +10583,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10616,11 +10652,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10629,11 +10665,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10686,11 +10722,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10775,11 +10811,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10797,11 +10833,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11012,7 +11048,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i19.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i20.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -11027,7 +11063,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_81(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_82(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -11041,7 +11077,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_81(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_82(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -11077,7 +11113,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11092,7 +11128,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11129,7 +11165,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11143,7 +11179,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11180,7 +11216,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11194,7 +11230,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11228,7 +11264,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11241,7 +11277,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11317,14 +11353,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_82(
+        returnValue: _FakeEvent_83(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_82(
+        returnValueForMissingStub: _FakeEvent_83(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -11341,11 +11377,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_79(
+        returnValue: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_79(
+        returnValueForMissingStub: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
@@ -11354,11 +11390,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -11424,11 +11460,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11453,11 +11489,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11475,11 +11511,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11526,7 +11562,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11538,7 +11574,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11608,7 +11644,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11621,7 +11657,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/widgets/create_subspace_dialog_test.mocks.dart
+++ b/test/widgets/create_subspace_dialog_test.mocks.dart
@@ -4,14 +4,15 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/models/join_mode.dart' as _i25;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/models/join_mode.dart' as _i26;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -26,14 +27,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i25;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i23;
+import 'package:matrix/src/utils/space_child.dart' as _i24;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -847,8 +848,9 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_75(
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -857,9 +859,19 @@ class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_76 extends _i1.SmartFake
+class _FakeRoomSummary_76 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_76(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_77 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_76(
+  _FakeLatestReceiptState_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -868,8 +880,8 @@ class _FakeLatestReceiptState_76 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_77(
+class _FakeTimeline_78 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -878,8 +890,8 @@ class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_78(
+class _FakeUser_79 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -888,8 +900,8 @@ class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeStateEvent_79 extends _i1.SmartFake implements _i2.StateEvent {
-  _FakeStateEvent_79(
+class _FakeStateEvent_80 extends _i1.SmartFake implements _i2.StateEvent {
+  _FakeStateEvent_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -916,12 +928,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1041,11 +1053,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1082,11 +1094,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1116,11 +1128,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1129,11 +1141,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1419,34 +1431,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1602,7 +1614,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1891,14 +1903,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2286,8 +2298,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2303,8 +2315,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2345,7 +2357,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2361,7 +2373,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2410,7 +2422,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2431,7 +2443,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2534,7 +2546,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2552,7 +2564,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3071,7 +3083,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3423,7 +3435,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3437,7 +3449,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3588,7 +3600,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4966,7 +4978,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4988,7 +5000,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5482,7 +5494,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5494,7 +5506,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6502,7 +6514,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6513,7 +6525,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6761,7 +6773,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6773,7 +6785,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7033,7 +7045,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7046,7 +7058,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7113,7 +7125,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7126,7 +7138,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7174,7 +7186,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7186,7 +7198,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7434,7 +7446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7445,7 +7457,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7707,7 +7719,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7734,7 +7746,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7764,11 +7776,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7893,6 +7905,19 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7990,6 +8015,15 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -8034,7 +8068,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8059,6 +8093,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8068,6 +8103,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8128,7 +8164,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8137,7 +8173,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8156,7 +8192,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8167,7 +8203,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8215,7 +8251,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8253,7 +8289,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8262,7 +8298,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8271,16 +8307,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8308,11 +8344,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8342,11 +8378,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_75(
+        returnValue: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_75(
+        returnValueForMissingStub: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
@@ -8399,11 +8435,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8439,11 +8475,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8459,11 +8495,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8472,11 +8508,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8519,11 +8555,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8566,11 +8602,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_76(
+        returnValue: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_76(
+        returnValueForMissingStub: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8789,18 +8825,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i23.SpaceParent>[],
-        returnValueForMissingStub: <_i23.SpaceParent>[],
-      ) as List<_i23.SpaceParent>);
+        returnValue: <_i24.SpaceParent>[],
+        returnValueForMissingStub: <_i24.SpaceParent>[],
+      ) as List<_i24.SpaceParent>);
 
   @override
-  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i23.SpaceChild>[],
-        returnValueForMissingStub: <_i23.SpaceChild>[],
-      ) as List<_i23.SpaceChild>);
+        returnValue: <_i24.SpaceChild>[],
+        returnValueForMissingStub: <_i24.SpaceChild>[],
+      ) as List<_i24.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8967,14 +9003,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9022,7 +9058,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9030,7 +9066,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9045,7 +9081,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9053,7 +9089,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9147,7 +9183,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9155,7 +9191,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9397,7 +9433,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9408,7 +9444,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9497,15 +9533,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i25.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i24.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i24.TimelineChunk?>.value(),
-      ) as _i5.Future<_i24.TimelineChunk?>);
+        returnValue: _i5.Future<_i25.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i25.TimelineChunk?>.value(),
+      ) as _i5.Future<_i25.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9546,7 +9582,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9563,7 +9599,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9627,14 +9663,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9650,14 +9686,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9713,7 +9749,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9721,7 +9757,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10032,14 +10068,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
 class MockSpaceAccessService extends _i1.Mock
     implements _i12.SpaceAccessService {
   @override
-  _i25.JoinMode getJoinMode(_i2.Room? room) => (super.noSuchMethod(
+  _i26.JoinMode getJoinMode(_i2.Room? room) => (super.noSuchMethod(
         Invocation.method(
           #getJoinMode,
           [room],
         ),
-        returnValue: _i25.JoinMode.invite,
-        returnValueForMissingStub: _i25.JoinMode.invite,
-      ) as _i25.JoinMode);
+        returnValue: _i26.JoinMode.invite,
+        returnValueForMissingStub: _i26.JoinMode.invite,
+      ) as _i26.JoinMode);
 
   @override
   List<String> allowedSpaceIds(_i2.Room? room) => (super.noSuchMethod(
@@ -10123,7 +10159,7 @@ class MockSpaceAccessService extends _i1.Mock
   @override
   _i5.Future<void> applyJoinMode({
     required String? roomId,
-    required _i25.JoinMode? mode,
+    required _i26.JoinMode? mode,
     List<String>? allowSpaceIds = const [],
   }) =>
       (super.noSuchMethod(
@@ -10142,7 +10178,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   Map<String, Object?> buildJoinRulesPayload(
-    _i25.JoinMode? mode,
+    _i26.JoinMode? mode,
     List<String>? allowSpaceIds, {
     List<Map<String, Object?>>? preserveEntries = const [],
   }) =>
@@ -10161,7 +10197,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   _i2.StateEvent buildJoinRulesStateEvent(
-    _i25.JoinMode? mode,
+    _i26.JoinMode? mode,
     List<String>? allowSpaceIds,
   ) =>
       (super.noSuchMethod(
@@ -10172,7 +10208,7 @@ class MockSpaceAccessService extends _i1.Mock
             allowSpaceIds,
           ],
         ),
-        returnValue: _FakeStateEvent_79(
+        returnValue: _FakeStateEvent_80(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -10182,7 +10218,7 @@ class MockSpaceAccessService extends _i1.Mock
             ],
           ),
         ),
-        returnValueForMissingStub: _FakeStateEvent_79(
+        returnValueForMissingStub: _FakeStateEvent_80(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -10207,7 +10243,7 @@ class MockSpaceAccessService extends _i1.Mock
             newVersion,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,
@@ -10218,7 +10254,7 @@ class MockSpaceAccessService extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,

--- a/test/widgets/homeserver_controller_test.mocks.dart
+++ b/test/widgets/homeserver_controller_test.mocks.dart
@@ -3,13 +3,14 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i15;
-import 'dart:ui' as _i16;
+import 'dart:async' as _i16;
+import 'dart:ui' as _i17;
 
-import 'package:flutter/services.dart' as _i17;
-import 'package:flutter/widgets.dart' as _i18;
-import 'package:kohera/core/models/server_auth_capabilities.dart' as _i12;
-import 'package:kohera/core/services/matrix_service.dart' as _i13;
+import 'package:flutter/services.dart' as _i18;
+import 'package:flutter/widgets.dart' as _i19;
+import 'package:kohera/core/models/server_auth_capabilities.dart' as _i13;
+import 'package:kohera/core/services/matrix_service.dart' as _i14;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i12;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -26,7 +27,7 @@ import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
 import 'package:matrix/matrix.dart' as _i4;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -148,9 +149,20 @@ class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
         );
 }
 
-class _FakeServerAuthCapabilities_10 extends _i1.SmartFake
-    implements _i12.ServerAuthCapabilities {
-  _FakeServerAuthCapabilities_10(
+class _FakeStickerPackService_10 extends _i1.SmartFake
+    implements _i12.StickerPackService {
+  _FakeStickerPackService_10(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeServerAuthCapabilities_11 extends _i1.SmartFake
+    implements _i13.ServerAuthCapabilities {
+  _FakeServerAuthCapabilities_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -162,7 +174,7 @@ class _FakeServerAuthCapabilities_10 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i14.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -192,11 +204,11 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i14.dummyValue<String>(
+        returnValue: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i14.dummyValue<String>(
+        returnValueForMissingStub: _i15.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -321,6 +333,19 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as _i11.OutboxService);
 
   @override
+  _i12.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i12.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -418,6 +443,15 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
+  set stickerPacks(_i12.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -425,14 +459,14 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  _i15.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i16.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -462,7 +496,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i16.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i17.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -472,21 +506,22 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i15.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i16.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<bool> login({
+  _i16.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -496,14 +531,15 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<bool> completeSsoLogin({
+  _i16.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -516,12 +552,12 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<void> completeRegistration(
+  _i16.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -531,32 +567,32 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> logout() => (super.noSuchMethod(
+  _i16.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i16.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -565,7 +601,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -574,17 +610,17 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i15.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i16.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i17.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i18.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -595,7 +631,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i17.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i18.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -632,26 +668,26 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i15.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i16.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<bool> didPushRouteInformation(
-          _i18.RouteInformation? routeInformation) =>
+  _i16.Future<bool> didPushRouteInformation(
+          _i19.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -681,7 +717,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i16.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i17.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -690,7 +726,7 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i16.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i17.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -699,16 +735,16 @@ class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
       );
 
   @override
-  _i15.Future<_i16.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i16.Future<_i17.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i15.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
+            _i16.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i15.Future<_i16.AppExitResponse>.value(_i16.AppExitResponse.exit),
-      ) as _i15.Future<_i16.AppExitResponse>);
+            _i16.Future<_i17.AppExitResponse>.value(_i17.AppExitResponse.exit),
+      ) as _i16.Future<_i17.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -766,10 +802,11 @@ class MockAuthService extends _i1.Mock implements _i10.AuthService {
       ) as bool);
 
   @override
-  _i15.Future<bool> login({
+  _i16.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -779,14 +816,15 @@ class MockAuthService extends _i1.Mock implements _i10.AuthService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<bool> completeSsoLogin({
+  _i16.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -799,12 +837,12 @@ class MockAuthService extends _i1.Mock implements _i10.AuthService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<void> completeRegistration(
+  _i16.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -814,9 +852,9 @@ class MockAuthService extends _i1.Mock implements _i10.AuthService {
           [response],
           {#password: password},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
   void activateRestoredSession() => super.noSuchMethod(
@@ -828,37 +866,37 @@ class MockAuthService extends _i1.Mock implements _i10.AuthService {
       );
 
   @override
-  _i15.Future<void> logout() => (super.noSuchMethod(
+  _i16.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> handleServerLogout() => (super.noSuchMethod(
+  _i16.Future<void> handleServerLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleServerLogout,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> saveSessionBackup() => (super.noSuchMethod(
+  _i16.Future<void> saveSessionBackup() => (super.noSuchMethod(
         Invocation.method(
           #saveSessionBackup,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i12.ServerAuthCapabilities> getServerAuthCapabilities(
+  _i16.Future<_i13.ServerAuthCapabilities> getServerAuthCapabilities(
     String? homeserver, {
     required bool? isLoggedIn,
   }) =>
@@ -868,8 +906,8 @@ class MockAuthService extends _i1.Mock implements _i10.AuthService {
           [homeserver],
           {#isLoggedIn: isLoggedIn},
         ),
-        returnValue: _i15.Future<_i12.ServerAuthCapabilities>.value(
-            _FakeServerAuthCapabilities_10(
+        returnValue: _i16.Future<_i13.ServerAuthCapabilities>.value(
+            _FakeServerAuthCapabilities_11(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -878,8 +916,8 @@ class MockAuthService extends _i1.Mock implements _i10.AuthService {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i12.ServerAuthCapabilities>.value(
-                _FakeServerAuthCapabilities_10(
+            _i16.Future<_i13.ServerAuthCapabilities>.value(
+                _FakeServerAuthCapabilities_11(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -887,7 +925,7 @@ class MockAuthService extends _i1.Mock implements _i10.AuthService {
             {#isLoggedIn: isLoggedIn},
           ),
         )),
-      ) as _i15.Future<_i12.ServerAuthCapabilities>);
+      ) as _i16.Future<_i13.ServerAuthCapabilities>);
 
   @override
   bool isPermanentAuthFailure(Object? error) => (super.noSuchMethod(
@@ -900,37 +938,81 @@ class MockAuthService extends _i1.Mock implements _i10.AuthService {
       ) as bool);
 
   @override
-  _i15.Future<void> clearSessionKeys() => (super.noSuchMethod(
+  _i16.Future<void> clearSessionKeys() => (super.noSuchMethod(
         Invocation.method(
           #clearSessionKeys,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> migrateStorageKeys() => (super.noSuchMethod(
+  _i16.Future<void> saveLoginCredentials({
+    required String? homeserver,
+    required String? username,
+    required String? password,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #saveLoginCredentials,
+          [],
+          {
+            #homeserver: homeserver,
+            #username: username,
+            #password: password,
+          },
+        ),
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
+
+  @override
+  _i16.Future<({String password, String username})?> loadLoginCredentials(
+          String? homeserver) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #loadLoginCredentials,
+          [homeserver],
+        ),
+        returnValue: _i16.Future<({String password, String username})?>.value(),
+        returnValueForMissingStub:
+            _i16.Future<({String password, String username})?>.value(),
+      ) as _i16.Future<({String password, String username})?>);
+
+  @override
+  _i16.Future<void> clearLoginCredentials(String? homeserver) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #clearLoginCredentials,
+          [homeserver],
+        ),
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
+
+  @override
+  _i16.Future<void> migrateStorageKeys() => (super.noSuchMethod(
         Invocation.method(
           #migrateStorageKeys,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> persistCredentials() => (super.noSuchMethod(
+  _i16.Future<void> persistCredentials() => (super.noSuchMethod(
         Invocation.method(
           #persistCredentials,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  void addListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -939,7 +1021,7 @@ class MockAuthService extends _i1.Mock implements _i10.AuthService {
       );
 
   @override
-  void removeListener(_i16.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i17.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/test/widgets/invite_dialog_test.mocks.dart
+++ b/test/widgets/invite_dialog_test.mocks.dart
@@ -3,14 +3,15 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i14;
-import 'dart:typed_data' as _i24;
-import 'dart:ui' as _i18;
+import 'dart:async' as _i15;
+import 'dart:typed_data' as _i25;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
-import 'package:http/http.dart' as _i13;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
+import 'package:http/http.dart' as _i14;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i12;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -25,14 +26,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i23;
+import 'package:matrix/encryption.dart' as _i24;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i15;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i12;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i16;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i23;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i13;
+import 'package:matrix/src/utils/space_child.dart' as _i22;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -154,8 +155,9 @@ class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
         );
 }
 
-class _FakeRoomSummary_10 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_10(
+class _FakeStickerPackService_10 extends _i1.SmartFake
+    implements _i12.StickerPackService {
+  _FakeStickerPackService_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -164,9 +166,8 @@ class _FakeRoomSummary_10 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_11<T> extends _i1.SmartFake
-    implements _i12.CachedStreamController<T> {
-  _FakeCachedStreamController_11(
+class _FakeRoomSummary_11 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -175,8 +176,9 @@ class _FakeCachedStreamController_11<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_12 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_12(
+class _FakeCachedStreamController_12<T> extends _i1.SmartFake
+    implements _i13.CachedStreamController<T> {
+  _FakeCachedStreamController_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -185,9 +187,19 @@ class _FakeDateTime_12 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_13 extends _i1.SmartFake
+class _FakeDateTime_13 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_13(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_14 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_13(
+  _FakeLatestReceiptState_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -196,8 +208,8 @@ class _FakeLatestReceiptState_13 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_14 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_14(
+class _FakeSyncUpdate_15 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -206,8 +218,8 @@ class _FakeSyncUpdate_14 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeTimeline_15 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_15(
+class _FakeTimeline_16 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -216,8 +228,8 @@ class _FakeTimeline_15 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_16 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_16(
+class _FakeUser_17 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -226,8 +238,8 @@ class _FakeUser_16 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeUri_17 extends _i1.SmartFake implements Uri {
-  _FakeUri_17(
+class _FakeUri_18 extends _i1.SmartFake implements Uri {
+  _FakeUri_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -236,8 +248,8 @@ class _FakeUri_17 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_18 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_18(
+class _FakeDatabaseApi_19 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -246,8 +258,8 @@ class _FakeDatabaseApi_18 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_19 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_19(
+class _FakeFilter_20 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -256,9 +268,9 @@ class _FakeFilter_19 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_20 extends _i1.SmartFake
+class _FakeNativeImplementations_21 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_20(
+  _FakeNativeImplementations_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -267,8 +279,8 @@ class _FakeNativeImplementations_20 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_21 extends _i1.SmartFake implements Duration {
-  _FakeDuration_21(
+class _FakeDuration_22 extends _i1.SmartFake implements Duration {
+  _FakeDuration_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -277,9 +289,9 @@ class _FakeDuration_21 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_22 extends _i1.SmartFake
+class _FakePushruleEvaluator_23 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_22(
+  _FakePushruleEvaluator_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -288,8 +300,8 @@ class _FakePushruleEvaluator_22 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_23 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_23(
+class _FakeProfile_24 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -298,8 +310,8 @@ class _FakeProfile_23 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeClient_24 extends _i1.SmartFake implements _i13.Client {
-  _FakeClient_24(
+class _FakeClient_25 extends _i1.SmartFake implements _i14.Client {
+  _FakeClient_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -308,9 +320,9 @@ class _FakeClient_24 extends _i1.SmartFake implements _i13.Client {
         );
 }
 
-class _FakeDiscoveryInformation_25 extends _i1.SmartFake
+class _FakeDiscoveryInformation_26 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_25(
+  _FakeDiscoveryInformation_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -319,9 +331,9 @@ class _FakeDiscoveryInformation_25 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_26 extends _i1.SmartFake
+class _FakeGetVersionsResponse_27 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_26(
+  _FakeGetVersionsResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -330,9 +342,9 @@ class _FakeGetVersionsResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_27 extends _i1.SmartFake
+class _FakeRegisterResponse_28 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_27(
+  _FakeRegisterResponse_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -341,8 +353,8 @@ class _FakeRegisterResponse_27 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_28 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_28(
+class _FakeLoginResponse_29 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -351,9 +363,9 @@ class _FakeLoginResponse_28 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_29 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_30 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_29(
+  _FakeGetAuthMetadataResponse_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -362,8 +374,8 @@ class _FakeGetAuthMetadataResponse_29 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_30<T1> extends _i1.SmartFake implements _i14.Future<T1> {
-  _FakeFuture_30(
+class _FakeFuture_31<T1> extends _i1.SmartFake implements _i15.Future<T1> {
+  _FakeFuture_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -372,9 +384,9 @@ class _FakeFuture_30<T1> extends _i1.SmartFake implements _i14.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_31 extends _i1.SmartFake
+class _FakeCachedProfileInformation_32 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_31(
+  _FakeCachedProfileInformation_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -383,8 +395,8 @@ class _FakeCachedProfileInformation_31 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_32 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_32(
+class _FakeMediaConfig_33 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -393,8 +405,8 @@ class _FakeMediaConfig_32 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_33 extends _i1.SmartFake implements _i15.FileResponse {
-  _FakeFileResponse_33(
+class _FakeFileResponse_34 extends _i1.SmartFake implements _i16.FileResponse {
+  _FakeFileResponse_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -403,8 +415,8 @@ class _FakeFileResponse_33 extends _i1.SmartFake implements _i15.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_34 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_34(
+class _FakePreviewForUrl_35 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -413,9 +425,9 @@ class _FakePreviewForUrl_34 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_35 extends _i1.SmartFake
+class _FakeCachedPresence_36 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_35(
+  _FakeCachedPresence_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -424,9 +436,9 @@ class _FakeCachedPresence_35 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_36 extends _i1.SmartFake
+class _FakeTurnServerCredentials_37 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_36(
+  _FakeTurnServerCredentials_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -435,9 +447,9 @@ class _FakeTurnServerCredentials_36 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_37 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_38 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_37(
+  _FakeRoomKeysUpdateResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -446,8 +458,8 @@ class _FakeRoomKeysUpdateResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_38 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_38(
+class _FakeKeyBackupData_39 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -456,9 +468,9 @@ class _FakeKeyBackupData_38 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_39 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_40 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_39(
+  _FakeGetWellknownSupportResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -467,9 +479,9 @@ class _FakeGetWellknownSupportResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_40 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_41 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_40(
+  _FakeGenerateLoginTokenResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -478,9 +490,9 @@ class _FakeGenerateLoginTokenResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_41 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_42 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_41(
+  _FakeGetRoomSummaryResponse$3_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -489,9 +501,9 @@ class _FakeGetRoomSummaryResponse$3_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_42 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_43 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_42(
+  _FakeGetSpaceHierarchyResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -500,9 +512,9 @@ class _FakeGetSpaceHierarchyResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_43 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_44 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_43(
+  _FakeGetRelatingEventsResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -511,9 +523,9 @@ class _FakeGetRelatingEventsResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_44 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_45 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_44(
+  _FakeGetRelatingEventsWithRelTypeResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -522,9 +534,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -533,9 +545,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_46 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_47 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_46(
+  _FakeGetThreadRootsResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -544,9 +556,9 @@ class _FakeGetThreadRootsResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_47 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_48 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_47(
+  _FakeGetEventByTimestampResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -555,9 +567,9 @@ class _FakeGetEventByTimestampResponse_47 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_48 extends _i1.SmartFake
+class _FakeRequestTokenResponse_49 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_48(
+  _FakeRequestTokenResponse_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -566,9 +578,9 @@ class _FakeRequestTokenResponse_48 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_49 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_50 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_49(
+  _FakeTokenOwnerInfo_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -577,8 +589,8 @@ class _FakeTokenOwnerInfo_49 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_50 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_50(
+class _FakeWhoIsInfo_51 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -587,8 +599,8 @@ class _FakeWhoIsInfo_50 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_51 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_51(
+class _FakeCapabilities_52 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -597,8 +609,8 @@ class _FakeCapabilities_51 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_52 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_52(
+class _FakeDevice_53 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -607,9 +619,9 @@ class _FakeDevice_52 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_53 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_54 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_53(
+  _FakeGetRoomIdByAliasResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -618,9 +630,9 @@ class _FakeGetRoomIdByAliasResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_54 extends _i1.SmartFake
+class _FakeGetEventsResponse_55 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_54(
+  _FakeGetEventsResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -629,9 +641,9 @@ class _FakeGetEventsResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_55 extends _i1.SmartFake
+class _FakePeekEventsResponse_56 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_55(
+  _FakePeekEventsResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -640,8 +652,8 @@ class _FakePeekEventsResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_56 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_56(
+class _FakeMatrixEvent_57 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -650,9 +662,9 @@ class _FakeMatrixEvent_56 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_57 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_58 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_57(
+  _FakeGetKeysChangesResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -661,9 +673,9 @@ class _FakeGetKeysChangesResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_58 extends _i1.SmartFake
+class _FakeClaimKeysResponse_59 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_58(
+  _FakeClaimKeysResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -672,9 +684,9 @@ class _FakeClaimKeysResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_59 extends _i1.SmartFake
+class _FakeQueryKeysResponse_60 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_59(
+  _FakeQueryKeysResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -683,9 +695,9 @@ class _FakeQueryKeysResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_60 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_61 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_60(
+  _FakeGetNotificationsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -694,9 +706,9 @@ class _FakeGetNotificationsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_61 extends _i1.SmartFake
+class _FakeGetPresenceResponse_62 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_61(
+  _FakeGetPresenceResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -705,9 +717,9 @@ class _FakeGetPresenceResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_62 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_63 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_62(
+  _FakeGetPublicRoomsResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -716,9 +728,9 @@ class _FakeGetPublicRoomsResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_63 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_64 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_63(
+  _FakeQueryPublicRoomsResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -727,8 +739,8 @@ class _FakeQueryPublicRoomsResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_64 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_64(
+class _FakePushRuleSet_65 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -737,9 +749,9 @@ class _FakePushRuleSet_64 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_65 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_66 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_65(
+  _FakeGetPushRulesGlobalResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -748,8 +760,8 @@ class _FakeGetPushRulesGlobalResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_66 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_66(
+class _FakePushRule_67 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -758,9 +770,9 @@ class _FakePushRule_66 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_67 extends _i1.SmartFake
+class _FakeRefreshResponse_68 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_67(
+  _FakeRefreshResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -769,8 +781,8 @@ class _FakeRefreshResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_68 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_68(
+class _FakeRoomKeys_69 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -779,8 +791,8 @@ class _FakeRoomKeys_68 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_69 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_69(
+class _FakeRoomKeyBackup_70 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -789,9 +801,9 @@ class _FakeRoomKeyBackup_69 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_70 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_71 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_70(
+  _FakeGetRoomKeysVersionCurrentResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -800,9 +812,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_71 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_72 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_71(
+  _FakeGetRoomKeysVersionResponse_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -811,8 +823,8 @@ class _FakeGetRoomKeysVersionResponse_71 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_72 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_72(
+class _FakeEventContext_73 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -821,9 +833,9 @@ class _FakeEventContext_72 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_73 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_74 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_73(
+  _FakeGetRoomEventsResponse_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -832,8 +844,8 @@ class _FakeGetRoomEventsResponse_73 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_74 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_74(
+class _FakeSearchResults_75 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,9 +854,9 @@ class _FakeSearchResults_74 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_75 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_76 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_75(
+  _FakeGetProtocolMetadataResponse$2_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -853,9 +865,9 @@ class _FakeGetProtocolMetadataResponse$2_75 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_76 extends _i1.SmartFake
+class _FakeOpenIdCredentials_77 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_76(
+  _FakeOpenIdCredentials_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -864,9 +876,9 @@ class _FakeOpenIdCredentials_76 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_77 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_78 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_77(
+  _FakeSearchUserDirectoryResponse_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -875,9 +887,9 @@ class _FakeSearchUserDirectoryResponse_77 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_78 extends _i1.SmartFake
+class _FakeCreateContentResponse_79 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_78(
+  _FakeCreateContentResponse_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -889,7 +901,7 @@ class _FakeCreateContentResponse_78 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -919,11 +931,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1048,6 +1060,19 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i11.OutboxService);
 
   @override
+  _i12.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i12.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -1145,6 +1170,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set stickerPacks(_i12.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -1152,14 +1186,14 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i15.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1189,7 +1223,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1199,21 +1233,22 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i15.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> login({
+  _i15.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1223,14 +1258,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> completeSsoLogin({
+  _i15.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1243,12 +1279,12 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> completeRegistration(
+  _i15.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1258,32 +1294,32 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i15.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1292,7 +1328,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1301,17 +1337,17 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i15.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1322,7 +1358,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1359,26 +1395,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i15.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+  _i15.Future<bool> didPushRouteInformation(
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1408,7 +1444,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1417,7 +1453,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1426,16 +1462,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i15.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i15.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i14.Future<_i18.AppExitResponse>);
+            _i15.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i15.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1463,11 +1499,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1497,11 +1533,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_10(
+        returnValue: _FakeRoomSummary_11(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_10(
+        returnValueForMissingStub: _FakeRoomSummary_11(
           this,
           Invocation.getter(#summary),
         ),
@@ -1531,11 +1567,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i14.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i15.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i14.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i14.Completer<dynamic>>[],
-      ) as List<_i14.Completer<dynamic>>);
+        returnValue: <_i15.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i15.Completer<dynamic>>[],
+      ) as List<_i15.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1554,51 +1590,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i12.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i13.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_11<String>(
+        returnValue: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i12.CachedStreamController<String> get onSessionKeyReceived =>
+  _i13.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_11<String>(
+        returnValue: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1614,11 +1650,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1627,11 +1663,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1674,11 +1710,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1687,11 +1723,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_12(
+        returnValue: _FakeDateTime_13(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_12(
+        returnValueForMissingStub: _FakeDateTime_13(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -1721,11 +1757,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_13(
+        returnValue: _FakeLatestReceiptState_14(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_13(
+        returnValueForMissingStub: _FakeLatestReceiptState_14(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -1746,18 +1782,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i14.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i15.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -1944,18 +1980,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i22.SpaceParent>[],
+        returnValueForMissingStub: <_i22.SpaceParent>[],
+      ) as List<_i22.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i22.SpaceChild>[],
+        returnValueForMissingStub: <_i22.SpaceChild>[],
+      ) as List<_i22.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -2068,14 +2104,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i14.Future<void> postLoad() => (super.noSuchMethod(
+  _i15.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -2103,15 +2139,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i14.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i15.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i14.Future<List<_i4.User>>);
+            _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i15.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -2122,14 +2158,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2139,18 +2175,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i14.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i15.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Event?> refreshLastEvent(
+  _i15.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2158,9 +2194,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -2172,12 +2208,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i14.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i15.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2185,22 +2221,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i15.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2208,17 +2244,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> addTag(
+  _i15.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2228,27 +2264,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i15.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i15.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2256,53 +2292,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i15.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i15.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+  _i15.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
         Invocation.method(
           #setLowPriority,
           [lowPriority],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i15.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2310,14 +2346,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2329,7 +2365,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i14.Future<String?> sendTextEvent(
+  _i15.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2361,12 +2397,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendReaction(
+  _i15.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2380,12 +2416,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendLocation(
+  _i15.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2399,12 +2435,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendFileEvent(
+  _i15.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2432,25 +2468,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i15.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i14.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i15.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i14.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i15.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i14.Future<_i4.EncryptionHealthState>);
+      ) as _i15.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i14.Future<String?> sendEvent(
+  _i15.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -2474,73 +2510,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i15.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> leave() => (super.noSuchMethod(
+  _i15.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> forget() => (super.noSuchMethod(
+  _i15.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> setPower(
+  _i15.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2552,7 +2588,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2563,7 +2599,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2573,10 +2609,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> invite(
+  _i15.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2586,12 +2622,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<int> requestHistory({
+  _i15.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -2608,32 +2644,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<int>.value(0),
-        returnValueForMissingStub: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+        returnValueForMissingStub: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
-  _i14.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i15.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setReadMarker(
+  _i15.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2647,23 +2683,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
+  _i15.Future<_i23.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i14.Future<_i22.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i14.Future<_i22.TimelineChunk?>.value(),
-      ) as _i14.Future<_i22.TimelineChunk?>);
+        returnValue: _i15.Future<_i23.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i15.Future<_i23.TimelineChunk?>.value(),
+      ) as _i15.Future<_i23.TimelineChunk?>);
 
   @override
-  _i14.Future<void> postReceipt(
+  _i15.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -2673,12 +2709,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Timeline> getTimeline({
+  _i15.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2701,7 +2737,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i14.Future<_i4.Timeline>.value(_FakeTimeline_15(
+        returnValue: _i15.Future<_i4.Timeline>.value(_FakeTimeline_16(
           this,
           Invocation.method(
             #getTimeline,
@@ -2718,7 +2754,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Timeline>.value(_FakeTimeline_15(
+            _i15.Future<_i4.Timeline>.value(_FakeTimeline_16(
           this,
           Invocation.method(
             #getTimeline,
@@ -2734,7 +2770,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Timeline>);
+      ) as _i15.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -2753,7 +2789,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i14.Future<List<_i4.User>> requestParticipants([
+  _i15.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -2771,10 +2807,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i14.Future<List<_i4.User>>);
+            _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i15.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -2782,14 +2818,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_16(
+        returnValue: _FakeUser_17(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_16(
+        returnValueForMissingStub: _FakeUser_17(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -2805,14 +2841,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_16(
+        returnValue: _FakeUser_17(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_16(
+        returnValueForMissingStub: _FakeUser_17(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -2822,7 +2858,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i14.Future<_i4.User?> requestUser(
+  _i15.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2838,19 +2874,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i14.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.User?>.value(),
-      ) as _i14.Future<_i4.User?>);
+        returnValue: _i15.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.User?>.value(),
+      ) as _i15.Future<_i4.User?>);
 
   @override
-  _i14.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i15.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2863,12 +2899,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i14.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i15.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2876,14 +2912,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2906,14 +2942,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i14.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i15.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -2952,18 +2988,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i14.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i15.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEvent(
+  _i15.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -2977,12 +3013,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> setTyping(
+  _i15.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -2992,12 +3028,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setJoinRules(
+  _i15.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -3011,59 +3047,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i15.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setHistoryVisibility(
+  _i15.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i15.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i15.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i15.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i14.Future<List<_i4.DeviceKeys>>);
+            _i15.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i15.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i14.Future<void> requestSessionKey(
+  _i15.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -3075,12 +3111,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setSpaceChild(
+  _i15.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3096,44 +3132,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i15.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i14.Future<Uri>.value(_FakeUri_17(
+        returnValue: _i15.Future<Uri>.value(_FakeUri_18(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_17(
+        returnValueForMissingStub: _i15.Future<Uri>.value(_FakeUri_18(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i14.Future<Uri>);
+      ) as _i15.Future<Uri>);
 
   @override
-  _i14.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<
+  _i15.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -3160,21 +3196,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i14.Future<
+        returnValue: _i15.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i14.Future<
+        returnValueForMissingStub: _i15.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i14.Future<
+      ) as _i15.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -3189,23 +3225,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_18(
+        returnValue: _FakeDatabaseApi_19(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_18(
+        returnValueForMissingStub: _FakeDatabaseApi_19(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i23.KeyVerificationMethod> get verificationMethods =>
+  Set<_i24.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i23.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i23.KeyVerificationMethod>{},
-      ) as Set<_i23.KeyVerificationMethod>);
+        returnValue: <_i24.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i24.KeyVerificationMethod>{},
+      ) as Set<_i24.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3266,11 +3302,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_19(
+        returnValue: _FakeFilter_20(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_19(
+        returnValueForMissingStub: _FakeFilter_20(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -3279,11 +3315,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_20(
+        returnValue: _FakeNativeImplementations_21(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_20(
+        returnValueForMissingStub: _FakeNativeImplementations_21(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -3299,11 +3335,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_21(
+        returnValue: _FakeDuration_22(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_21(
+        returnValueForMissingStub: _FakeDuration_22(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3312,11 +3348,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_21(
+        returnValue: _FakeDuration_22(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_21(
+        returnValueForMissingStub: _FakeDuration_22(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3325,11 +3361,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -3366,11 +3402,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3400,11 +3436,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3413,11 +3449,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3440,11 +3476,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_22(
+        returnValue: _FakePushruleEvaluator_23(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_22(
+        returnValueForMissingStub: _FakePushruleEvaluator_23(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -3465,332 +3501,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i14.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i15.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i12.CachedStreamController<String> get onUserProfileUpdate =>
+  _i13.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_11<String>(
+        returnValue: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i14.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i15.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i14.Future<List<_i4.Room>>);
+            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i15.Future<List<_i4.Room>>);
 
   @override
-  _i12.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i13.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_11<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_12<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.EventUpdate>(
+            _FakeCachedStreamController_12<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.EventUpdate>);
+      ) as _i13.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i13.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_11<_i4.Event>(
+        returnValue: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i13.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_11<_i4.Event>(
+        returnValue: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onNotification =>
+  _i13.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_11<_i4.Event>(
+        returnValue: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i13.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_11<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_12<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_12<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i13.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i12.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i13.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_11<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_12<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_11<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_12<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i12.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i13.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i12.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i13.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_11<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_12<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.LoginState>(
+            _FakeCachedStreamController_12<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i12.CachedStreamController<_i4.LoginState>);
+      ) as _i13.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i12.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i13.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_11<bool>(
+        returnValue: _FakeCachedStreamController_12<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i12.CachedStreamController<bool>);
+      ) as _i13.CachedStreamController<bool>);
 
   @override
-  _i12.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i13.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_11<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_12<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i12.CachedStreamController<_i4.SdkError>);
+      ) as _i13.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i12.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i13.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_11<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_12<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.SyncUpdate>(
+            _FakeCachedStreamController_12<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i12.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i13.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i13.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_11<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_12<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_12<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i12.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i13.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.Presence> get onPresence =>
+  _i13.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_11<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_12<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i12.CachedStreamController<_i4.Presence>);
+      ) as _i13.CachedStreamController<_i4.Presence>);
 
   @override
-  _i12.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i13.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_11<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_12<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.CachedPresence>(
+            _FakeCachedStreamController_12<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i12.CachedStreamController<_i4.CachedPresence>);
+      ) as _i13.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i12.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i13.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_11<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_12<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.BasicEvent>(
+            _FakeCachedStreamController_12<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i12.CachedStreamController<_i4.BasicEvent>);
+      ) as _i13.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i12.CachedStreamController<_i23.RoomKeyRequest> get onRoomKeyRequest =>
+  _i13.CachedStreamController<_i24.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_11<_i23.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_12<_i24.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i23.RoomKeyRequest>(
+            _FakeCachedStreamController_12<_i24.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i12.CachedStreamController<_i23.RoomKeyRequest>);
+      ) as _i13.CachedStreamController<_i24.RoomKeyRequest>);
 
   @override
-  _i12.CachedStreamController<_i23.KeyVerification>
+  _i13.CachedStreamController<_i24.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_11<_i23.KeyVerification>(
+            returnValue: _FakeCachedStreamController_12<_i24.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_11<_i23.KeyVerification>(
+                _FakeCachedStreamController_12<_i24.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i12.CachedStreamController<_i23.KeyVerification>);
+          ) as _i13.CachedStreamController<_i24.KeyVerification>);
 
   @override
-  _i12.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i13.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_11<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_12<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_12<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i12.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i13.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i13.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_11<_i4.Event>(
+        returnValue: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<String> get onCancelSendEvent =>
+  _i13.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_11<String>(
+        returnValue: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i12.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i13.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_11<
+            returnValue: _FakeCachedStreamController_12<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_11<
+            returnValueForMissingStub: _FakeCachedStreamController_12<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i12.CachedStreamController<
+          ) as _i13.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -3810,11 +3846,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_12(
+        returnValue: _FakeDateTime_13(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_12(
+        returnValueForMissingStub: _FakeDateTime_13(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3887,7 +3923,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i23.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i24.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3942,7 +3978,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i14.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i15.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -3953,7 +3989,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i14.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i15.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -4064,7 +4100,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -4073,7 +4109,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -4082,7 +4118,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4109,20 +4145,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Client get httpClient => (super.noSuchMethod(
+  _i14.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_24(
+        returnValue: _FakeClient_25(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_24(
+        returnValueForMissingStub: _FakeClient_25(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i13.Client);
+      ) as _i14.Client);
 
   @override
-  set httpClient(_i13.Client? value) => super.noSuchMethod(
+  set httpClient(_i14.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4149,7 +4185,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<void> refreshAccessToken(
+  _i15.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4157,9 +4193,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4177,14 +4213,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4221,33 +4257,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i14.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i15.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_25(
+        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_26(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_25(
+        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_26(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i14.Future<_i4.DiscoveryInformation>);
+      ) as _i15.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i14.Future<
+  _i15.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -4269,7 +4305,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i14.Future<
+        returnValue: _i15.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4277,7 +4313,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_26(
+          _FakeGetVersionsResponse_27(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4292,7 +4328,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i14.Future<
+        returnValueForMissingStub: _i15.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4300,7 +4336,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_26(
+          _FakeGetVersionsResponse_27(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4315,7 +4351,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i14.Future<
+      ) as _i15.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -4324,7 +4360,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i14.Future<_i4.DiscoveryInformation> getWellknown({
+  _i15.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4337,8 +4373,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_25(
+        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_26(
           this,
           Invocation.method(
             #getWellknown,
@@ -4349,8 +4385,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_25(
+        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_26(
           this,
           Invocation.method(
             #getWellknown,
@@ -4361,10 +4397,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.DiscoveryInformation>);
+      ) as _i15.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i14.Future<_i4.RegisterResponse> register({
+  _i15.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -4392,7 +4428,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
+            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_28(
           this,
           Invocation.method(
             #register,
@@ -4411,7 +4447,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
+            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_28(
           this,
           Invocation.method(
             #register,
@@ -4429,10 +4465,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RegisterResponse>);
+      ) as _i15.Future<_i4.RegisterResponse>);
 
   @override
-  _i14.Future<_i4.LoginResponse> login(
+  _i15.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -4462,7 +4498,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
+        returnValue: _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_29(
           this,
           Invocation.method(
             #login,
@@ -4482,7 +4518,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
+            _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_29(
           this,
           Invocation.method(
             #login,
@@ -4501,10 +4537,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.LoginResponse>);
+      ) as _i15.Future<_i4.LoginResponse>);
 
   @override
-  _i14.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i15.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4517,8 +4553,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_29(
+        returnValue: _i15.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_30(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4530,8 +4566,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_29(
+            _i15.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_30(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4542,74 +4578,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i15.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logoutAll() => (super.noSuchMethod(
+  _i15.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<T> uiaRequestBackground<T>(
-          _i14.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i15.Future<T> uiaRequestBackground<T>(
+          _i15.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i14.Future<T>.value(v),
+              (T v) => _i15.Future<T>.value(v),
             ) ??
-            _FakeFuture_30<T>(
+            _FakeFuture_31<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i14.Future<T>.value(v),
+              (T v) => _i15.Future<T>.value(v),
             ) ??
-            _FakeFuture_30<T>(
+            _FakeFuture_31<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i14.Future<T>);
+      ) as _i15.Future<T>);
 
   @override
-  _i14.Future<String> startDirectChat(
+  _i15.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -4631,7 +4667,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4647,7 +4683,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4662,10 +4698,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> createGroupChat({
+  _i15.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -4696,7 +4732,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4717,7 +4753,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4737,10 +4773,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i15.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4756,7 +4792,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4769,7 +4805,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4781,21 +4817,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i15.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<String> createSpace({
+  _i15.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -4820,7 +4856,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4838,7 +4874,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4855,10 +4891,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i15.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4866,7 +4902,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4875,7 +4911,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4883,10 +4919,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i14.Future<_i4.Profile> fetchOwnProfile({
+  _i15.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4899,7 +4935,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4911,7 +4947,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4922,10 +4958,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i14.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i15.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4939,8 +4975,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i14.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_31(
+        returnValue: _i15.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_32(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4952,8 +4988,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_31(
+            _i15.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_32(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4964,10 +5000,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.CachedProfileInformation>);
+      ) as _i15.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i14.Future<_i4.Profile> getProfileFromUserId(
+  _i15.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -4985,7 +5021,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4999,7 +5035,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -5012,7 +5048,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -5034,31 +5070,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i14.Future<List<_i4.Room>>);
+            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i15.Future<List<_i4.Room>>);
 
   @override
-  _i14.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i15.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i14.Future<List<_i4.ArchivedRoom>>);
+            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i15.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i14.Future<_i4.GetVersionsResponse> getVersions({
+  _i15.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5071,8 +5107,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_26(
+        returnValue: _i15.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_27(
           this,
           Invocation.method(
             #getVersions,
@@ -5083,8 +5119,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_26(
+        returnValueForMissingStub: _i15.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_27(
           this,
           Invocation.method(
             #getVersions,
@@ -5095,20 +5131,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetVersionsResponse>);
+      ) as _i15.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i14.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i15.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.MediaConfig> getConfig({
+  _i15.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5121,7 +5157,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfig,
@@ -5133,7 +5169,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfig,
@@ -5144,10 +5180,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.MediaConfig>);
+      ) as _i15.Future<_i4.MediaConfig>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContent(
+  _i15.Future<_i16.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5167,7 +5203,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContent,
@@ -5183,7 +5219,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContent,
@@ -5198,10 +5234,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentOverrideName(
+  _i15.Future<_i16.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5223,7 +5259,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5240,7 +5276,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5256,10 +5292,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentThumbnail(
+  _i15.Future<_i16.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5287,7 +5323,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5307,7 +5343,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5326,10 +5362,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i15.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5339,7 +5375,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5348,7 +5384,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5356,11 +5392,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i14.Future<_i4.PreviewForUrl>);
+      ) as _i15.Future<_i4.PreviewForUrl>);
 
   @override
-  _i14.Future<Uri> uploadContent(
-    _i24.Uint8List? file, {
+  _i15.Future<Uri> uploadContent(
+    _i25.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5373,7 +5409,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i14.Future<Uri>.value(_FakeUri_17(
+        returnValue: _i15.Future<Uri>.value(_FakeUri_18(
           this,
           Invocation.method(
             #uploadContent,
@@ -5384,7 +5420,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_17(
+        returnValueForMissingStub: _i15.Future<Uri>.value(_FakeUri_18(
           this,
           Invocation.method(
             #uploadContent,
@@ -5395,10 +5431,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<Uri>);
+      ) as _i15.Future<Uri>);
 
   @override
-  _i14.Future<void> setTyping(
+  _i15.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5414,42 +5450,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> exportDump() => (super.noSuchMethod(
+  _i15.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i15.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i15.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Event?> getEventByPushNotification(
+  _i15.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -5465,12 +5501,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
-  _i14.Future<void> init({
+  _i15.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5505,9 +5541,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5519,40 +5555,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<void> clear() => (super.noSuchMethod(
+  _i15.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i15.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ensureNotSoftLoggedOut(
+  _i15.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSync(
+  _i15.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -5562,9 +5598,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -5577,29 +5613,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i14.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i15.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i15.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDevice(
+  _i15.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5613,12 +5649,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDevicesOfUserIds(
+  _i15.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5634,12 +5670,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDeviceEncrypted(
+  _i15.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5659,12 +5695,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDeviceEncryptedChunked(
+  _i15.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -5678,23 +5714,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i15.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> joinRoom(
+  _i15.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -5712,7 +5748,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5726,7 +5762,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5739,10 +5775,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> changePassword(
+  _i15.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -5758,22 +5794,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> clearCache() => (super.noSuchMethod(
+  _i15.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ignoreUser(
+  _i15.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5783,22 +5819,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i15.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i15.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5809,7 +5845,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_36(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5818,7 +5854,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_36(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5826,32 +5862,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i14.Future<_i4.CachedPresence>);
+      ) as _i15.Future<_i4.CachedPresence>);
 
   @override
-  _i14.Future<void> abortSync() => (super.noSuchMethod(
+  _i15.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i15.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEventWithMetadata(
+  _i15.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5871,14 +5907,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i13.BaseResponse? response,
-    _i24.Uint8List? body,
+    _i14.BaseResponse? response,
+    _i25.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5910,7 +5946,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i14.Future<Map<String, Object?>> request(
+  _i15.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -5931,13 +5967,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> postPusher(
+  _i15.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -5947,57 +5983,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i15.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i15.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i15.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i14.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_36(
+        returnValue: _i15.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_37(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_36(
+        returnValueForMissingStub: _i15.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_37(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.TurnServerCredentials>);
+      ) as _i15.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6011,8 +6047,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6024,8 +6060,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6036,10 +6072,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6055,8 +6091,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6069,8 +6105,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6082,10 +6118,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i15.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6099,7 +6135,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
+        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6111,7 +6147,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
+            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6122,17 +6158,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.KeyBackupData>);
+      ) as _i15.Future<_i4.KeyBackupData>);
 
   @override
-  _i14.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i15.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i14.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_39(
+        returnValue: _i15.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_40(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6140,18 +6176,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_39(
+            _i15.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_40(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i15.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i14.Future<int> pingAppservice(
+  _i15.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6161,12 +6197,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i14.Future<int>.value(0),
-        returnValueForMissingStub: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+        returnValueForMissingStub: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
-  _i14.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i15.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6174,8 +6210,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_40(
+        returnValue: _i15.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_41(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6184,8 +6220,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_40(
+            _i15.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_41(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6193,15 +6229,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i14.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i15.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i14.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i15.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6209,17 +6245,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.MediaConfig>);
+      ) as _i15.Future<_i4.MediaConfig>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentAuthed(
+  _i15.Future<_i16.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6233,7 +6269,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6245,7 +6281,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6256,10 +6292,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentOverrideNameAuthed(
+  _i15.Future<_i16.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6275,7 +6311,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6288,7 +6324,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6300,10 +6336,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i15.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6313,7 +6349,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6322,7 +6358,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6330,10 +6366,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i14.Future<_i4.PreviewForUrl>);
+      ) as _i15.Future<_i4.PreviewForUrl>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentThumbnailAuthed(
+  _i15.Future<_i16.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -6357,7 +6393,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6375,7 +6411,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6392,21 +6428,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<bool> registrationTokenValidity(String? token) =>
+  _i15.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i15.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6416,8 +6452,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_41(
+        returnValue: _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_42(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6426,8 +6462,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_41(
+            _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_42(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6435,10 +6471,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i15.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i14.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i15.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6456,8 +6492,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_42(
+        returnValue: _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_43(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6471,8 +6507,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_42(
+            _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_43(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6485,10 +6521,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i15.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i15.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -6512,8 +6548,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i14.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_43(
+        returnValue: _i15.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_44(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6531,8 +6567,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_43(
+            _i15.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_44(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6549,10 +6585,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i15.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6580,8 +6616,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_44(
+                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6600,8 +6636,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_44(
+                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6619,10 +6655,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i15.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6651,9 +6687,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i14.Future<
+            returnValue: _i15.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6672,9 +6708,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i14.Future<
+            returnValueForMissingStub: _i15.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6693,11 +6729,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i14
+          ) as _i15
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i14.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i15.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -6713,8 +6749,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i14.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_46(
+        returnValue: _i15.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_47(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6727,8 +6763,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_46(
+            _i15.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_47(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6740,10 +6776,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetThreadRootsResponse>);
+      ) as _i15.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i14.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i15.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -6757,8 +6793,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i14.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_47(
+        returnValue: _i15.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_48(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6770,8 +6806,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_47(
+            _i15.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_48(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6782,33 +6818,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i15.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i15.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i14.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i15.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i14.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i15.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i14.Future<Uri?>.value(),
-        returnValueForMissingStub: _i14.Future<Uri?>.value(),
-      ) as _i14.Future<Uri?>);
+        returnValue: _i15.Future<Uri?>.value(),
+        returnValueForMissingStub: _i15.Future<Uri?>.value(),
+      ) as _i15.Future<Uri?>);
 
   @override
-  _i14.Future<void> add3PID(
+  _i15.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -6822,12 +6858,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> bind3PID(
+  _i15.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6843,12 +6879,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i15.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6862,14 +6898,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6891,8 +6927,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6908,8 +6944,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6925,10 +6961,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6952,8 +6988,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6970,8 +7006,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6988,10 +7024,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i15.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -7005,14 +7041,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i15.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -7027,14 +7063,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7056,8 +7092,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7073,8 +7109,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7090,10 +7126,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7117,8 +7153,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7135,8 +7171,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7153,16 +7189,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i15.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
+            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_50(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7170,22 +7206,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
+            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_50(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.TokenOwnerInfo>);
+      ) as _i15.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i14.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i15.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
+        returnValue: _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_51(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7193,22 +7229,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
+            _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_51(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i14.Future<_i4.WhoIsInfo>);
+      ) as _i15.Future<_i4.WhoIsInfo>);
 
   @override
-  _i14.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i15.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
+        returnValue: _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_52(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7216,17 +7252,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
+            _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_52(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.Capabilities>);
+      ) as _i15.Future<_i4.Capabilities>);
 
   @override
-  _i14.Future<String> createRoom({
+  _i15.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -7259,7 +7295,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7281,7 +7317,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7302,10 +7338,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> deleteDevices(
+  _i15.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7315,22 +7351,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.Device>?>.value(),
-      ) as _i14.Future<List<_i4.Device>?>);
+        returnValue: _i15.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.Device>?>.value(),
+      ) as _i15.Future<List<_i4.Device>?>);
 
   @override
-  _i14.Future<void> deleteDevice(
+  _i15.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7340,34 +7376,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i15.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i14.Future<_i4.Device>.value(_FakeDevice_52(
+        returnValue: _i15.Future<_i4.Device>.value(_FakeDevice_53(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Device>.value(_FakeDevice_52(
+        returnValueForMissingStub: _i15.Future<_i4.Device>.value(_FakeDevice_53(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i14.Future<_i4.Device>);
+      ) as _i15.Future<_i4.Device>);
 
   @override
-  _i14.Future<void> updateDevice(
+  _i15.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7377,12 +7413,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i15.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -7397,24 +7433,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i15.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i14.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Visibility?>.value(),
-      ) as _i14.Future<_i4.Visibility?>);
+        returnValue: _i15.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Visibility?>.value(),
+      ) as _i15.Future<_i4.Visibility?>);
 
   @override
-  _i14.Future<void> setRoomVisibilityOnDirectory(
+  _i15.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -7424,30 +7460,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i15.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i15.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_53(
+        returnValue: _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_54(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7455,18 +7491,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_53(
+            _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_54(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i15.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i14.Future<void> setRoomAlias(
+  _i15.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7478,12 +7514,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetEventsResponse> getEvents({
+  _i15.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7497,7 +7533,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
+            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_55(
           this,
           Invocation.method(
             #getEvents,
@@ -7509,7 +7545,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
+            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_55(
           this,
           Invocation.method(
             #getEvents,
@@ -7520,10 +7556,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetEventsResponse>);
+      ) as _i15.Future<_i4.GetEventsResponse>);
 
   @override
-  _i14.Future<_i4.PeekEventsResponse> peekEvents({
+  _i15.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7538,8 +7574,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i14.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_55(
+        returnValue: _i15.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_56(
           this,
           Invocation.method(
             #peekEvents,
@@ -7551,8 +7587,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_55(
+        returnValueForMissingStub: _i15.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_56(
           this,
           Invocation.method(
             #peekEvents,
@@ -7564,16 +7600,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.PeekEventsResponse>);
+      ) as _i15.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i14.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i15.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
+        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7581,27 +7617,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
+            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i14.Future<_i4.MatrixEvent>);
+      ) as _i15.Future<_i4.MatrixEvent>);
 
   @override
-  _i14.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i15.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 
   @override
-  _i14.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i15.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7613,8 +7649,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i14.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_57(
+        returnValue: _i15.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_58(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7625,8 +7661,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_57(
+            _i15.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_58(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7636,10 +7672,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.GetKeysChangesResponse>);
+      ) as _i15.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i14.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i15.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7650,7 +7686,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
+            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_59(
           this,
           Invocation.method(
             #claimKeys,
@@ -7659,7 +7695,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
+            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_59(
           this,
           Invocation.method(
             #claimKeys,
@@ -7667,10 +7703,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i14.Future<_i4.ClaimKeysResponse>);
+      ) as _i15.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i14.Future<void> uploadCrossSigningKeys({
+  _i15.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -7687,12 +7723,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.QueryKeysResponse> queryKeys(
+  _i15.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7703,7 +7739,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
+            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_60(
           this,
           Invocation.method(
             #queryKeys,
@@ -7712,7 +7748,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
+            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_60(
           this,
           Invocation.method(
             #queryKeys,
@@ -7720,10 +7756,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i14.Future<_i4.QueryKeysResponse>);
+      ) as _i15.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7731,14 +7767,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i14.Future<
+            returnValue: _i15.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i14.Future<
+            returnValueForMissingStub: _i15.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i14.Future<Map<String, int>> uploadKeys({
+  _i15.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -7753,13 +7789,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i14.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i15.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i14.Future<Map<String, int>>);
+            _i15.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i15.Future<Map<String, int>>);
 
   @override
-  _i14.Future<String> knockRoom(
+  _i15.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7773,7 +7809,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7785,7 +7821,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7796,20 +7832,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i15.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i14.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i15.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i15.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i14.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i15.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7824,8 +7860,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i14.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_60(
+        returnValue: _i15.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_61(
           this,
           Invocation.method(
             #getNotifications,
@@ -7838,8 +7874,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_60(
+            _i15.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_61(
           this,
           Invocation.method(
             #getNotifications,
@@ -7851,35 +7887,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetNotificationsResponse>);
+      ) as _i15.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i14.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i15.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i14.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_61(
+        returnValue: _i15.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_62(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_61(
+        returnValueForMissingStub: _i15.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_62(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i14.Future<_i4.GetPresenceResponse>);
+      ) as _i15.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i14.Future<void> setPresence(
+  _i15.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -7893,12 +7929,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, Object?>> deleteProfileField(
+  _i15.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7911,13 +7947,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getProfileField(
+  _i15.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7930,13 +7966,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<Map<String, Object?>> setProfileField(
+  _i15.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7951,13 +7987,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i15.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -7972,8 +8008,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i14.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_62(
+        returnValue: _i15.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_63(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7986,8 +8022,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_62(
+            _i15.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_63(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7999,10 +8035,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i15.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i14.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i15.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -8023,8 +8059,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i14.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_63(
+        returnValue: _i15.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_64(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8040,8 +8076,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_63(
+            _i15.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_64(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8056,25 +8092,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i15.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i14.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.Pusher>?>.value(),
-      ) as _i14.Future<List<_i4.Pusher>?>);
+        returnValue: _i15.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.Pusher>?>.value(),
+      ) as _i15.Future<List<_i4.Pusher>?>);
 
   @override
-  _i14.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i15.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
+        returnValue: _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_65(
           this,
           Invocation.method(
             #getPushRules,
@@ -8082,24 +8118,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
+            _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_65(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.PushRuleSet>);
+      ) as _i15.Future<_i4.PushRuleSet>);
 
   @override
-  _i14.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i15.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_65(
+        returnValue: _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_66(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8107,18 +8143,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_65(
+            _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_66(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i15.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i14.Future<void> deletePushRule(
+  _i15.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8130,12 +8166,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.PushRule> getPushRule(
+  _i15.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8147,7 +8183,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<_i4.PushRule>.value(_FakePushRule_66(
+        returnValue: _i15.Future<_i4.PushRule>.value(_FakePushRule_67(
           this,
           Invocation.method(
             #getPushRule,
@@ -8158,7 +8194,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PushRule>.value(_FakePushRule_66(
+            _i15.Future<_i4.PushRule>.value(_FakePushRule_67(
           this,
           Invocation.method(
             #getPushRule,
@@ -8168,10 +8204,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.PushRule>);
+      ) as _i15.Future<_i4.PushRule>);
 
   @override
-  _i14.Future<void> setPushRule(
+  _i15.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -8195,12 +8231,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<Object?>> getPushRuleActions(
+  _i15.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8212,13 +8248,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i15.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i14.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i14.Future<List<Object?>>);
+            _i15.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i15.Future<List<Object?>>);
 
   @override
-  _i14.Future<void> setPushRuleActions(
+  _i15.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -8232,12 +8268,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> isPushRuleEnabled(
+  _i15.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8249,12 +8285,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> setPushRuleEnabled(
+  _i15.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -8268,19 +8304,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i15.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
+            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_68(
           this,
           Invocation.method(
             #refresh,
@@ -8288,28 +8324,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
+            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_68(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i14.Future<_i4.RefreshResponse>);
+      ) as _i15.Future<_i4.RefreshResponse>);
 
   @override
-  _i14.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i15.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i14.Future<bool?>.value(),
-        returnValueForMissingStub: _i14.Future<bool?>.value(),
-      ) as _i14.Future<bool?>);
+        returnValue: _i15.Future<bool?>.value(),
+        returnValueForMissingStub: _i15.Future<bool?>.value(),
+      ) as _i15.Future<bool?>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8331,8 +8367,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8348,8 +8384,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8365,10 +8401,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8392,8 +8428,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8410,8 +8446,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8428,17 +8464,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8446,23 +8482,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i15.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
+        returnValue: _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_69(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8470,17 +8506,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
+            _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_69(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeys>);
+      ) as _i15.Future<_i4.RoomKeys>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -8492,8 +8528,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8504,8 +8540,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8515,10 +8551,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8530,8 +8566,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8542,8 +8578,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8553,10 +8589,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8568,7 +8604,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
+        returnValue: _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_70(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8579,7 +8615,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
+            _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_70(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8589,10 +8625,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeyBackup>);
+      ) as _i15.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -8606,8 +8642,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8619,8 +8655,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8631,10 +8667,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8648,8 +8684,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8661,8 +8697,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8673,10 +8709,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i15.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8690,7 +8726,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
+        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8702,7 +8738,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
+            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8713,10 +8749,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.KeyBackupData>);
+      ) as _i15.Future<_i4.KeyBackupData>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8732,8 +8768,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8746,8 +8782,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8759,18 +8795,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_70(
+                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_71(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8778,18 +8814,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_70(
+                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_71(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i14.Future<String> postRoomKeysVersion(
+  _i15.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -8801,7 +8837,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8812,7 +8848,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8822,29 +8858,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i15.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i15.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_71(
+        returnValue: _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_72(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8852,18 +8888,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_71(
+            _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_72(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i15.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i15.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -8878,24 +8914,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i15.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 
   @override
-  _i14.Future<void> ban(
+  _i15.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8909,12 +8945,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.EventContext> getEventContext(
+  _i15.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -8932,7 +8968,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i4.EventContext>.value(_FakeEventContext_72(
+        returnValue: _i15.Future<_i4.EventContext>.value(_FakeEventContext_73(
           this,
           Invocation.method(
             #getEventContext,
@@ -8947,7 +8983,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.EventContext>.value(_FakeEventContext_72(
+            _i15.Future<_i4.EventContext>.value(_FakeEventContext_73(
           this,
           Invocation.method(
             #getEventContext,
@@ -8961,10 +8997,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.EventContext>);
+      ) as _i15.Future<_i4.EventContext>);
 
   @override
-  _i14.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i15.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -8976,7 +9012,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
+        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8987,7 +9023,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
+            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8997,20 +9033,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.MatrixEvent>);
+      ) as _i15.Future<_i4.MatrixEvent>);
 
   @override
-  _i14.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> inviteBy3PID(
+  _i15.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -9022,12 +9058,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> inviteUser(
+  _i15.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9041,12 +9077,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> joinRoomById(
+  _i15.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -9060,7 +9096,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9072,7 +9108,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9083,23 +9119,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i15.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i15.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i14.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i14.Future<Map<String, _i4.RoomMember>?>);
+            _i15.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i15.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i14.Future<void> kick(
+  _i15.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9113,12 +9149,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> leaveRoom(
+  _i15.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9128,12 +9164,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i15.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -9149,12 +9185,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i14.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i14.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i15.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i15.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i14.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i15.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -9176,8 +9212,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_73(
+        returnValue: _i15.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_74(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9193,8 +9229,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_73(
+        returnValueForMissingStub: _i15.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_74(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9210,10 +9246,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomEventsResponse>);
+      ) as _i15.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i14.Future<void> setReadMarker(
+  _i15.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9229,12 +9265,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> postReceipt(
+  _i15.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -9250,12 +9286,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEvent(
+  _i15.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9271,12 +9307,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> reportRoom(
+  _i15.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9288,12 +9324,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> reportEvent(
+  _i15.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9311,12 +9347,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> sendMessage(
+  _i15.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9332,7 +9368,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9345,7 +9381,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9357,23 +9393,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i15.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i14.Future<List<_i4.MatrixEvent>>);
+            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i15.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i15.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -9390,13 +9426,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<String> setRoomStateWithKey(
+  _i15.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9412,7 +9448,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9425,7 +9461,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9437,10 +9473,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> unban(
+  _i15.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9454,12 +9490,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> upgradeRoom(
+  _i15.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9473,7 +9509,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9485,7 +9521,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9496,10 +9532,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.SearchResults> search(
+  _i15.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -9509,7 +9545,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
+        returnValue: _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_75(
           this,
           Invocation.method(
             #search,
@@ -9518,7 +9554,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
+            _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_75(
           this,
           Invocation.method(
             #search,
@@ -9526,10 +9562,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i14.Future<_i4.SearchResults>);
+      ) as _i15.Future<_i4.SearchResults>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> sync({
+  _i15.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -9550,7 +9586,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #sync,
@@ -9566,7 +9602,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #sync,
@@ -9581,22 +9617,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i15.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i14.Future<List<_i4.Location>>);
+            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i15.Future<List<_i4.Location>>);
 
   @override
-  _i14.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i15.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9606,21 +9642,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i14.Future<List<_i4.Location>>);
+            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i15.Future<List<_i4.Location>>);
 
   @override
-  _i14.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i15.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_75(
+        returnValue: _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_76(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9628,45 +9664,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_75(
+            _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_76(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i14.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i15.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i14.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i15.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9677,13 +9713,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getAccountData(
+  _i15.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9696,13 +9732,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> setAccountData(
+  _i15.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9716,12 +9752,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> defineFilter(
+  _i15.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -9733,7 +9769,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9744,7 +9780,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9754,10 +9790,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.Filter> getFilter(
+  _i15.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9769,7 +9805,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i14.Future<_i4.Filter>.value(_FakeFilter_19(
+        returnValue: _i15.Future<_i4.Filter>.value(_FakeFilter_20(
           this,
           Invocation.method(
             #getFilter,
@@ -9779,7 +9815,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Filter>.value(_FakeFilter_19(
+        returnValueForMissingStub: _i15.Future<_i4.Filter>.value(_FakeFilter_20(
           this,
           Invocation.method(
             #getFilter,
@@ -9789,10 +9825,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.Filter>);
+      ) as _i15.Future<_i4.Filter>);
 
   @override
-  _i14.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i15.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9805,7 +9841,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
+            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_77(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9816,7 +9852,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
+            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_77(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9826,10 +9862,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.OpenIdCredentials>);
+      ) as _i15.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i14.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i15.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9844,13 +9880,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> setAccountDataPerRoom(
+  _i15.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9866,12 +9902,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i15.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9883,12 +9919,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i14.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i14.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i14.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i15.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i15.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i15.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i14.Future<void> deleteRoomTag(
+  _i15.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9902,12 +9938,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setRoomTag(
+  _i15.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9923,12 +9959,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i15.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9938,8 +9974,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i14.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_77(
+        returnValue: _i15.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_78(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9948,8 +9984,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_77(
+            _i15.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_78(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9957,10 +9993,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i14.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i15.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> reportUser(
+  _i15.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -9973,40 +10009,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i15.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i14.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_78(
+        returnValue: _i15.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_79(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_78(
+        returnValueForMissingStub: _i15.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_79(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.CreateContentResponse>);
+      ) as _i15.Future<_i4.CreateContentResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> uploadContentToMXC(
+  _i15.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i24.Uint8List? body, {
+    _i25.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -10024,8 +10060,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 }

--- a/test/widgets/invite_tile_test.mocks.dart
+++ b/test/widgets/invite_tile_test.mocks.dart
@@ -3,14 +3,15 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i14;
-import 'dart:typed_data' as _i24;
-import 'dart:ui' as _i18;
+import 'dart:async' as _i15;
+import 'dart:typed_data' as _i25;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
-import 'package:http/http.dart' as _i13;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
+import 'package:http/http.dart' as _i14;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i12;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -25,14 +26,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i23;
+import 'package:matrix/encryption.dart' as _i24;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i15;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i12;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i16;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i23;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i13;
+import 'package:matrix/src/utils/space_child.dart' as _i22;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -154,8 +155,9 @@ class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
         );
 }
 
-class _FakeRoomSummary_10 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_10(
+class _FakeStickerPackService_10 extends _i1.SmartFake
+    implements _i12.StickerPackService {
+  _FakeStickerPackService_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -164,9 +166,8 @@ class _FakeRoomSummary_10 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_11<T> extends _i1.SmartFake
-    implements _i12.CachedStreamController<T> {
-  _FakeCachedStreamController_11(
+class _FakeRoomSummary_11 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -175,8 +176,9 @@ class _FakeCachedStreamController_11<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_12 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_12(
+class _FakeCachedStreamController_12<T> extends _i1.SmartFake
+    implements _i13.CachedStreamController<T> {
+  _FakeCachedStreamController_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -185,9 +187,19 @@ class _FakeDateTime_12 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_13 extends _i1.SmartFake
+class _FakeDateTime_13 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_13(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_14 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_13(
+  _FakeLatestReceiptState_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -196,8 +208,8 @@ class _FakeLatestReceiptState_13 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_14 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_14(
+class _FakeSyncUpdate_15 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -206,8 +218,8 @@ class _FakeSyncUpdate_14 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeTimeline_15 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_15(
+class _FakeTimeline_16 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -216,8 +228,8 @@ class _FakeTimeline_15 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_16 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_16(
+class _FakeUser_17 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -226,8 +238,8 @@ class _FakeUser_16 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeUri_17 extends _i1.SmartFake implements Uri {
-  _FakeUri_17(
+class _FakeUri_18 extends _i1.SmartFake implements Uri {
+  _FakeUri_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -236,8 +248,8 @@ class _FakeUri_17 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_18 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_18(
+class _FakeDatabaseApi_19 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -246,8 +258,8 @@ class _FakeDatabaseApi_18 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_19 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_19(
+class _FakeFilter_20 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -256,9 +268,9 @@ class _FakeFilter_19 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_20 extends _i1.SmartFake
+class _FakeNativeImplementations_21 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_20(
+  _FakeNativeImplementations_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -267,8 +279,8 @@ class _FakeNativeImplementations_20 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_21 extends _i1.SmartFake implements Duration {
-  _FakeDuration_21(
+class _FakeDuration_22 extends _i1.SmartFake implements Duration {
+  _FakeDuration_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -277,9 +289,9 @@ class _FakeDuration_21 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_22 extends _i1.SmartFake
+class _FakePushruleEvaluator_23 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_22(
+  _FakePushruleEvaluator_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -288,8 +300,8 @@ class _FakePushruleEvaluator_22 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_23 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_23(
+class _FakeProfile_24 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -298,8 +310,8 @@ class _FakeProfile_23 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeClient_24 extends _i1.SmartFake implements _i13.Client {
-  _FakeClient_24(
+class _FakeClient_25 extends _i1.SmartFake implements _i14.Client {
+  _FakeClient_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -308,9 +320,9 @@ class _FakeClient_24 extends _i1.SmartFake implements _i13.Client {
         );
 }
 
-class _FakeDiscoveryInformation_25 extends _i1.SmartFake
+class _FakeDiscoveryInformation_26 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_25(
+  _FakeDiscoveryInformation_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -319,9 +331,9 @@ class _FakeDiscoveryInformation_25 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_26 extends _i1.SmartFake
+class _FakeGetVersionsResponse_27 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_26(
+  _FakeGetVersionsResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -330,9 +342,9 @@ class _FakeGetVersionsResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_27 extends _i1.SmartFake
+class _FakeRegisterResponse_28 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_27(
+  _FakeRegisterResponse_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -341,8 +353,8 @@ class _FakeRegisterResponse_27 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_28 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_28(
+class _FakeLoginResponse_29 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -351,9 +363,9 @@ class _FakeLoginResponse_28 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_29 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_30 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_29(
+  _FakeGetAuthMetadataResponse_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -362,8 +374,8 @@ class _FakeGetAuthMetadataResponse_29 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_30<T1> extends _i1.SmartFake implements _i14.Future<T1> {
-  _FakeFuture_30(
+class _FakeFuture_31<T1> extends _i1.SmartFake implements _i15.Future<T1> {
+  _FakeFuture_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -372,9 +384,9 @@ class _FakeFuture_30<T1> extends _i1.SmartFake implements _i14.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_31 extends _i1.SmartFake
+class _FakeCachedProfileInformation_32 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_31(
+  _FakeCachedProfileInformation_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -383,8 +395,8 @@ class _FakeCachedProfileInformation_31 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_32 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_32(
+class _FakeMediaConfig_33 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -393,8 +405,8 @@ class _FakeMediaConfig_32 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_33 extends _i1.SmartFake implements _i15.FileResponse {
-  _FakeFileResponse_33(
+class _FakeFileResponse_34 extends _i1.SmartFake implements _i16.FileResponse {
+  _FakeFileResponse_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -403,8 +415,8 @@ class _FakeFileResponse_33 extends _i1.SmartFake implements _i15.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_34 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_34(
+class _FakePreviewForUrl_35 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -413,9 +425,9 @@ class _FakePreviewForUrl_34 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_35 extends _i1.SmartFake
+class _FakeCachedPresence_36 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_35(
+  _FakeCachedPresence_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -424,9 +436,9 @@ class _FakeCachedPresence_35 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_36 extends _i1.SmartFake
+class _FakeTurnServerCredentials_37 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_36(
+  _FakeTurnServerCredentials_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -435,9 +447,9 @@ class _FakeTurnServerCredentials_36 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_37 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_38 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_37(
+  _FakeRoomKeysUpdateResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -446,8 +458,8 @@ class _FakeRoomKeysUpdateResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_38 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_38(
+class _FakeKeyBackupData_39 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -456,9 +468,9 @@ class _FakeKeyBackupData_38 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_39 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_40 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_39(
+  _FakeGetWellknownSupportResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -467,9 +479,9 @@ class _FakeGetWellknownSupportResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_40 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_41 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_40(
+  _FakeGenerateLoginTokenResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -478,9 +490,9 @@ class _FakeGenerateLoginTokenResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_41 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_42 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_41(
+  _FakeGetRoomSummaryResponse$3_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -489,9 +501,9 @@ class _FakeGetRoomSummaryResponse$3_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_42 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_43 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_42(
+  _FakeGetSpaceHierarchyResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -500,9 +512,9 @@ class _FakeGetSpaceHierarchyResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_43 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_44 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_43(
+  _FakeGetRelatingEventsResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -511,9 +523,9 @@ class _FakeGetRelatingEventsResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_44 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_45 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_44(
+  _FakeGetRelatingEventsWithRelTypeResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -522,9 +534,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -533,9 +545,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_46 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_47 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_46(
+  _FakeGetThreadRootsResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -544,9 +556,9 @@ class _FakeGetThreadRootsResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_47 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_48 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_47(
+  _FakeGetEventByTimestampResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -555,9 +567,9 @@ class _FakeGetEventByTimestampResponse_47 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_48 extends _i1.SmartFake
+class _FakeRequestTokenResponse_49 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_48(
+  _FakeRequestTokenResponse_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -566,9 +578,9 @@ class _FakeRequestTokenResponse_48 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_49 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_50 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_49(
+  _FakeTokenOwnerInfo_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -577,8 +589,8 @@ class _FakeTokenOwnerInfo_49 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_50 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_50(
+class _FakeWhoIsInfo_51 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -587,8 +599,8 @@ class _FakeWhoIsInfo_50 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_51 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_51(
+class _FakeCapabilities_52 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -597,8 +609,8 @@ class _FakeCapabilities_51 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_52 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_52(
+class _FakeDevice_53 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -607,9 +619,9 @@ class _FakeDevice_52 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_53 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_54 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_53(
+  _FakeGetRoomIdByAliasResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -618,9 +630,9 @@ class _FakeGetRoomIdByAliasResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_54 extends _i1.SmartFake
+class _FakeGetEventsResponse_55 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_54(
+  _FakeGetEventsResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -629,9 +641,9 @@ class _FakeGetEventsResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_55 extends _i1.SmartFake
+class _FakePeekEventsResponse_56 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_55(
+  _FakePeekEventsResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -640,8 +652,8 @@ class _FakePeekEventsResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_56 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_56(
+class _FakeMatrixEvent_57 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -650,9 +662,9 @@ class _FakeMatrixEvent_56 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_57 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_58 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_57(
+  _FakeGetKeysChangesResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -661,9 +673,9 @@ class _FakeGetKeysChangesResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_58 extends _i1.SmartFake
+class _FakeClaimKeysResponse_59 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_58(
+  _FakeClaimKeysResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -672,9 +684,9 @@ class _FakeClaimKeysResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_59 extends _i1.SmartFake
+class _FakeQueryKeysResponse_60 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_59(
+  _FakeQueryKeysResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -683,9 +695,9 @@ class _FakeQueryKeysResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_60 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_61 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_60(
+  _FakeGetNotificationsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -694,9 +706,9 @@ class _FakeGetNotificationsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_61 extends _i1.SmartFake
+class _FakeGetPresenceResponse_62 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_61(
+  _FakeGetPresenceResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -705,9 +717,9 @@ class _FakeGetPresenceResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_62 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_63 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_62(
+  _FakeGetPublicRoomsResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -716,9 +728,9 @@ class _FakeGetPublicRoomsResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_63 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_64 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_63(
+  _FakeQueryPublicRoomsResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -727,8 +739,8 @@ class _FakeQueryPublicRoomsResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_64 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_64(
+class _FakePushRuleSet_65 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -737,9 +749,9 @@ class _FakePushRuleSet_64 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_65 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_66 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_65(
+  _FakeGetPushRulesGlobalResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -748,8 +760,8 @@ class _FakeGetPushRulesGlobalResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_66 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_66(
+class _FakePushRule_67 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -758,9 +770,9 @@ class _FakePushRule_66 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_67 extends _i1.SmartFake
+class _FakeRefreshResponse_68 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_67(
+  _FakeRefreshResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -769,8 +781,8 @@ class _FakeRefreshResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_68 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_68(
+class _FakeRoomKeys_69 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -779,8 +791,8 @@ class _FakeRoomKeys_68 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_69 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_69(
+class _FakeRoomKeyBackup_70 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -789,9 +801,9 @@ class _FakeRoomKeyBackup_69 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_70 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_71 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_70(
+  _FakeGetRoomKeysVersionCurrentResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -800,9 +812,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_71 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_72 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_71(
+  _FakeGetRoomKeysVersionResponse_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -811,8 +823,8 @@ class _FakeGetRoomKeysVersionResponse_71 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_72 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_72(
+class _FakeEventContext_73 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -821,9 +833,9 @@ class _FakeEventContext_72 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_73 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_74 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_73(
+  _FakeGetRoomEventsResponse_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -832,8 +844,8 @@ class _FakeGetRoomEventsResponse_73 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_74 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_74(
+class _FakeSearchResults_75 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -842,9 +854,9 @@ class _FakeSearchResults_74 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_75 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_76 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_75(
+  _FakeGetProtocolMetadataResponse$2_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -853,9 +865,9 @@ class _FakeGetProtocolMetadataResponse$2_75 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_76 extends _i1.SmartFake
+class _FakeOpenIdCredentials_77 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_76(
+  _FakeOpenIdCredentials_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -864,9 +876,9 @@ class _FakeOpenIdCredentials_76 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_77 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_78 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_77(
+  _FakeSearchUserDirectoryResponse_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -875,9 +887,9 @@ class _FakeSearchUserDirectoryResponse_77 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_78 extends _i1.SmartFake
+class _FakeCreateContentResponse_79 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_78(
+  _FakeCreateContentResponse_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -889,7 +901,7 @@ class _FakeCreateContentResponse_78 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -919,11 +931,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1048,6 +1060,19 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i11.OutboxService);
 
   @override
+  _i12.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i12.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -1145,6 +1170,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set stickerPacks(_i12.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -1152,14 +1186,14 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i15.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1189,7 +1223,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1199,21 +1233,22 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i15.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> login({
+  _i15.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1223,14 +1258,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> completeSsoLogin({
+  _i15.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1243,12 +1279,12 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> completeRegistration(
+  _i15.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1258,32 +1294,32 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i15.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1292,7 +1328,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1301,17 +1337,17 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i15.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1322,7 +1358,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1359,26 +1395,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i15.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+  _i15.Future<bool> didPushRouteInformation(
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1408,7 +1444,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1417,7 +1453,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1426,16 +1462,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i15.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i15.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i14.Future<_i18.AppExitResponse>);
+            _i15.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i15.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1463,11 +1499,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1497,11 +1533,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_10(
+        returnValue: _FakeRoomSummary_11(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_10(
+        returnValueForMissingStub: _FakeRoomSummary_11(
           this,
           Invocation.getter(#summary),
         ),
@@ -1531,11 +1567,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i14.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i15.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i14.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i14.Completer<dynamic>>[],
-      ) as List<_i14.Completer<dynamic>>);
+        returnValue: <_i15.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i15.Completer<dynamic>>[],
+      ) as List<_i15.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1554,51 +1590,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i12.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i13.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_11<String>(
+        returnValue: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i12.CachedStreamController<String> get onSessionKeyReceived =>
+  _i13.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_11<String>(
+        returnValue: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1614,11 +1650,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1627,11 +1663,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1674,11 +1710,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1687,11 +1723,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_12(
+        returnValue: _FakeDateTime_13(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_12(
+        returnValueForMissingStub: _FakeDateTime_13(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -1721,11 +1757,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_13(
+        returnValue: _FakeLatestReceiptState_14(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_13(
+        returnValueForMissingStub: _FakeLatestReceiptState_14(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -1746,18 +1782,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i14.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i15.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -1944,18 +1980,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i22.SpaceParent>[],
+        returnValueForMissingStub: <_i22.SpaceParent>[],
+      ) as List<_i22.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i22.SpaceChild>[],
+        returnValueForMissingStub: <_i22.SpaceChild>[],
+      ) as List<_i22.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -2068,14 +2104,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i14.Future<void> postLoad() => (super.noSuchMethod(
+  _i15.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -2103,15 +2139,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i14.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i15.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i14.Future<List<_i4.User>>);
+            _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i15.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -2122,14 +2158,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2139,18 +2175,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i14.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i15.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Event?> refreshLastEvent(
+  _i15.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2158,9 +2194,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -2172,12 +2208,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i14.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i15.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2185,22 +2221,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i15.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2208,17 +2244,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> addTag(
+  _i15.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2228,27 +2264,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i15.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i15.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2256,53 +2292,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i15.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i15.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+  _i15.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
         Invocation.method(
           #setLowPriority,
           [lowPriority],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i15.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2310,14 +2346,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2329,7 +2365,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i14.Future<String?> sendTextEvent(
+  _i15.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2361,12 +2397,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendReaction(
+  _i15.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2380,12 +2416,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendLocation(
+  _i15.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2399,12 +2435,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendFileEvent(
+  _i15.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2432,25 +2468,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i15.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i14.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i15.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i14.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i15.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i14.Future<_i4.EncryptionHealthState>);
+      ) as _i15.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i14.Future<String?> sendEvent(
+  _i15.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -2474,73 +2510,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i15.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> leave() => (super.noSuchMethod(
+  _i15.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> forget() => (super.noSuchMethod(
+  _i15.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> setPower(
+  _i15.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2552,7 +2588,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2563,7 +2599,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2573,10 +2609,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> invite(
+  _i15.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2586,12 +2622,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<int> requestHistory({
+  _i15.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -2608,32 +2644,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<int>.value(0),
-        returnValueForMissingStub: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+        returnValueForMissingStub: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
-  _i14.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i15.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setReadMarker(
+  _i15.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2647,23 +2683,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
+  _i15.Future<_i23.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i14.Future<_i22.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i14.Future<_i22.TimelineChunk?>.value(),
-      ) as _i14.Future<_i22.TimelineChunk?>);
+        returnValue: _i15.Future<_i23.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i15.Future<_i23.TimelineChunk?>.value(),
+      ) as _i15.Future<_i23.TimelineChunk?>);
 
   @override
-  _i14.Future<void> postReceipt(
+  _i15.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -2673,12 +2709,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Timeline> getTimeline({
+  _i15.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2701,7 +2737,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i14.Future<_i4.Timeline>.value(_FakeTimeline_15(
+        returnValue: _i15.Future<_i4.Timeline>.value(_FakeTimeline_16(
           this,
           Invocation.method(
             #getTimeline,
@@ -2718,7 +2754,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Timeline>.value(_FakeTimeline_15(
+            _i15.Future<_i4.Timeline>.value(_FakeTimeline_16(
           this,
           Invocation.method(
             #getTimeline,
@@ -2734,7 +2770,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Timeline>);
+      ) as _i15.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -2753,7 +2789,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i14.Future<List<_i4.User>> requestParticipants([
+  _i15.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -2771,10 +2807,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i14.Future<List<_i4.User>>);
+            _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i15.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -2782,14 +2818,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_16(
+        returnValue: _FakeUser_17(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_16(
+        returnValueForMissingStub: _FakeUser_17(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -2805,14 +2841,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_16(
+        returnValue: _FakeUser_17(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_16(
+        returnValueForMissingStub: _FakeUser_17(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -2822,7 +2858,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i14.Future<_i4.User?> requestUser(
+  _i15.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2838,19 +2874,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i14.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.User?>.value(),
-      ) as _i14.Future<_i4.User?>);
+        returnValue: _i15.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.User?>.value(),
+      ) as _i15.Future<_i4.User?>);
 
   @override
-  _i14.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i15.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2863,12 +2899,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i14.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i15.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2876,14 +2912,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2906,14 +2942,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i14.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i15.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -2952,18 +2988,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i14.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i15.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEvent(
+  _i15.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -2977,12 +3013,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> setTyping(
+  _i15.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -2992,12 +3028,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setJoinRules(
+  _i15.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -3011,59 +3047,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i15.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setHistoryVisibility(
+  _i15.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i15.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i15.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i15.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i14.Future<List<_i4.DeviceKeys>>);
+            _i15.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i15.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i14.Future<void> requestSessionKey(
+  _i15.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -3075,12 +3111,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setSpaceChild(
+  _i15.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3096,44 +3132,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i15.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i14.Future<Uri>.value(_FakeUri_17(
+        returnValue: _i15.Future<Uri>.value(_FakeUri_18(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_17(
+        returnValueForMissingStub: _i15.Future<Uri>.value(_FakeUri_18(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i14.Future<Uri>);
+      ) as _i15.Future<Uri>);
 
   @override
-  _i14.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<
+  _i15.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -3160,21 +3196,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i14.Future<
+        returnValue: _i15.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i14.Future<
+        returnValueForMissingStub: _i15.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i14.Future<
+      ) as _i15.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -3189,23 +3225,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_18(
+        returnValue: _FakeDatabaseApi_19(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_18(
+        returnValueForMissingStub: _FakeDatabaseApi_19(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i23.KeyVerificationMethod> get verificationMethods =>
+  Set<_i24.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i23.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i23.KeyVerificationMethod>{},
-      ) as Set<_i23.KeyVerificationMethod>);
+        returnValue: <_i24.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i24.KeyVerificationMethod>{},
+      ) as Set<_i24.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3266,11 +3302,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_19(
+        returnValue: _FakeFilter_20(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_19(
+        returnValueForMissingStub: _FakeFilter_20(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -3279,11 +3315,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_20(
+        returnValue: _FakeNativeImplementations_21(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_20(
+        returnValueForMissingStub: _FakeNativeImplementations_21(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -3299,11 +3335,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_21(
+        returnValue: _FakeDuration_22(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_21(
+        returnValueForMissingStub: _FakeDuration_22(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3312,11 +3348,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_21(
+        returnValue: _FakeDuration_22(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_21(
+        returnValueForMissingStub: _FakeDuration_22(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3325,11 +3361,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -3366,11 +3402,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3400,11 +3436,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3413,11 +3449,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3440,11 +3476,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_22(
+        returnValue: _FakePushruleEvaluator_23(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_22(
+        returnValueForMissingStub: _FakePushruleEvaluator_23(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -3465,332 +3501,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i14.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i15.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i12.CachedStreamController<String> get onUserProfileUpdate =>
+  _i13.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_11<String>(
+        returnValue: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i14.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i15.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i14.Future<List<_i4.Room>>);
+            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i15.Future<List<_i4.Room>>);
 
   @override
-  _i12.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i13.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_11<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_12<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.EventUpdate>(
+            _FakeCachedStreamController_12<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.EventUpdate>);
+      ) as _i13.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i13.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_11<_i4.Event>(
+        returnValue: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i13.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_11<_i4.Event>(
+        returnValue: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onNotification =>
+  _i13.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_11<_i4.Event>(
+        returnValue: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i13.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_11<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_12<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_12<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i13.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i12.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i13.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_11<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_12<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_11<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_12<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i12.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i13.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i12.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i13.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_11<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_12<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.LoginState>(
+            _FakeCachedStreamController_12<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i12.CachedStreamController<_i4.LoginState>);
+      ) as _i13.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i12.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i13.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_11<bool>(
+        returnValue: _FakeCachedStreamController_12<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i12.CachedStreamController<bool>);
+      ) as _i13.CachedStreamController<bool>);
 
   @override
-  _i12.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i13.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_11<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_12<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i12.CachedStreamController<_i4.SdkError>);
+      ) as _i13.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i12.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i13.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_11<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_12<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.SyncUpdate>(
+            _FakeCachedStreamController_12<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i12.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i13.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i13.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_11<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_12<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_12<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i12.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i13.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.Presence> get onPresence =>
+  _i13.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_11<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_12<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i12.CachedStreamController<_i4.Presence>);
+      ) as _i13.CachedStreamController<_i4.Presence>);
 
   @override
-  _i12.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i13.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_11<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_12<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.CachedPresence>(
+            _FakeCachedStreamController_12<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i12.CachedStreamController<_i4.CachedPresence>);
+      ) as _i13.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i12.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i13.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_11<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_12<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.BasicEvent>(
+            _FakeCachedStreamController_12<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i12.CachedStreamController<_i4.BasicEvent>);
+      ) as _i13.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i12.CachedStreamController<_i23.RoomKeyRequest> get onRoomKeyRequest =>
+  _i13.CachedStreamController<_i24.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_11<_i23.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_12<_i24.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i23.RoomKeyRequest>(
+            _FakeCachedStreamController_12<_i24.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i12.CachedStreamController<_i23.RoomKeyRequest>);
+      ) as _i13.CachedStreamController<_i24.RoomKeyRequest>);
 
   @override
-  _i12.CachedStreamController<_i23.KeyVerification>
+  _i13.CachedStreamController<_i24.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_11<_i23.KeyVerification>(
+            returnValue: _FakeCachedStreamController_12<_i24.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_11<_i23.KeyVerification>(
+                _FakeCachedStreamController_12<_i24.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i12.CachedStreamController<_i23.KeyVerification>);
+          ) as _i13.CachedStreamController<_i24.KeyVerification>);
 
   @override
-  _i12.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i13.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_11<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_12<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_12<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i12.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i13.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i13.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_11<_i4.Event>(
+        returnValue: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<String> get onCancelSendEvent =>
+  _i13.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_11<String>(
+        returnValue: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i12.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i13.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_11<
+            returnValue: _FakeCachedStreamController_12<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_11<
+            returnValueForMissingStub: _FakeCachedStreamController_12<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i12.CachedStreamController<
+          ) as _i13.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -3810,11 +3846,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_12(
+        returnValue: _FakeDateTime_13(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_12(
+        returnValueForMissingStub: _FakeDateTime_13(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3887,7 +3923,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i23.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i24.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3942,7 +3978,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i14.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i15.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -3953,7 +3989,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i14.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i15.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -4064,7 +4100,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -4073,7 +4109,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -4082,7 +4118,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4109,20 +4145,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Client get httpClient => (super.noSuchMethod(
+  _i14.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_24(
+        returnValue: _FakeClient_25(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_24(
+        returnValueForMissingStub: _FakeClient_25(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i13.Client);
+      ) as _i14.Client);
 
   @override
-  set httpClient(_i13.Client? value) => super.noSuchMethod(
+  set httpClient(_i14.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4149,7 +4185,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<void> refreshAccessToken(
+  _i15.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4157,9 +4193,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4177,14 +4213,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4221,33 +4257,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i14.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i15.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_25(
+        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_26(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_25(
+        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_26(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i14.Future<_i4.DiscoveryInformation>);
+      ) as _i15.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i14.Future<
+  _i15.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -4269,7 +4305,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i14.Future<
+        returnValue: _i15.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4277,7 +4313,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_26(
+          _FakeGetVersionsResponse_27(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4292,7 +4328,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i14.Future<
+        returnValueForMissingStub: _i15.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4300,7 +4336,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_26(
+          _FakeGetVersionsResponse_27(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4315,7 +4351,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i14.Future<
+      ) as _i15.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -4324,7 +4360,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i14.Future<_i4.DiscoveryInformation> getWellknown({
+  _i15.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4337,8 +4373,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_25(
+        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_26(
           this,
           Invocation.method(
             #getWellknown,
@@ -4349,8 +4385,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_25(
+        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_26(
           this,
           Invocation.method(
             #getWellknown,
@@ -4361,10 +4397,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.DiscoveryInformation>);
+      ) as _i15.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i14.Future<_i4.RegisterResponse> register({
+  _i15.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -4392,7 +4428,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
+            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_28(
           this,
           Invocation.method(
             #register,
@@ -4411,7 +4447,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
+            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_28(
           this,
           Invocation.method(
             #register,
@@ -4429,10 +4465,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RegisterResponse>);
+      ) as _i15.Future<_i4.RegisterResponse>);
 
   @override
-  _i14.Future<_i4.LoginResponse> login(
+  _i15.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -4462,7 +4498,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
+        returnValue: _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_29(
           this,
           Invocation.method(
             #login,
@@ -4482,7 +4518,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
+            _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_29(
           this,
           Invocation.method(
             #login,
@@ -4501,10 +4537,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.LoginResponse>);
+      ) as _i15.Future<_i4.LoginResponse>);
 
   @override
-  _i14.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i15.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4517,8 +4553,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_29(
+        returnValue: _i15.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_30(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4530,8 +4566,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_29(
+            _i15.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_30(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4542,74 +4578,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i15.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logoutAll() => (super.noSuchMethod(
+  _i15.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<T> uiaRequestBackground<T>(
-          _i14.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i15.Future<T> uiaRequestBackground<T>(
+          _i15.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i14.Future<T>.value(v),
+              (T v) => _i15.Future<T>.value(v),
             ) ??
-            _FakeFuture_30<T>(
+            _FakeFuture_31<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i14.Future<T>.value(v),
+              (T v) => _i15.Future<T>.value(v),
             ) ??
-            _FakeFuture_30<T>(
+            _FakeFuture_31<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i14.Future<T>);
+      ) as _i15.Future<T>);
 
   @override
-  _i14.Future<String> startDirectChat(
+  _i15.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -4631,7 +4667,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4647,7 +4683,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4662,10 +4698,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> createGroupChat({
+  _i15.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -4696,7 +4732,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4717,7 +4753,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4737,10 +4773,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i15.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4756,7 +4792,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4769,7 +4805,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4781,21 +4817,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i15.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<String> createSpace({
+  _i15.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -4820,7 +4856,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4838,7 +4874,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4855,10 +4891,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i15.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4866,7 +4902,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4875,7 +4911,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4883,10 +4919,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i14.Future<_i4.Profile> fetchOwnProfile({
+  _i15.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4899,7 +4935,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4911,7 +4947,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4922,10 +4958,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i14.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i15.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4939,8 +4975,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i14.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_31(
+        returnValue: _i15.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_32(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4952,8 +4988,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_31(
+            _i15.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_32(
           this,
           Invocation.method(
             #getUserProfile,
@@ -4964,10 +5000,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.CachedProfileInformation>);
+      ) as _i15.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i14.Future<_i4.Profile> getProfileFromUserId(
+  _i15.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -4985,7 +5021,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -4999,7 +5035,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -5012,7 +5048,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -5034,31 +5070,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i14.Future<List<_i4.Room>>);
+            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i15.Future<List<_i4.Room>>);
 
   @override
-  _i14.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i15.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i14.Future<List<_i4.ArchivedRoom>>);
+            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i15.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i14.Future<_i4.GetVersionsResponse> getVersions({
+  _i15.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5071,8 +5107,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_26(
+        returnValue: _i15.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_27(
           this,
           Invocation.method(
             #getVersions,
@@ -5083,8 +5119,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_26(
+        returnValueForMissingStub: _i15.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_27(
           this,
           Invocation.method(
             #getVersions,
@@ -5095,20 +5131,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetVersionsResponse>);
+      ) as _i15.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i14.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i15.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.MediaConfig> getConfig({
+  _i15.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5121,7 +5157,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfig,
@@ -5133,7 +5169,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfig,
@@ -5144,10 +5180,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.MediaConfig>);
+      ) as _i15.Future<_i4.MediaConfig>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContent(
+  _i15.Future<_i16.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5167,7 +5203,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContent,
@@ -5183,7 +5219,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContent,
@@ -5198,10 +5234,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentOverrideName(
+  _i15.Future<_i16.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5223,7 +5259,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5240,7 +5276,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5256,10 +5292,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentThumbnail(
+  _i15.Future<_i16.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5287,7 +5323,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5307,7 +5343,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5326,10 +5362,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i15.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5339,7 +5375,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5348,7 +5384,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5356,11 +5392,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i14.Future<_i4.PreviewForUrl>);
+      ) as _i15.Future<_i4.PreviewForUrl>);
 
   @override
-  _i14.Future<Uri> uploadContent(
-    _i24.Uint8List? file, {
+  _i15.Future<Uri> uploadContent(
+    _i25.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5373,7 +5409,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i14.Future<Uri>.value(_FakeUri_17(
+        returnValue: _i15.Future<Uri>.value(_FakeUri_18(
           this,
           Invocation.method(
             #uploadContent,
@@ -5384,7 +5420,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_17(
+        returnValueForMissingStub: _i15.Future<Uri>.value(_FakeUri_18(
           this,
           Invocation.method(
             #uploadContent,
@@ -5395,10 +5431,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<Uri>);
+      ) as _i15.Future<Uri>);
 
   @override
-  _i14.Future<void> setTyping(
+  _i15.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5414,42 +5450,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> exportDump() => (super.noSuchMethod(
+  _i15.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i15.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i15.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Event?> getEventByPushNotification(
+  _i15.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -5465,12 +5501,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
-  _i14.Future<void> init({
+  _i15.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5505,9 +5541,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5519,40 +5555,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<void> clear() => (super.noSuchMethod(
+  _i15.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i15.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ensureNotSoftLoggedOut(
+  _i15.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSync(
+  _i15.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -5562,9 +5598,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -5577,29 +5613,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i14.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i15.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i15.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDevice(
+  _i15.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5613,12 +5649,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDevicesOfUserIds(
+  _i15.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5634,12 +5670,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDeviceEncrypted(
+  _i15.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5659,12 +5695,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDeviceEncryptedChunked(
+  _i15.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -5678,23 +5714,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i15.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> joinRoom(
+  _i15.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -5712,7 +5748,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5726,7 +5762,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5739,10 +5775,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> changePassword(
+  _i15.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -5758,22 +5794,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> clearCache() => (super.noSuchMethod(
+  _i15.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ignoreUser(
+  _i15.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5783,22 +5819,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i15.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i15.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5809,7 +5845,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_36(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5818,7 +5854,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_36(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5826,32 +5862,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i14.Future<_i4.CachedPresence>);
+      ) as _i15.Future<_i4.CachedPresence>);
 
   @override
-  _i14.Future<void> abortSync() => (super.noSuchMethod(
+  _i15.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i15.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEventWithMetadata(
+  _i15.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5871,14 +5907,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i13.BaseResponse? response,
-    _i24.Uint8List? body,
+    _i14.BaseResponse? response,
+    _i25.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5910,7 +5946,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i14.Future<Map<String, Object?>> request(
+  _i15.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -5931,13 +5967,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> postPusher(
+  _i15.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -5947,57 +5983,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i15.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i15.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i15.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i14.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_36(
+        returnValue: _i15.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_37(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_36(
+        returnValueForMissingStub: _i15.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_37(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.TurnServerCredentials>);
+      ) as _i15.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6011,8 +6047,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6024,8 +6060,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6036,10 +6072,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6055,8 +6091,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6069,8 +6105,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6082,10 +6118,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i15.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6099,7 +6135,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
+        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6111,7 +6147,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
+            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6122,17 +6158,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.KeyBackupData>);
+      ) as _i15.Future<_i4.KeyBackupData>);
 
   @override
-  _i14.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i15.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i14.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_39(
+        returnValue: _i15.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_40(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6140,18 +6176,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_39(
+            _i15.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_40(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i15.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i14.Future<int> pingAppservice(
+  _i15.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6161,12 +6197,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i14.Future<int>.value(0),
-        returnValueForMissingStub: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+        returnValueForMissingStub: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
-  _i14.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i15.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6174,8 +6210,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_40(
+        returnValue: _i15.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_41(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6184,8 +6220,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_40(
+            _i15.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_41(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6193,15 +6229,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i14.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i15.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i14.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i15.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6209,17 +6245,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.MediaConfig>);
+      ) as _i15.Future<_i4.MediaConfig>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentAuthed(
+  _i15.Future<_i16.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6233,7 +6269,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6245,7 +6281,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6256,10 +6292,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentOverrideNameAuthed(
+  _i15.Future<_i16.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6275,7 +6311,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6288,7 +6324,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6300,10 +6336,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i15.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6313,7 +6349,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6322,7 +6358,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6330,10 +6366,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i14.Future<_i4.PreviewForUrl>);
+      ) as _i15.Future<_i4.PreviewForUrl>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentThumbnailAuthed(
+  _i15.Future<_i16.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -6357,7 +6393,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6375,7 +6411,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6392,21 +6428,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<bool> registrationTokenValidity(String? token) =>
+  _i15.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i15.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6416,8 +6452,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_41(
+        returnValue: _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_42(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6426,8 +6462,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_41(
+            _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_42(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6435,10 +6471,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i15.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i14.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i15.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6456,8 +6492,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_42(
+        returnValue: _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_43(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6471,8 +6507,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_42(
+            _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_43(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6485,10 +6521,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i15.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i15.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -6512,8 +6548,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i14.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_43(
+        returnValue: _i15.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_44(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6531,8 +6567,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_43(
+            _i15.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_44(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6549,10 +6585,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i15.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6580,8 +6616,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_44(
+                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6600,8 +6636,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_44(
+                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6619,10 +6655,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i15.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6651,9 +6687,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i14.Future<
+            returnValue: _i15.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6672,9 +6708,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i14.Future<
+            returnValueForMissingStub: _i15.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6693,11 +6729,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i14
+          ) as _i15
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i14.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i15.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -6713,8 +6749,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i14.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_46(
+        returnValue: _i15.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_47(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6727,8 +6763,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_46(
+            _i15.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_47(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6740,10 +6776,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetThreadRootsResponse>);
+      ) as _i15.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i14.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i15.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -6757,8 +6793,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i14.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_47(
+        returnValue: _i15.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_48(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6770,8 +6806,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_47(
+            _i15.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_48(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6782,33 +6818,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i15.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i15.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i14.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i15.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i14.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i15.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i14.Future<Uri?>.value(),
-        returnValueForMissingStub: _i14.Future<Uri?>.value(),
-      ) as _i14.Future<Uri?>);
+        returnValue: _i15.Future<Uri?>.value(),
+        returnValueForMissingStub: _i15.Future<Uri?>.value(),
+      ) as _i15.Future<Uri?>);
 
   @override
-  _i14.Future<void> add3PID(
+  _i15.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -6822,12 +6858,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> bind3PID(
+  _i15.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6843,12 +6879,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i15.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6862,14 +6898,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6891,8 +6927,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6908,8 +6944,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6925,10 +6961,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6952,8 +6988,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6970,8 +7006,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -6988,10 +7024,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i15.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -7005,14 +7041,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i15.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -7027,14 +7063,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7056,8 +7092,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7073,8 +7109,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7090,10 +7126,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7117,8 +7153,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7135,8 +7171,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7153,16 +7189,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i15.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
+            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_50(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7170,22 +7206,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
+            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_50(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.TokenOwnerInfo>);
+      ) as _i15.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i14.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i15.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
+        returnValue: _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_51(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7193,22 +7229,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
+            _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_51(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i14.Future<_i4.WhoIsInfo>);
+      ) as _i15.Future<_i4.WhoIsInfo>);
 
   @override
-  _i14.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i15.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
+        returnValue: _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_52(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7216,17 +7252,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
+            _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_52(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.Capabilities>);
+      ) as _i15.Future<_i4.Capabilities>);
 
   @override
-  _i14.Future<String> createRoom({
+  _i15.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -7259,7 +7295,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7281,7 +7317,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7302,10 +7338,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> deleteDevices(
+  _i15.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7315,22 +7351,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.Device>?>.value(),
-      ) as _i14.Future<List<_i4.Device>?>);
+        returnValue: _i15.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.Device>?>.value(),
+      ) as _i15.Future<List<_i4.Device>?>);
 
   @override
-  _i14.Future<void> deleteDevice(
+  _i15.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7340,34 +7376,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i15.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i14.Future<_i4.Device>.value(_FakeDevice_52(
+        returnValue: _i15.Future<_i4.Device>.value(_FakeDevice_53(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Device>.value(_FakeDevice_52(
+        returnValueForMissingStub: _i15.Future<_i4.Device>.value(_FakeDevice_53(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i14.Future<_i4.Device>);
+      ) as _i15.Future<_i4.Device>);
 
   @override
-  _i14.Future<void> updateDevice(
+  _i15.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7377,12 +7413,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i15.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -7397,24 +7433,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i15.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i14.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Visibility?>.value(),
-      ) as _i14.Future<_i4.Visibility?>);
+        returnValue: _i15.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Visibility?>.value(),
+      ) as _i15.Future<_i4.Visibility?>);
 
   @override
-  _i14.Future<void> setRoomVisibilityOnDirectory(
+  _i15.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -7424,30 +7460,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i15.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i15.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_53(
+        returnValue: _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_54(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7455,18 +7491,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_53(
+            _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_54(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i15.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i14.Future<void> setRoomAlias(
+  _i15.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7478,12 +7514,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetEventsResponse> getEvents({
+  _i15.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7497,7 +7533,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
+            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_55(
           this,
           Invocation.method(
             #getEvents,
@@ -7509,7 +7545,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
+            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_55(
           this,
           Invocation.method(
             #getEvents,
@@ -7520,10 +7556,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetEventsResponse>);
+      ) as _i15.Future<_i4.GetEventsResponse>);
 
   @override
-  _i14.Future<_i4.PeekEventsResponse> peekEvents({
+  _i15.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7538,8 +7574,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i14.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_55(
+        returnValue: _i15.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_56(
           this,
           Invocation.method(
             #peekEvents,
@@ -7551,8 +7587,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_55(
+        returnValueForMissingStub: _i15.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_56(
           this,
           Invocation.method(
             #peekEvents,
@@ -7564,16 +7600,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.PeekEventsResponse>);
+      ) as _i15.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i14.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i15.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
+        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7581,27 +7617,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
+            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i14.Future<_i4.MatrixEvent>);
+      ) as _i15.Future<_i4.MatrixEvent>);
 
   @override
-  _i14.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i15.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 
   @override
-  _i14.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i15.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7613,8 +7649,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i14.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_57(
+        returnValue: _i15.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_58(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7625,8 +7661,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_57(
+            _i15.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_58(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7636,10 +7672,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.GetKeysChangesResponse>);
+      ) as _i15.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i14.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i15.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7650,7 +7686,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
+            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_59(
           this,
           Invocation.method(
             #claimKeys,
@@ -7659,7 +7695,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
+            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_59(
           this,
           Invocation.method(
             #claimKeys,
@@ -7667,10 +7703,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i14.Future<_i4.ClaimKeysResponse>);
+      ) as _i15.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i14.Future<void> uploadCrossSigningKeys({
+  _i15.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -7687,12 +7723,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.QueryKeysResponse> queryKeys(
+  _i15.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7703,7 +7739,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
+            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_60(
           this,
           Invocation.method(
             #queryKeys,
@@ -7712,7 +7748,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
+            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_60(
           this,
           Invocation.method(
             #queryKeys,
@@ -7720,10 +7756,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i14.Future<_i4.QueryKeysResponse>);
+      ) as _i15.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7731,14 +7767,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i14.Future<
+            returnValue: _i15.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i14.Future<
+            returnValueForMissingStub: _i15.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i14.Future<Map<String, int>> uploadKeys({
+  _i15.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -7753,13 +7789,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i14.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i15.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i14.Future<Map<String, int>>);
+            _i15.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i15.Future<Map<String, int>>);
 
   @override
-  _i14.Future<String> knockRoom(
+  _i15.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7773,7 +7809,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7785,7 +7821,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7796,20 +7832,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i15.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i14.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i15.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i15.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i14.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i15.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7824,8 +7860,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i14.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_60(
+        returnValue: _i15.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_61(
           this,
           Invocation.method(
             #getNotifications,
@@ -7838,8 +7874,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_60(
+            _i15.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_61(
           this,
           Invocation.method(
             #getNotifications,
@@ -7851,35 +7887,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetNotificationsResponse>);
+      ) as _i15.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i14.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i15.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i14.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_61(
+        returnValue: _i15.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_62(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_61(
+        returnValueForMissingStub: _i15.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_62(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i14.Future<_i4.GetPresenceResponse>);
+      ) as _i15.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i14.Future<void> setPresence(
+  _i15.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -7893,12 +7929,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, Object?>> deleteProfileField(
+  _i15.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7911,13 +7947,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getProfileField(
+  _i15.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7930,13 +7966,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<Map<String, Object?>> setProfileField(
+  _i15.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7951,13 +7987,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i15.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -7972,8 +8008,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i14.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_62(
+        returnValue: _i15.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_63(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7986,8 +8022,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_62(
+            _i15.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_63(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -7999,10 +8035,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i15.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i14.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i15.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -8023,8 +8059,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i14.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_63(
+        returnValue: _i15.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_64(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8040,8 +8076,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_63(
+            _i15.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_64(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8056,25 +8092,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i15.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i14.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.Pusher>?>.value(),
-      ) as _i14.Future<List<_i4.Pusher>?>);
+        returnValue: _i15.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.Pusher>?>.value(),
+      ) as _i15.Future<List<_i4.Pusher>?>);
 
   @override
-  _i14.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i15.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
+        returnValue: _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_65(
           this,
           Invocation.method(
             #getPushRules,
@@ -8082,24 +8118,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
+            _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_65(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.PushRuleSet>);
+      ) as _i15.Future<_i4.PushRuleSet>);
 
   @override
-  _i14.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i15.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_65(
+        returnValue: _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_66(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8107,18 +8143,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_65(
+            _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_66(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i15.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i14.Future<void> deletePushRule(
+  _i15.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8130,12 +8166,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.PushRule> getPushRule(
+  _i15.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8147,7 +8183,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<_i4.PushRule>.value(_FakePushRule_66(
+        returnValue: _i15.Future<_i4.PushRule>.value(_FakePushRule_67(
           this,
           Invocation.method(
             #getPushRule,
@@ -8158,7 +8194,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PushRule>.value(_FakePushRule_66(
+            _i15.Future<_i4.PushRule>.value(_FakePushRule_67(
           this,
           Invocation.method(
             #getPushRule,
@@ -8168,10 +8204,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.PushRule>);
+      ) as _i15.Future<_i4.PushRule>);
 
   @override
-  _i14.Future<void> setPushRule(
+  _i15.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -8195,12 +8231,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<Object?>> getPushRuleActions(
+  _i15.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8212,13 +8248,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i15.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i14.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i14.Future<List<Object?>>);
+            _i15.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i15.Future<List<Object?>>);
 
   @override
-  _i14.Future<void> setPushRuleActions(
+  _i15.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -8232,12 +8268,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> isPushRuleEnabled(
+  _i15.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8249,12 +8285,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> setPushRuleEnabled(
+  _i15.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -8268,19 +8304,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i15.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
+            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_68(
           this,
           Invocation.method(
             #refresh,
@@ -8288,28 +8324,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
+            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_68(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i14.Future<_i4.RefreshResponse>);
+      ) as _i15.Future<_i4.RefreshResponse>);
 
   @override
-  _i14.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i15.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i14.Future<bool?>.value(),
-        returnValueForMissingStub: _i14.Future<bool?>.value(),
-      ) as _i14.Future<bool?>);
+        returnValue: _i15.Future<bool?>.value(),
+        returnValueForMissingStub: _i15.Future<bool?>.value(),
+      ) as _i15.Future<bool?>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8331,8 +8367,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8348,8 +8384,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8365,10 +8401,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8392,8 +8428,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8410,8 +8446,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8428,17 +8464,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8446,23 +8482,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i15.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
+        returnValue: _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_69(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8470,17 +8506,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
+            _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_69(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeys>);
+      ) as _i15.Future<_i4.RoomKeys>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -8492,8 +8528,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8504,8 +8540,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8515,10 +8551,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8530,8 +8566,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8542,8 +8578,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8553,10 +8589,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8568,7 +8604,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
+        returnValue: _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_70(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8579,7 +8615,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
+            _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_70(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8589,10 +8625,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeyBackup>);
+      ) as _i15.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -8606,8 +8642,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8619,8 +8655,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8631,10 +8667,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8648,8 +8684,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8661,8 +8697,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8673,10 +8709,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i15.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8690,7 +8726,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
+        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8702,7 +8738,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
+            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8713,10 +8749,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.KeyBackupData>);
+      ) as _i15.Future<_i4.KeyBackupData>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8732,8 +8768,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8746,8 +8782,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8759,18 +8795,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_70(
+                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_71(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8778,18 +8814,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_70(
+                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_71(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i14.Future<String> postRoomKeysVersion(
+  _i15.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -8801,7 +8837,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8812,7 +8848,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8822,29 +8858,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i15.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i15.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_71(
+        returnValue: _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_72(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8852,18 +8888,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_71(
+            _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_72(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i15.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i15.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -8878,24 +8914,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i15.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 
   @override
-  _i14.Future<void> ban(
+  _i15.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8909,12 +8945,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.EventContext> getEventContext(
+  _i15.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -8932,7 +8968,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i4.EventContext>.value(_FakeEventContext_72(
+        returnValue: _i15.Future<_i4.EventContext>.value(_FakeEventContext_73(
           this,
           Invocation.method(
             #getEventContext,
@@ -8947,7 +8983,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.EventContext>.value(_FakeEventContext_72(
+            _i15.Future<_i4.EventContext>.value(_FakeEventContext_73(
           this,
           Invocation.method(
             #getEventContext,
@@ -8961,10 +8997,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.EventContext>);
+      ) as _i15.Future<_i4.EventContext>);
 
   @override
-  _i14.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i15.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -8976,7 +9012,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
+        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8987,7 +9023,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
+            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -8997,20 +9033,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.MatrixEvent>);
+      ) as _i15.Future<_i4.MatrixEvent>);
 
   @override
-  _i14.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> inviteBy3PID(
+  _i15.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -9022,12 +9058,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> inviteUser(
+  _i15.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9041,12 +9077,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> joinRoomById(
+  _i15.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -9060,7 +9096,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9072,7 +9108,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9083,23 +9119,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i15.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i15.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i14.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i14.Future<Map<String, _i4.RoomMember>?>);
+            _i15.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i15.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i14.Future<void> kick(
+  _i15.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9113,12 +9149,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> leaveRoom(
+  _i15.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9128,12 +9164,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i15.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -9149,12 +9185,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i14.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i14.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i15.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i15.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i14.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i15.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -9176,8 +9212,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_73(
+        returnValue: _i15.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_74(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9193,8 +9229,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_73(
+        returnValueForMissingStub: _i15.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_74(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9210,10 +9246,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomEventsResponse>);
+      ) as _i15.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i14.Future<void> setReadMarker(
+  _i15.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9229,12 +9265,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> postReceipt(
+  _i15.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -9250,12 +9286,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEvent(
+  _i15.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9271,12 +9307,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> reportRoom(
+  _i15.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9288,12 +9324,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> reportEvent(
+  _i15.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9311,12 +9347,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> sendMessage(
+  _i15.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9332,7 +9368,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9345,7 +9381,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9357,23 +9393,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i15.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i14.Future<List<_i4.MatrixEvent>>);
+            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i15.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i15.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -9390,13 +9426,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<String> setRoomStateWithKey(
+  _i15.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9412,7 +9448,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9425,7 +9461,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9437,10 +9473,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> unban(
+  _i15.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9454,12 +9490,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> upgradeRoom(
+  _i15.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9473,7 +9509,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9485,7 +9521,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9496,10 +9532,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.SearchResults> search(
+  _i15.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -9509,7 +9545,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
+        returnValue: _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_75(
           this,
           Invocation.method(
             #search,
@@ -9518,7 +9554,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
+            _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_75(
           this,
           Invocation.method(
             #search,
@@ -9526,10 +9562,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i14.Future<_i4.SearchResults>);
+      ) as _i15.Future<_i4.SearchResults>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> sync({
+  _i15.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -9550,7 +9586,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #sync,
@@ -9566,7 +9602,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #sync,
@@ -9581,22 +9617,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i15.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i14.Future<List<_i4.Location>>);
+            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i15.Future<List<_i4.Location>>);
 
   @override
-  _i14.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i15.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9606,21 +9642,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i14.Future<List<_i4.Location>>);
+            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i15.Future<List<_i4.Location>>);
 
   @override
-  _i14.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i15.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_75(
+        returnValue: _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_76(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9628,45 +9664,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_75(
+            _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_76(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i14.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i15.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i14.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i15.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9677,13 +9713,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getAccountData(
+  _i15.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9696,13 +9732,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> setAccountData(
+  _i15.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9716,12 +9752,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> defineFilter(
+  _i15.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -9733,7 +9769,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9744,7 +9780,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9754,10 +9790,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.Filter> getFilter(
+  _i15.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9769,7 +9805,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i14.Future<_i4.Filter>.value(_FakeFilter_19(
+        returnValue: _i15.Future<_i4.Filter>.value(_FakeFilter_20(
           this,
           Invocation.method(
             #getFilter,
@@ -9779,7 +9815,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Filter>.value(_FakeFilter_19(
+        returnValueForMissingStub: _i15.Future<_i4.Filter>.value(_FakeFilter_20(
           this,
           Invocation.method(
             #getFilter,
@@ -9789,10 +9825,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.Filter>);
+      ) as _i15.Future<_i4.Filter>);
 
   @override
-  _i14.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i15.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9805,7 +9841,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
+            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_77(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9816,7 +9852,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
+            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_77(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9826,10 +9862,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.OpenIdCredentials>);
+      ) as _i15.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i14.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i15.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9844,13 +9880,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> setAccountDataPerRoom(
+  _i15.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9866,12 +9902,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i15.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9883,12 +9919,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i14.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i14.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i14.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i15.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i15.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i15.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i14.Future<void> deleteRoomTag(
+  _i15.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9902,12 +9938,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setRoomTag(
+  _i15.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9923,12 +9959,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i15.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9938,8 +9974,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i14.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_77(
+        returnValue: _i15.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_78(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9948,8 +9984,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_77(
+            _i15.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_78(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9957,10 +9993,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i14.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i15.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> reportUser(
+  _i15.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -9973,40 +10009,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i15.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i14.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_78(
+        returnValue: _i15.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_79(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_78(
+        returnValueForMissingStub: _i15.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_79(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.CreateContentResponse>);
+      ) as _i15.Future<_i4.CreateContentResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> uploadContentToMXC(
+  _i15.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i24.Uint8List? body, {
+    _i25.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -10024,8 +10060,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 }

--- a/test/widgets/join_access_controller_test.mocks.dart
+++ b/test/widgets/join_access_controller_test.mocks.dart
@@ -3,15 +3,16 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i14;
-import 'dart:typed_data' as _i23;
-import 'dart:ui' as _i18;
+import 'dart:async' as _i15;
+import 'dart:typed_data' as _i24;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
-import 'package:http/http.dart' as _i13;
-import 'package:kohera/core/models/join_mode.dart' as _i21;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
+import 'package:http/http.dart' as _i14;
+import 'package:kohera/core/models/join_mode.dart' as _i22;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i12;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -26,14 +27,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i22;
+import 'package:matrix/encryption.dart' as _i23;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i15;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i25;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i12;
-import 'package:matrix/src/utils/space_child.dart' as _i24;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i16;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i26;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i13;
+import 'package:matrix/src/utils/space_child.dart' as _i25;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -155,8 +156,9 @@ class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
         );
 }
 
-class _FakeStateEvent_10 extends _i1.SmartFake implements _i4.StateEvent {
-  _FakeStateEvent_10(
+class _FakeStickerPackService_10 extends _i1.SmartFake
+    implements _i12.StickerPackService {
+  _FakeStickerPackService_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -165,8 +167,8 @@ class _FakeStateEvent_10 extends _i1.SmartFake implements _i4.StateEvent {
         );
 }
 
-class _FakeDatabaseApi_11 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_11(
+class _FakeStateEvent_11 extends _i1.SmartFake implements _i4.StateEvent {
+  _FakeStateEvent_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -175,8 +177,8 @@ class _FakeDatabaseApi_11 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_12 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_12(
+class _FakeDatabaseApi_12 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -185,9 +187,19 @@ class _FakeFilter_12 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_13 extends _i1.SmartFake
+class _FakeFilter_13 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_13(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeNativeImplementations_14 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_13(
+  _FakeNativeImplementations_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -196,8 +208,8 @@ class _FakeNativeImplementations_13 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_14 extends _i1.SmartFake implements Duration {
-  _FakeDuration_14(
+class _FakeDuration_15 extends _i1.SmartFake implements Duration {
+  _FakeDuration_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -206,9 +218,9 @@ class _FakeDuration_14 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_15 extends _i1.SmartFake
+class _FakePushruleEvaluator_16 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_15(
+  _FakePushruleEvaluator_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -217,8 +229,8 @@ class _FakePushruleEvaluator_15 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_16 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_16(
+class _FakeProfile_17 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -227,9 +239,9 @@ class _FakeProfile_16 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeCachedStreamController_17<T> extends _i1.SmartFake
-    implements _i12.CachedStreamController<T> {
-  _FakeCachedStreamController_17(
+class _FakeCachedStreamController_18<T> extends _i1.SmartFake
+    implements _i13.CachedStreamController<T> {
+  _FakeCachedStreamController_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -238,8 +250,8 @@ class _FakeCachedStreamController_17<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_18 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_18(
+class _FakeDateTime_19 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -248,8 +260,8 @@ class _FakeDateTime_18 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_19 extends _i1.SmartFake implements _i13.Client {
-  _FakeClient_19(
+class _FakeClient_20 extends _i1.SmartFake implements _i14.Client {
+  _FakeClient_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -258,9 +270,9 @@ class _FakeClient_19 extends _i1.SmartFake implements _i13.Client {
         );
 }
 
-class _FakeDiscoveryInformation_20 extends _i1.SmartFake
+class _FakeDiscoveryInformation_21 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_20(
+  _FakeDiscoveryInformation_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -269,9 +281,9 @@ class _FakeDiscoveryInformation_20 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_21 extends _i1.SmartFake
+class _FakeGetVersionsResponse_22 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_21(
+  _FakeGetVersionsResponse_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -280,9 +292,9 @@ class _FakeGetVersionsResponse_21 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_22 extends _i1.SmartFake
+class _FakeRegisterResponse_23 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_22(
+  _FakeRegisterResponse_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -291,8 +303,8 @@ class _FakeRegisterResponse_22 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_23 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_23(
+class _FakeLoginResponse_24 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -301,9 +313,9 @@ class _FakeLoginResponse_23 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_24 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_25 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_24(
+  _FakeGetAuthMetadataResponse_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -312,8 +324,8 @@ class _FakeGetAuthMetadataResponse_24 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_25<T1> extends _i1.SmartFake implements _i14.Future<T1> {
-  _FakeFuture_25(
+class _FakeFuture_26<T1> extends _i1.SmartFake implements _i15.Future<T1> {
+  _FakeFuture_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -322,8 +334,8 @@ class _FakeFuture_25<T1> extends _i1.SmartFake implements _i14.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_26 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_26(
+class _FakeSyncUpdate_27 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -332,9 +344,9 @@ class _FakeSyncUpdate_26 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_27 extends _i1.SmartFake
+class _FakeCachedProfileInformation_28 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_27(
+  _FakeCachedProfileInformation_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -343,8 +355,8 @@ class _FakeCachedProfileInformation_27 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_28 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_28(
+class _FakeMediaConfig_29 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -353,8 +365,8 @@ class _FakeMediaConfig_28 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_29 extends _i1.SmartFake implements _i15.FileResponse {
-  _FakeFileResponse_29(
+class _FakeFileResponse_30 extends _i1.SmartFake implements _i16.FileResponse {
+  _FakeFileResponse_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -363,8 +375,8 @@ class _FakeFileResponse_29 extends _i1.SmartFake implements _i15.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_30 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_30(
+class _FakePreviewForUrl_31 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -373,8 +385,8 @@ class _FakePreviewForUrl_30 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeUri_31 extends _i1.SmartFake implements Uri {
-  _FakeUri_31(
+class _FakeUri_32 extends _i1.SmartFake implements Uri {
+  _FakeUri_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -383,9 +395,9 @@ class _FakeUri_31 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_32 extends _i1.SmartFake
+class _FakeCachedPresence_33 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_32(
+  _FakeCachedPresence_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -394,9 +406,9 @@ class _FakeCachedPresence_32 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_33 extends _i1.SmartFake
+class _FakeTurnServerCredentials_34 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_33(
+  _FakeTurnServerCredentials_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -405,9 +417,9 @@ class _FakeTurnServerCredentials_33 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_34 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_34(
+  _FakeRoomKeysUpdateResponse_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -416,8 +428,8 @@ class _FakeRoomKeysUpdateResponse_34 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_35 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_35(
+class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -426,9 +438,9 @@ class _FakeKeyBackupData_35 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_36 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_36(
+  _FakeGetWellknownSupportResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -437,9 +449,9 @@ class _FakeGetWellknownSupportResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_37 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_37(
+  _FakeGenerateLoginTokenResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -448,9 +460,9 @@ class _FakeGenerateLoginTokenResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_38 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_38(
+  _FakeGetRoomSummaryResponse$3_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -459,9 +471,9 @@ class _FakeGetRoomSummaryResponse$3_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_39 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_39(
+  _FakeGetSpaceHierarchyResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -470,9 +482,9 @@ class _FakeGetSpaceHierarchyResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_40 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_40(
+  _FakeGetRelatingEventsResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -481,9 +493,9 @@ class _FakeGetRelatingEventsResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_41 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_41(
+  _FakeGetRelatingEventsWithRelTypeResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -492,9 +504,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -503,9 +515,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_43 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_43(
+  _FakeGetThreadRootsResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -514,9 +526,9 @@ class _FakeGetThreadRootsResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_44 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_44(
+  _FakeGetEventByTimestampResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -525,9 +537,9 @@ class _FakeGetEventByTimestampResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_45 extends _i1.SmartFake
+class _FakeRequestTokenResponse_46 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_45(
+  _FakeRequestTokenResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -536,9 +548,9 @@ class _FakeRequestTokenResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_46 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_46(
+  _FakeTokenOwnerInfo_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -547,8 +559,8 @@ class _FakeTokenOwnerInfo_46 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_47 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_47(
+class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -557,8 +569,8 @@ class _FakeWhoIsInfo_47 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_48 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_48(
+class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -567,8 +579,8 @@ class _FakeCapabilities_48 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_49 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_49(
+class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -577,9 +589,9 @@ class _FakeDevice_49 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_50 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_50(
+  _FakeGetRoomIdByAliasResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -588,9 +600,9 @@ class _FakeGetRoomIdByAliasResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_51 extends _i1.SmartFake
+class _FakeGetEventsResponse_52 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_51(
+  _FakeGetEventsResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -599,9 +611,9 @@ class _FakeGetEventsResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_52 extends _i1.SmartFake
+class _FakePeekEventsResponse_53 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_52(
+  _FakePeekEventsResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -610,8 +622,8 @@ class _FakePeekEventsResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_53 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_53(
+class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -620,9 +632,9 @@ class _FakeMatrixEvent_53 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_54 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_54(
+  _FakeGetKeysChangesResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -631,9 +643,9 @@ class _FakeGetKeysChangesResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_55 extends _i1.SmartFake
+class _FakeClaimKeysResponse_56 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_55(
+  _FakeClaimKeysResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -642,9 +654,9 @@ class _FakeClaimKeysResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_56 extends _i1.SmartFake
+class _FakeQueryKeysResponse_57 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_56(
+  _FakeQueryKeysResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -653,9 +665,9 @@ class _FakeQueryKeysResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_57 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_57(
+  _FakeGetNotificationsResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -664,9 +676,9 @@ class _FakeGetNotificationsResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_58 extends _i1.SmartFake
+class _FakeGetPresenceResponse_59 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_58(
+  _FakeGetPresenceResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -675,9 +687,9 @@ class _FakeGetPresenceResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_59 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_59(
+  _FakeGetPublicRoomsResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -686,9 +698,9 @@ class _FakeGetPublicRoomsResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_60 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_60(
+  _FakeQueryPublicRoomsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -697,8 +709,8 @@ class _FakeQueryPublicRoomsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_61 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_61(
+class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -707,9 +719,9 @@ class _FakePushRuleSet_61 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_62 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_62(
+  _FakeGetPushRulesGlobalResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -718,8 +730,8 @@ class _FakeGetPushRulesGlobalResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_63 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_63(
+class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -728,9 +740,9 @@ class _FakePushRule_63 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_64 extends _i1.SmartFake
+class _FakeRefreshResponse_65 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_64(
+  _FakeRefreshResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -739,8 +751,8 @@ class _FakeRefreshResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_65 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_65(
+class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -749,8 +761,8 @@ class _FakeRoomKeys_65 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_66 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_66(
+class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -759,9 +771,9 @@ class _FakeRoomKeyBackup_66 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_67 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_67(
+  _FakeGetRoomKeysVersionCurrentResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -770,9 +782,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_68 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_68(
+  _FakeGetRoomKeysVersionResponse_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -781,8 +793,8 @@ class _FakeGetRoomKeysVersionResponse_68 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_69 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_69(
+class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -791,9 +803,9 @@ class _FakeEventContext_69 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_70 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_70(
+  _FakeGetRoomEventsResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -802,8 +814,8 @@ class _FakeGetRoomEventsResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_71 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_71(
+class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -812,9 +824,9 @@ class _FakeSearchResults_71 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_72 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_72(
+  _FakeGetProtocolMetadataResponse$2_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -823,9 +835,9 @@ class _FakeGetProtocolMetadataResponse$2_72 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_73 extends _i1.SmartFake
+class _FakeOpenIdCredentials_74 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_73(
+  _FakeOpenIdCredentials_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -834,9 +846,9 @@ class _FakeOpenIdCredentials_73 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_74 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_74(
+  _FakeSearchUserDirectoryResponse_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -845,9 +857,9 @@ class _FakeSearchUserDirectoryResponse_74 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_75 extends _i1.SmartFake
+class _FakeCreateContentResponse_76 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_75(
+  _FakeCreateContentResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -856,8 +868,8 @@ class _FakeCreateContentResponse_75 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_76 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_76(
+class _FakeRoomSummary_77 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -866,9 +878,9 @@ class _FakeRoomSummary_76 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_77 extends _i1.SmartFake
+class _FakeLatestReceiptState_78 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_77(
+  _FakeLatestReceiptState_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -877,8 +889,8 @@ class _FakeLatestReceiptState_77 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_78 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_78(
+class _FakeTimeline_79 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -887,8 +899,8 @@ class _FakeTimeline_78 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_79 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_79(
+class _FakeUser_80 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -900,7 +912,7 @@ class _FakeUser_79 extends _i1.SmartFake implements _i4.User {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -930,11 +942,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1059,6 +1071,19 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i11.OutboxService);
 
   @override
+  _i12.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i12.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -1156,6 +1181,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set stickerPacks(_i12.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -1163,14 +1197,14 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i15.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1200,7 +1234,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1210,21 +1244,22 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i15.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> login({
+  _i15.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1234,14 +1269,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> completeSsoLogin({
+  _i15.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1254,12 +1290,12 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> completeRegistration(
+  _i15.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1269,32 +1305,32 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i15.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1303,7 +1339,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1312,17 +1348,17 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i15.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1333,7 +1369,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1370,26 +1406,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i15.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+  _i15.Future<bool> didPushRouteInformation(
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1419,7 +1455,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1428,7 +1464,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1437,16 +1473,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i15.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i15.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i14.Future<_i18.AppExitResponse>);
+            _i15.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i15.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1473,14 +1509,14 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
 class MockSpaceAccessService extends _i1.Mock
     implements _i8.SpaceAccessService {
   @override
-  _i21.JoinMode getJoinMode(_i4.Room? room) => (super.noSuchMethod(
+  _i22.JoinMode getJoinMode(_i4.Room? room) => (super.noSuchMethod(
         Invocation.method(
           #getJoinMode,
           [room],
         ),
-        returnValue: _i21.JoinMode.invite,
-        returnValueForMissingStub: _i21.JoinMode.invite,
-      ) as _i21.JoinMode);
+        returnValue: _i22.JoinMode.invite,
+        returnValueForMissingStub: _i22.JoinMode.invite,
+      ) as _i22.JoinMode);
 
   @override
   List<String> allowedSpaceIds(_i4.Room? room) => (super.noSuchMethod(
@@ -1508,27 +1544,27 @@ class MockSpaceAccessService extends _i1.Mock
       ) as bool);
 
   @override
-  _i14.Future<void> setInviteOnly(_i4.Room? room) => (super.noSuchMethod(
+  _i15.Future<void> setInviteOnly(_i4.Room? room) => (super.noSuchMethod(
         Invocation.method(
           #setInviteOnly,
           [room],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setPublic(_i4.Room? room) => (super.noSuchMethod(
+  _i15.Future<void> setPublic(_i4.Room? room) => (super.noSuchMethod(
         Invocation.method(
           #setPublic,
           [room],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setRestrictedJoin(
+  _i15.Future<void> setRestrictedJoin(
     _i4.Room? room,
     List<_i4.Room>? allowSpaces,
   ) =>
@@ -1540,12 +1576,12 @@ class MockSpaceAccessService extends _i1.Mock
             allowSpaces,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setKnockRestricted(
+  _i15.Future<void> setKnockRestricted(
     _i4.Room? room,
     List<_i4.Room>? allowSpaces,
   ) =>
@@ -1557,14 +1593,14 @@ class MockSpaceAccessService extends _i1.Mock
             allowSpaces,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> applyJoinMode({
+  _i15.Future<void> applyJoinMode({
     required String? roomId,
-    required _i21.JoinMode? mode,
+    required _i22.JoinMode? mode,
     List<String>? allowSpaceIds = const [],
   }) =>
       (super.noSuchMethod(
@@ -1577,13 +1613,13 @@ class MockSpaceAccessService extends _i1.Mock
             #allowSpaceIds: allowSpaceIds,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   Map<String, Object?> buildJoinRulesPayload(
-    _i21.JoinMode? mode,
+    _i22.JoinMode? mode,
     List<String>? allowSpaceIds, {
     List<Map<String, Object?>>? preserveEntries = const [],
   }) =>
@@ -1602,7 +1638,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   _i4.StateEvent buildJoinRulesStateEvent(
-    _i21.JoinMode? mode,
+    _i22.JoinMode? mode,
     List<String>? allowSpaceIds,
   ) =>
       (super.noSuchMethod(
@@ -1613,7 +1649,7 @@ class MockSpaceAccessService extends _i1.Mock
             allowSpaceIds,
           ],
         ),
-        returnValue: _FakeStateEvent_10(
+        returnValue: _FakeStateEvent_11(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -1623,7 +1659,7 @@ class MockSpaceAccessService extends _i1.Mock
             ],
           ),
         ),
-        returnValueForMissingStub: _FakeStateEvent_10(
+        returnValueForMissingStub: _FakeStateEvent_11(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -1636,7 +1672,7 @@ class MockSpaceAccessService extends _i1.Mock
       ) as _i4.StateEvent);
 
   @override
-  _i14.Future<String> upgradeRoomTo(
+  _i15.Future<String> upgradeRoomTo(
     _i4.Room? room,
     String? newVersion,
   ) =>
@@ -1648,7 +1684,7 @@ class MockSpaceAccessService extends _i1.Mock
             newVersion,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,
@@ -1659,7 +1695,7 @@ class MockSpaceAccessService extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,
@@ -1669,10 +1705,10 @@ class MockSpaceAccessService extends _i1.Mock
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> rewireParentSpaces({
+  _i15.Future<void> rewireParentSpaces({
     required String? oldRoomId,
     required String? newRoomId,
     required List<_i4.Room>? parents,
@@ -1687,32 +1723,32 @@ class MockSpaceAccessService extends _i1.Mock
             #parents: parents,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> pickRestrictedRoomVersion({required bool? wantKnock}) =>
+  _i15.Future<String?> pickRestrictedRoomVersion({required bool? wantKnock}) =>
       (super.noSuchMethod(
         Invocation.method(
           #pickRestrictedRoomVersion,
           [],
           {#wantKnock: wantKnock},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<List<String>> serverSupportedRoomVersions() =>
+  _i15.Future<List<String>> serverSupportedRoomVersions() =>
       (super.noSuchMethod(
         Invocation.method(
           #serverSupportedRoomVersions,
           [],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 }
 
 /// A class which mocks [Client].
@@ -1722,23 +1758,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_11(
+        returnValue: _FakeDatabaseApi_12(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_11(
+        returnValueForMissingStub: _FakeDatabaseApi_12(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i22.KeyVerificationMethod> get verificationMethods =>
+  Set<_i23.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i22.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i22.KeyVerificationMethod>{},
-      ) as Set<_i22.KeyVerificationMethod>);
+        returnValue: <_i23.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i23.KeyVerificationMethod>{},
+      ) as Set<_i23.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1799,11 +1835,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_12(
+        returnValue: _FakeFilter_13(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_12(
+        returnValueForMissingStub: _FakeFilter_13(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -1812,11 +1848,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_13(
+        returnValue: _FakeNativeImplementations_14(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_13(
+        returnValueForMissingStub: _FakeNativeImplementations_14(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -1832,11 +1868,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_14(
+        returnValue: _FakeDuration_15(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_14(
+        returnValueForMissingStub: _FakeDuration_15(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -1845,11 +1881,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_14(
+        returnValue: _FakeDuration_15(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_14(
+        returnValueForMissingStub: _FakeDuration_15(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -1858,11 +1894,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1899,11 +1935,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1933,11 +1969,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1946,11 +1982,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1973,11 +2009,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_15(
+        returnValue: _FakePushruleEvaluator_16(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_15(
+        returnValueForMissingStub: _FakePushruleEvaluator_16(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -1998,332 +2034,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i14.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i15.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_16(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_16(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i12.CachedStreamController<String> get onUserProfileUpdate =>
+  _i13.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_17<String>(
+        returnValue: _FakeCachedStreamController_18<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i14.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i15.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i14.Future<List<_i4.Room>>);
+            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i15.Future<List<_i4.Room>>);
 
   @override
-  _i12.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i13.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_17<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_18<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.EventUpdate>(
+            _FakeCachedStreamController_18<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.EventUpdate>);
+      ) as _i13.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i13.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_17<_i4.Event>(
+        returnValue: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i13.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_17<_i4.Event>(
+        returnValue: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onNotification =>
+  _i13.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_17<_i4.Event>(
+        returnValue: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i13.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_17<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_18<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_18<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i13.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i12.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i13.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_17<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_18<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_17<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_18<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i12.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i13.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i12.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i13.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_17<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_18<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.LoginState>(
+            _FakeCachedStreamController_18<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i12.CachedStreamController<_i4.LoginState>);
+      ) as _i13.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i12.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i13.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_17<bool>(
+        returnValue: _FakeCachedStreamController_18<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i12.CachedStreamController<bool>);
+      ) as _i13.CachedStreamController<bool>);
 
   @override
-  _i12.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i13.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_17<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_18<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i12.CachedStreamController<_i4.SdkError>);
+      ) as _i13.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i12.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i13.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_17<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_18<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.SyncUpdate>(
+            _FakeCachedStreamController_18<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i12.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i13.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i13.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_17<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_18<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_18<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i12.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i13.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.Presence> get onPresence =>
+  _i13.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_17<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_18<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i12.CachedStreamController<_i4.Presence>);
+      ) as _i13.CachedStreamController<_i4.Presence>);
 
   @override
-  _i12.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i13.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_17<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_18<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.CachedPresence>(
+            _FakeCachedStreamController_18<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i12.CachedStreamController<_i4.CachedPresence>);
+      ) as _i13.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i12.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i13.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_17<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_18<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.BasicEvent>(
+            _FakeCachedStreamController_18<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i12.CachedStreamController<_i4.BasicEvent>);
+      ) as _i13.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i12.CachedStreamController<_i22.RoomKeyRequest> get onRoomKeyRequest =>
+  _i13.CachedStreamController<_i23.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_17<_i22.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_18<_i23.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i22.RoomKeyRequest>(
+            _FakeCachedStreamController_18<_i23.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i12.CachedStreamController<_i22.RoomKeyRequest>);
+      ) as _i13.CachedStreamController<_i23.RoomKeyRequest>);
 
   @override
-  _i12.CachedStreamController<_i22.KeyVerification>
+  _i13.CachedStreamController<_i23.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_17<_i22.KeyVerification>(
+            returnValue: _FakeCachedStreamController_18<_i23.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_17<_i22.KeyVerification>(
+                _FakeCachedStreamController_18<_i23.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i12.CachedStreamController<_i22.KeyVerification>);
+          ) as _i13.CachedStreamController<_i23.KeyVerification>);
 
   @override
-  _i12.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i13.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_17<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_18<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_18<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i12.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i13.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i13.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_17<_i4.Event>(
+        returnValue: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<String> get onCancelSendEvent =>
+  _i13.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_17<String>(
+        returnValue: _FakeCachedStreamController_18<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i12.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i13.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_17<
+            returnValue: _FakeCachedStreamController_18<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_17<
+            returnValueForMissingStub: _FakeCachedStreamController_18<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i12.CachedStreamController<
+          ) as _i13.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -2343,11 +2379,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_18(
+        returnValue: _FakeDateTime_19(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_18(
+        returnValueForMissingStub: _FakeDateTime_19(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2420,7 +2456,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i22.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i23.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2475,7 +2511,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i14.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i15.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2486,7 +2522,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i14.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i15.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -2597,7 +2633,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -2606,7 +2642,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -2615,7 +2651,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -2642,20 +2678,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Client get httpClient => (super.noSuchMethod(
+  _i14.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_19(
+        returnValue: _FakeClient_20(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_19(
+        returnValueForMissingStub: _FakeClient_20(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i13.Client);
+      ) as _i14.Client);
 
   @override
-  set httpClient(_i13.Client? value) => super.noSuchMethod(
+  set httpClient(_i14.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -2682,7 +2718,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<void> refreshAccessToken(
+  _i15.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2690,9 +2726,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -2710,14 +2746,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2754,33 +2790,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i14.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i15.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_20(
+        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_21(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_20(
+        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_21(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i14.Future<_i4.DiscoveryInformation>);
+      ) as _i15.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i14.Future<
+  _i15.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -2802,7 +2838,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i14.Future<
+        returnValue: _i15.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2810,7 +2846,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_21(
+          _FakeGetVersionsResponse_22(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2825,7 +2861,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i14.Future<
+        returnValueForMissingStub: _i15.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2833,7 +2869,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_21(
+          _FakeGetVersionsResponse_22(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2848,7 +2884,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i14.Future<
+      ) as _i15.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -2857,7 +2893,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i14.Future<_i4.DiscoveryInformation> getWellknown({
+  _i15.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2870,8 +2906,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_20(
+        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_21(
           this,
           Invocation.method(
             #getWellknown,
@@ -2882,8 +2918,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_20(
+        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_21(
           this,
           Invocation.method(
             #getWellknown,
@@ -2894,10 +2930,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.DiscoveryInformation>);
+      ) as _i15.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i14.Future<_i4.RegisterResponse> register({
+  _i15.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -2925,7 +2961,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_22(
+            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_23(
           this,
           Invocation.method(
             #register,
@@ -2944,7 +2980,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_22(
+            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_23(
           this,
           Invocation.method(
             #register,
@@ -2962,10 +2998,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RegisterResponse>);
+      ) as _i15.Future<_i4.RegisterResponse>);
 
   @override
-  _i14.Future<_i4.LoginResponse> login(
+  _i15.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -2995,7 +3031,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_23(
+        returnValue: _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_24(
           this,
           Invocation.method(
             #login,
@@ -3015,7 +3051,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_23(
+            _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_24(
           this,
           Invocation.method(
             #login,
@@ -3034,10 +3070,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.LoginResponse>);
+      ) as _i15.Future<_i4.LoginResponse>);
 
   @override
-  _i14.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i15.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3050,8 +3086,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_24(
+        returnValue: _i15.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_25(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -3063,8 +3099,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_24(
+            _i15.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_25(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -3075,74 +3111,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i15.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logoutAll() => (super.noSuchMethod(
+  _i15.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<T> uiaRequestBackground<T>(
-          _i14.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i15.Future<T> uiaRequestBackground<T>(
+          _i15.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i14.Future<T>.value(v),
+              (T v) => _i15.Future<T>.value(v),
             ) ??
-            _FakeFuture_25<T>(
+            _FakeFuture_26<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i14.Future<T>.value(v),
+              (T v) => _i15.Future<T>.value(v),
             ) ??
-            _FakeFuture_25<T>(
+            _FakeFuture_26<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i14.Future<T>);
+      ) as _i15.Future<T>);
 
   @override
-  _i14.Future<String> startDirectChat(
+  _i15.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -3164,7 +3200,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3180,7 +3216,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3195,10 +3231,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> createGroupChat({
+  _i15.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -3229,7 +3265,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3250,7 +3286,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3270,10 +3306,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i15.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -3289,7 +3325,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3302,7 +3338,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3314,21 +3350,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i15.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<String> createSpace({
+  _i15.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -3353,7 +3389,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3371,7 +3407,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3388,10 +3424,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i15.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3399,7 +3435,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_16(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3408,7 +3444,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_16(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3416,10 +3452,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i14.Future<_i4.Profile> fetchOwnProfile({
+  _i15.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3432,7 +3468,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_16(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3444,7 +3480,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_16(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3455,10 +3491,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i14.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i15.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3472,8 +3508,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i14.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_27(
+        returnValue: _i15.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_28(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3485,8 +3521,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_27(
+            _i15.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_28(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3497,10 +3533,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.CachedProfileInformation>);
+      ) as _i15.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i14.Future<_i4.Profile> getProfileFromUserId(
+  _i15.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3518,7 +3554,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_16(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3532,7 +3568,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_16(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3545,7 +3581,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -3567,31 +3603,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i14.Future<List<_i4.Room>>);
+            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i15.Future<List<_i4.Room>>);
 
   @override
-  _i14.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i15.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i14.Future<List<_i4.ArchivedRoom>>);
+            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i15.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i14.Future<_i4.GetVersionsResponse> getVersions({
+  _i15.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3604,8 +3640,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_21(
+        returnValue: _i15.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_22(
           this,
           Invocation.method(
             #getVersions,
@@ -3616,8 +3652,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_21(
+        returnValueForMissingStub: _i15.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_22(
           this,
           Invocation.method(
             #getVersions,
@@ -3628,20 +3664,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetVersionsResponse>);
+      ) as _i15.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i14.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i15.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.MediaConfig> getConfig({
+  _i15.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3654,7 +3690,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
+        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
           this,
           Invocation.method(
             #getConfig,
@@ -3666,7 +3702,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
+            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
           this,
           Invocation.method(
             #getConfig,
@@ -3677,10 +3713,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.MediaConfig>);
+      ) as _i15.Future<_i4.MediaConfig>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContent(
+  _i15.Future<_i16.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -3700,7 +3736,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_29(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContent,
@@ -3716,7 +3752,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_29(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContent,
@@ -3731,10 +3767,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentOverrideName(
+  _i15.Future<_i16.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -3756,7 +3792,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_29(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3773,7 +3809,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_29(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3789,10 +3825,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentThumbnail(
+  _i15.Future<_i16.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -3820,7 +3856,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_29(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3840,7 +3876,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_29(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3859,10 +3895,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i15.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -3872,7 +3908,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
+        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3881,7 +3917,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
+            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3889,11 +3925,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i14.Future<_i4.PreviewForUrl>);
+      ) as _i15.Future<_i4.PreviewForUrl>);
 
   @override
-  _i14.Future<Uri> uploadContent(
-    _i23.Uint8List? file, {
+  _i15.Future<Uri> uploadContent(
+    _i24.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3906,7 +3942,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i14.Future<Uri>.value(_FakeUri_31(
+        returnValue: _i15.Future<Uri>.value(_FakeUri_32(
           this,
           Invocation.method(
             #uploadContent,
@@ -3917,7 +3953,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_31(
+        returnValueForMissingStub: _i15.Future<Uri>.value(_FakeUri_32(
           this,
           Invocation.method(
             #uploadContent,
@@ -3928,10 +3964,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<Uri>);
+      ) as _i15.Future<Uri>);
 
   @override
-  _i14.Future<void> setTyping(
+  _i15.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -3947,42 +3983,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> exportDump() => (super.noSuchMethod(
+  _i15.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i15.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i15.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Event?> getEventByPushNotification(
+  _i15.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -3998,12 +4034,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
-  _i14.Future<void> init({
+  _i15.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -4038,9 +4074,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -4052,40 +4088,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<void> clear() => (super.noSuchMethod(
+  _i15.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i15.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ensureNotSoftLoggedOut(
+  _i15.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSync(
+  _i15.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -4095,9 +4131,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -4110,29 +4146,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i14.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i15.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i15.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDevice(
+  _i15.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -4146,12 +4182,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDevicesOfUserIds(
+  _i15.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4167,12 +4203,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDeviceEncrypted(
+  _i15.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4192,12 +4228,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDeviceEncryptedChunked(
+  _i15.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -4211,23 +4247,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i15.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> joinRoom(
+  _i15.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -4245,7 +4281,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4259,7 +4295,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4272,10 +4308,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> changePassword(
+  _i15.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -4291,22 +4327,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> clearCache() => (super.noSuchMethod(
+  _i15.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ignoreUser(
+  _i15.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4316,22 +4352,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i15.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i15.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4342,7 +4378,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_32(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4351,7 +4387,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_32(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4359,32 +4395,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i14.Future<_i4.CachedPresence>);
+      ) as _i15.Future<_i4.CachedPresence>);
 
   @override
-  _i14.Future<void> abortSync() => (super.noSuchMethod(
+  _i15.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i15.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEventWithMetadata(
+  _i15.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4404,14 +4440,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i13.BaseResponse? response,
-    _i23.Uint8List? body,
+    _i14.BaseResponse? response,
+    _i24.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4443,7 +4479,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i14.Future<Map<String, Object?>> request(
+  _i15.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -4464,13 +4500,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> postPusher(
+  _i15.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -4480,57 +4516,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i15.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i15.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i15.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i14.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_33(
+        returnValue: _i15.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_34(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_33(
+        returnValueForMissingStub: _i15.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_34(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.TurnServerCredentials>);
+      ) as _i15.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4544,8 +4580,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4557,8 +4593,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4569,10 +4605,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4588,8 +4624,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4602,8 +4638,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4615,10 +4651,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i15.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4632,7 +4668,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
+        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4644,7 +4680,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
+            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4655,17 +4691,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.KeyBackupData>);
+      ) as _i15.Future<_i4.KeyBackupData>);
 
   @override
-  _i14.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i15.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i14.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_36(
+        returnValue: _i15.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_37(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -4673,18 +4709,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_36(
+            _i15.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_37(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i15.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i14.Future<int> pingAppservice(
+  _i15.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -4694,12 +4730,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i14.Future<int>.value(0),
-        returnValueForMissingStub: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+        returnValueForMissingStub: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
-  _i14.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i15.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4707,8 +4743,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_37(
+        returnValue: _i15.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_38(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4717,8 +4753,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_37(
+            _i15.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_38(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4726,15 +4762,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i14.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i15.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i14.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i15.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
+        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -4742,17 +4778,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
+            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.MediaConfig>);
+      ) as _i15.Future<_i4.MediaConfig>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentAuthed(
+  _i15.Future<_i16.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -4766,7 +4802,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_29(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4778,7 +4814,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_29(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4789,10 +4825,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentOverrideNameAuthed(
+  _i15.Future<_i16.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4808,7 +4844,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_29(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4821,7 +4857,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_29(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4833,10 +4869,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i15.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -4846,7 +4882,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
+        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4855,7 +4891,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
+            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4863,10 +4899,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i14.Future<_i4.PreviewForUrl>);
+      ) as _i15.Future<_i4.PreviewForUrl>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentThumbnailAuthed(
+  _i15.Future<_i16.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -4890,7 +4926,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_29(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4908,7 +4944,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_29(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4925,21 +4961,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<bool> registrationTokenValidity(String? token) =>
+  _i15.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i15.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -4949,8 +4985,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_38(
+        returnValue: _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_39(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4959,8 +4995,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_38(
+            _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_39(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4968,10 +5004,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i15.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i14.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i15.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -4989,8 +5025,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_39(
+        returnValue: _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_40(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -5004,8 +5040,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_39(
+            _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_40(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -5018,10 +5054,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i15.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i15.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -5045,8 +5081,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i14.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_40(
+        returnValue: _i15.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_41(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -5064,8 +5100,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_40(
+            _i15.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_41(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -5082,10 +5118,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i15.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -5113,8 +5149,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_41(
+                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5133,8 +5169,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_41(
+                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5152,10 +5188,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i15.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -5184,9 +5220,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i14.Future<
+            returnValue: _i15.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5205,9 +5241,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i14.Future<
+            returnValueForMissingStub: _i15.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5226,11 +5262,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i14
+          ) as _i15
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i14.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i15.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -5246,8 +5282,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i14.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_43(
+        returnValue: _i15.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_44(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5260,8 +5296,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_43(
+            _i15.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_44(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5273,10 +5309,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetThreadRootsResponse>);
+      ) as _i15.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i14.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i15.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -5290,8 +5326,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i14.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_44(
+        returnValue: _i15.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_45(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5303,8 +5339,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_44(
+            _i15.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_45(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5315,33 +5351,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i15.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i15.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i14.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i15.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i14.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i15.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i14.Future<Uri?>.value(),
-        returnValueForMissingStub: _i14.Future<Uri?>.value(),
-      ) as _i14.Future<Uri?>);
+        returnValue: _i15.Future<Uri?>.value(),
+        returnValueForMissingStub: _i15.Future<Uri?>.value(),
+      ) as _i15.Future<Uri?>);
 
   @override
-  _i14.Future<void> add3PID(
+  _i15.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -5355,12 +5391,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> bind3PID(
+  _i15.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5376,12 +5412,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i15.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5395,14 +5431,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5424,8 +5460,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5441,8 +5477,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5458,10 +5494,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5485,8 +5521,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5503,8 +5539,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5521,10 +5557,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i15.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5538,14 +5574,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i15.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -5560,14 +5596,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5589,8 +5625,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5606,8 +5642,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5623,10 +5659,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5650,8 +5686,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5668,8 +5704,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5686,16 +5722,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i15.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
+            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -5703,22 +5739,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
+            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.TokenOwnerInfo>);
+      ) as _i15.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i14.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i15.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_47(
+        returnValue: _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
           this,
           Invocation.method(
             #getWhoIs,
@@ -5726,22 +5762,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_47(
+            _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i14.Future<_i4.WhoIsInfo>);
+      ) as _i15.Future<_i4.WhoIsInfo>);
 
   @override
-  _i14.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i15.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_48(
+        returnValue: _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
           this,
           Invocation.method(
             #getCapabilities,
@@ -5749,17 +5785,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_48(
+            _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.Capabilities>);
+      ) as _i15.Future<_i4.Capabilities>);
 
   @override
-  _i14.Future<String> createRoom({
+  _i15.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -5792,7 +5828,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5814,7 +5850,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5835,10 +5871,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> deleteDevices(
+  _i15.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5848,22 +5884,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.Device>?>.value(),
-      ) as _i14.Future<List<_i4.Device>?>);
+        returnValue: _i15.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.Device>?>.value(),
+      ) as _i15.Future<List<_i4.Device>?>);
 
   @override
-  _i14.Future<void> deleteDevice(
+  _i15.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5873,34 +5909,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i15.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i14.Future<_i4.Device>.value(_FakeDevice_49(
+        returnValue: _i15.Future<_i4.Device>.value(_FakeDevice_50(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Device>.value(_FakeDevice_49(
+        returnValueForMissingStub: _i15.Future<_i4.Device>.value(_FakeDevice_50(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i14.Future<_i4.Device>);
+      ) as _i15.Future<_i4.Device>);
 
   @override
-  _i14.Future<void> updateDevice(
+  _i15.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -5910,12 +5946,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i15.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -5930,24 +5966,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i15.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i14.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Visibility?>.value(),
-      ) as _i14.Future<_i4.Visibility?>);
+        returnValue: _i15.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Visibility?>.value(),
+      ) as _i15.Future<_i4.Visibility?>);
 
   @override
-  _i14.Future<void> setRoomVisibilityOnDirectory(
+  _i15.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -5957,30 +5993,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i15.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i15.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_50(
+        returnValue: _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_51(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -5988,18 +6024,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_50(
+            _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_51(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i15.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i14.Future<void> setRoomAlias(
+  _i15.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -6011,12 +6047,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetEventsResponse> getEvents({
+  _i15.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -6030,7 +6066,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_51(
+            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
           this,
           Invocation.method(
             #getEvents,
@@ -6042,7 +6078,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_51(
+            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
           this,
           Invocation.method(
             #getEvents,
@@ -6053,10 +6089,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetEventsResponse>);
+      ) as _i15.Future<_i4.GetEventsResponse>);
 
   @override
-  _i14.Future<_i4.PeekEventsResponse> peekEvents({
+  _i15.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -6071,8 +6107,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i14.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_52(
+        returnValue: _i15.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_53(
           this,
           Invocation.method(
             #peekEvents,
@@ -6084,8 +6120,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_52(
+        returnValueForMissingStub: _i15.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_53(
           this,
           Invocation.method(
             #peekEvents,
@@ -6097,16 +6133,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.PeekEventsResponse>);
+      ) as _i15.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i14.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i15.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
+        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneEvent,
@@ -6114,27 +6150,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
+            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i14.Future<_i4.MatrixEvent>);
+      ) as _i15.Future<_i4.MatrixEvent>);
 
   @override
-  _i14.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i15.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 
   @override
-  _i14.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i15.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -6146,8 +6182,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i14.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_54(
+        returnValue: _i15.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_55(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6158,8 +6194,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_54(
+            _i15.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_55(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6169,10 +6205,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.GetKeysChangesResponse>);
+      ) as _i15.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i14.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i15.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -6183,7 +6219,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
+            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
           this,
           Invocation.method(
             #claimKeys,
@@ -6192,7 +6228,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
+            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
           this,
           Invocation.method(
             #claimKeys,
@@ -6200,10 +6236,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i14.Future<_i4.ClaimKeysResponse>);
+      ) as _i15.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i14.Future<void> uploadCrossSigningKeys({
+  _i15.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -6220,12 +6256,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.QueryKeysResponse> queryKeys(
+  _i15.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -6236,7 +6272,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
+            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
           this,
           Invocation.method(
             #queryKeys,
@@ -6245,7 +6281,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
+            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
           this,
           Invocation.method(
             #queryKeys,
@@ -6253,10 +6289,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i14.Future<_i4.QueryKeysResponse>);
+      ) as _i15.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -6264,14 +6300,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i14.Future<
+            returnValue: _i15.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i14.Future<
+            returnValueForMissingStub: _i15.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i14.Future<Map<String, int>> uploadKeys({
+  _i15.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -6286,13 +6322,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i14.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i15.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i14.Future<Map<String, int>>);
+            _i15.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i15.Future<Map<String, int>>);
 
   @override
-  _i14.Future<String> knockRoom(
+  _i15.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -6306,7 +6342,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6318,7 +6354,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6329,20 +6365,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i15.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i14.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i15.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i15.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i14.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i15.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6357,8 +6393,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i14.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_57(
+        returnValue: _i15.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_58(
           this,
           Invocation.method(
             #getNotifications,
@@ -6371,8 +6407,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_57(
+            _i15.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_58(
           this,
           Invocation.method(
             #getNotifications,
@@ -6384,35 +6420,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetNotificationsResponse>);
+      ) as _i15.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i14.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i15.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i14.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_58(
+        returnValue: _i15.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_59(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_58(
+        returnValueForMissingStub: _i15.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_59(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i14.Future<_i4.GetPresenceResponse>);
+      ) as _i15.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i14.Future<void> setPresence(
+  _i15.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -6426,12 +6462,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, Object?>> deleteProfileField(
+  _i15.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6444,13 +6480,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getProfileField(
+  _i15.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6463,13 +6499,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<Map<String, Object?>> setProfileField(
+  _i15.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6484,13 +6520,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i15.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6505,8 +6541,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i14.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_59(
+        returnValue: _i15.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_60(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6519,8 +6555,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_59(
+            _i15.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_60(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6532,10 +6568,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i15.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i14.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i15.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -6556,8 +6592,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i14.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_60(
+        returnValue: _i15.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_61(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6573,8 +6609,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_60(
+            _i15.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_61(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6589,25 +6625,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i15.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i14.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.Pusher>?>.value(),
-      ) as _i14.Future<List<_i4.Pusher>?>);
+        returnValue: _i15.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.Pusher>?>.value(),
+      ) as _i15.Future<List<_i4.Pusher>?>);
 
   @override
-  _i14.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i15.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_61(
+        returnValue: _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
           this,
           Invocation.method(
             #getPushRules,
@@ -6615,24 +6651,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_61(
+            _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.PushRuleSet>);
+      ) as _i15.Future<_i4.PushRuleSet>);
 
   @override
-  _i14.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i15.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_62(
+        returnValue: _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_63(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -6640,18 +6676,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_62(
+            _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_63(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i15.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i14.Future<void> deletePushRule(
+  _i15.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6663,12 +6699,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.PushRule> getPushRule(
+  _i15.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6680,7 +6716,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<_i4.PushRule>.value(_FakePushRule_63(
+        returnValue: _i15.Future<_i4.PushRule>.value(_FakePushRule_64(
           this,
           Invocation.method(
             #getPushRule,
@@ -6691,7 +6727,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PushRule>.value(_FakePushRule_63(
+            _i15.Future<_i4.PushRule>.value(_FakePushRule_64(
           this,
           Invocation.method(
             #getPushRule,
@@ -6701,10 +6737,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.PushRule>);
+      ) as _i15.Future<_i4.PushRule>);
 
   @override
-  _i14.Future<void> setPushRule(
+  _i15.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -6728,12 +6764,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<Object?>> getPushRuleActions(
+  _i15.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6745,13 +6781,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i15.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i14.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i14.Future<List<Object?>>);
+            _i15.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i15.Future<List<Object?>>);
 
   @override
-  _i14.Future<void> setPushRuleActions(
+  _i15.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -6765,12 +6801,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> isPushRuleEnabled(
+  _i15.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6782,12 +6818,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> setPushRuleEnabled(
+  _i15.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -6801,19 +6837,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i15.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_64(
+            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
           this,
           Invocation.method(
             #refresh,
@@ -6821,28 +6857,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_64(
+            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i14.Future<_i4.RefreshResponse>);
+      ) as _i15.Future<_i4.RefreshResponse>);
 
   @override
-  _i14.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i15.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i14.Future<bool?>.value(),
-        returnValueForMissingStub: _i14.Future<bool?>.value(),
-      ) as _i14.Future<bool?>);
+        returnValue: _i15.Future<bool?>.value(),
+        returnValueForMissingStub: _i15.Future<bool?>.value(),
+      ) as _i15.Future<bool?>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6864,8 +6900,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6881,8 +6917,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6898,10 +6934,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6925,8 +6961,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6943,8 +6979,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6961,17 +6997,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -6979,23 +7015,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i15.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_65(
+        returnValue: _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -7003,17 +7039,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_65(
+            _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeys>);
+      ) as _i15.Future<_i4.RoomKeys>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -7025,8 +7061,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -7037,8 +7073,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -7048,10 +7084,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -7063,8 +7099,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -7075,8 +7111,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -7086,10 +7122,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -7101,7 +7137,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
+        returnValue: _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -7112,7 +7148,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
+            _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -7122,10 +7158,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeyBackup>);
+      ) as _i15.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -7139,8 +7175,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7152,8 +7188,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7164,10 +7200,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7181,8 +7217,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7194,8 +7230,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7206,10 +7242,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i15.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7223,7 +7259,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
+        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7235,7 +7271,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
+            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7246,10 +7282,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.KeyBackupData>);
+      ) as _i15.Future<_i4.KeyBackupData>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7265,8 +7301,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7279,8 +7315,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7292,18 +7328,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_67(
+                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_68(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -7311,18 +7347,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_67(
+                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_68(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i14.Future<String> postRoomKeysVersion(
+  _i15.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -7334,7 +7370,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7345,7 +7381,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7355,29 +7391,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i15.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i15.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_68(
+        returnValue: _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_69(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7385,18 +7421,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_68(
+            _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_69(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i15.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i15.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -7411,24 +7447,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i15.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 
   @override
-  _i14.Future<void> ban(
+  _i15.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7442,12 +7478,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.EventContext> getEventContext(
+  _i15.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7465,7 +7501,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i4.EventContext>.value(_FakeEventContext_69(
+        returnValue: _i15.Future<_i4.EventContext>.value(_FakeEventContext_70(
           this,
           Invocation.method(
             #getEventContext,
@@ -7480,7 +7516,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.EventContext>.value(_FakeEventContext_69(
+            _i15.Future<_i4.EventContext>.value(_FakeEventContext_70(
           this,
           Invocation.method(
             #getEventContext,
@@ -7494,10 +7530,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.EventContext>);
+      ) as _i15.Future<_i4.EventContext>);
 
   @override
-  _i14.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i15.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7509,7 +7545,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
+        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7520,7 +7556,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
+            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7530,20 +7566,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.MatrixEvent>);
+      ) as _i15.Future<_i4.MatrixEvent>);
 
   @override
-  _i14.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> inviteBy3PID(
+  _i15.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -7555,12 +7591,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> inviteUser(
+  _i15.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7574,12 +7610,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> joinRoomById(
+  _i15.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -7593,7 +7629,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7605,7 +7641,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7616,23 +7652,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i15.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i15.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i14.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i14.Future<Map<String, _i4.RoomMember>?>);
+            _i15.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i15.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i14.Future<void> kick(
+  _i15.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7646,12 +7682,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> leaveRoom(
+  _i15.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -7661,12 +7697,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i15.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -7682,12 +7718,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i14.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i14.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i15.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i15.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i14.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i15.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -7709,8 +7745,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_70(
+        returnValue: _i15.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_71(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7726,8 +7762,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_70(
+        returnValueForMissingStub: _i15.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_71(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7743,10 +7779,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomEventsResponse>);
+      ) as _i15.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i14.Future<void> setReadMarker(
+  _i15.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -7762,12 +7798,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> postReceipt(
+  _i15.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -7783,12 +7819,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEvent(
+  _i15.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -7804,12 +7840,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> reportRoom(
+  _i15.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -7821,12 +7857,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> reportEvent(
+  _i15.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -7844,12 +7880,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> sendMessage(
+  _i15.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -7865,7 +7901,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7878,7 +7914,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7890,23 +7926,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i15.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i14.Future<List<_i4.MatrixEvent>>);
+            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i15.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i15.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -7923,13 +7959,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<String> setRoomStateWithKey(
+  _i15.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -7945,7 +7981,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7958,7 +7994,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7970,10 +8006,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> unban(
+  _i15.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7987,12 +8023,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> upgradeRoom(
+  _i15.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -8006,7 +8042,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -8018,7 +8054,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -8029,10 +8065,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.SearchResults> search(
+  _i15.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -8042,7 +8078,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_71(
+        returnValue: _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
           this,
           Invocation.method(
             #search,
@@ -8051,7 +8087,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_71(
+            _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
           this,
           Invocation.method(
             #search,
@@ -8059,10 +8095,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i14.Future<_i4.SearchResults>);
+      ) as _i15.Future<_i4.SearchResults>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> sync({
+  _i15.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -8083,7 +8119,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
           this,
           Invocation.method(
             #sync,
@@ -8099,7 +8135,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
           this,
           Invocation.method(
             #sync,
@@ -8114,22 +8150,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i15.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i14.Future<List<_i4.Location>>);
+            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i15.Future<List<_i4.Location>>);
 
   @override
-  _i14.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i15.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8139,21 +8175,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i14.Future<List<_i4.Location>>);
+            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i15.Future<List<_i4.Location>>);
 
   @override
-  _i14.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i15.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_72(
+        returnValue: _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_73(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -8161,45 +8197,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_72(
+            _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_73(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i14.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i15.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i14.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i15.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8210,13 +8246,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getAccountData(
+  _i15.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -8229,13 +8265,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> setAccountData(
+  _i15.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -8249,12 +8285,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> defineFilter(
+  _i15.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -8266,7 +8302,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8277,7 +8313,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8287,10 +8323,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.Filter> getFilter(
+  _i15.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -8302,7 +8338,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i14.Future<_i4.Filter>.value(_FakeFilter_12(
+        returnValue: _i15.Future<_i4.Filter>.value(_FakeFilter_13(
           this,
           Invocation.method(
             #getFilter,
@@ -8312,7 +8348,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Filter>.value(_FakeFilter_12(
+        returnValueForMissingStub: _i15.Future<_i4.Filter>.value(_FakeFilter_13(
           this,
           Invocation.method(
             #getFilter,
@@ -8322,10 +8358,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.Filter>);
+      ) as _i15.Future<_i4.Filter>);
 
   @override
-  _i14.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i15.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8338,7 +8374,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
+            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8349,7 +8385,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
+            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8359,10 +8395,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.OpenIdCredentials>);
+      ) as _i15.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i14.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i15.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8377,13 +8413,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> setAccountDataPerRoom(
+  _i15.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8399,12 +8435,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i15.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8416,12 +8452,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i14.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i14.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i14.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i15.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i15.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i15.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i14.Future<void> deleteRoomTag(
+  _i15.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8435,12 +8471,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setRoomTag(
+  _i15.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8456,12 +8492,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i15.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8471,8 +8507,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i14.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_74(
+        returnValue: _i15.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_75(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8481,8 +8517,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_74(
+            _i15.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_75(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8490,10 +8526,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i14.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i15.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> reportUser(
+  _i15.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8506,40 +8542,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i15.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i14.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_75(
+        returnValue: _i15.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_76(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_75(
+        returnValueForMissingStub: _i15.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_76(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.CreateContentResponse>);
+      ) as _i15.Future<_i4.CreateContentResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> uploadContentToMXC(
+  _i15.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i23.Uint8List? body, {
+    _i24.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8557,10 +8593,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [Room].
@@ -8570,11 +8606,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8604,11 +8640,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_76(
+        returnValue: _FakeRoomSummary_77(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_76(
+        returnValueForMissingStub: _FakeRoomSummary_77(
           this,
           Invocation.getter(#summary),
         ),
@@ -8638,11 +8674,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i14.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i15.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i14.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i14.Completer<dynamic>>[],
-      ) as List<_i14.Completer<dynamic>>);
+        returnValue: <_i15.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i15.Completer<dynamic>>[],
+      ) as List<_i15.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -8661,51 +8697,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i12.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i13.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_17<String>(
+        returnValue: _FakeCachedStreamController_18<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i12.CachedStreamController<String> get onSessionKeyReceived =>
+  _i13.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_17<String>(
+        returnValue: _FakeCachedStreamController_18<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8721,11 +8757,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8734,11 +8770,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8781,11 +8817,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8794,11 +8830,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_18(
+        returnValue: _FakeDateTime_19(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_18(
+        returnValueForMissingStub: _FakeDateTime_19(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -8828,11 +8864,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_77(
+        returnValue: _FakeLatestReceiptState_78(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_77(
+        returnValueForMissingStub: _FakeLatestReceiptState_78(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8853,18 +8889,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i14.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i15.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -9051,18 +9087,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i24.SpaceParent>[],
-        returnValueForMissingStub: <_i24.SpaceParent>[],
-      ) as List<_i24.SpaceParent>);
+        returnValue: <_i25.SpaceParent>[],
+        returnValueForMissingStub: <_i25.SpaceParent>[],
+      ) as List<_i25.SpaceParent>);
 
   @override
-  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i24.SpaceChild>[],
-        returnValueForMissingStub: <_i24.SpaceChild>[],
-      ) as List<_i24.SpaceChild>);
+        returnValue: <_i25.SpaceChild>[],
+        returnValueForMissingStub: <_i25.SpaceChild>[],
+      ) as List<_i25.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -9175,14 +9211,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i14.Future<void> postLoad() => (super.noSuchMethod(
+  _i15.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -9210,15 +9246,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i14.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i15.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i14.Future<List<_i4.User>>);
+            _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i15.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -9229,14 +9265,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9246,18 +9282,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i14.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i15.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Event?> refreshLastEvent(
+  _i15.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9265,9 +9301,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -9279,12 +9315,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i14.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i15.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9292,22 +9328,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i15.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9315,17 +9351,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> addTag(
+  _i15.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -9335,27 +9371,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i15.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i15.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -9363,53 +9399,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i15.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i15.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+  _i15.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
         Invocation.method(
           #setLowPriority,
           [lowPriority],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i15.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9417,14 +9453,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -9436,7 +9472,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i14.Future<String?> sendTextEvent(
+  _i15.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -9468,12 +9504,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendReaction(
+  _i15.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -9487,12 +9523,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendLocation(
+  _i15.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -9506,12 +9542,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendFileEvent(
+  _i15.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -9539,25 +9575,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i15.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i14.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i15.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i14.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i15.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i14.Future<_i4.EncryptionHealthState>);
+      ) as _i15.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i14.Future<String?> sendEvent(
+  _i15.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -9581,73 +9617,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i15.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> leave() => (super.noSuchMethod(
+  _i15.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> forget() => (super.noSuchMethod(
+  _i15.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> setPower(
+  _i15.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -9659,7 +9695,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9670,7 +9706,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9680,10 +9716,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> invite(
+  _i15.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -9693,12 +9729,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<int> requestHistory({
+  _i15.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -9715,32 +9751,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<int>.value(0),
-        returnValueForMissingStub: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+        returnValueForMissingStub: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
-  _i14.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i15.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setReadMarker(
+  _i15.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -9754,23 +9790,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i25.TimelineChunk?> getEventContext(String? eventId) =>
+  _i15.Future<_i26.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i14.Future<_i25.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i14.Future<_i25.TimelineChunk?>.value(),
-      ) as _i14.Future<_i25.TimelineChunk?>);
+        returnValue: _i15.Future<_i26.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i15.Future<_i26.TimelineChunk?>.value(),
+      ) as _i15.Future<_i26.TimelineChunk?>);
 
   @override
-  _i14.Future<void> postReceipt(
+  _i15.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -9780,12 +9816,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Timeline> getTimeline({
+  _i15.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -9808,7 +9844,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i14.Future<_i4.Timeline>.value(_FakeTimeline_78(
+        returnValue: _i15.Future<_i4.Timeline>.value(_FakeTimeline_79(
           this,
           Invocation.method(
             #getTimeline,
@@ -9825,7 +9861,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Timeline>.value(_FakeTimeline_78(
+            _i15.Future<_i4.Timeline>.value(_FakeTimeline_79(
           this,
           Invocation.method(
             #getTimeline,
@@ -9841,7 +9877,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Timeline>);
+      ) as _i15.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -9860,7 +9896,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i14.Future<List<_i4.User>> requestParticipants([
+  _i15.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -9878,10 +9914,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i14.Future<List<_i4.User>>);
+            _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i15.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -9889,14 +9925,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_79(
+        returnValue: _FakeUser_80(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_79(
+        returnValueForMissingStub: _FakeUser_80(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9912,14 +9948,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_79(
+        returnValue: _FakeUser_80(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_79(
+        returnValueForMissingStub: _FakeUser_80(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9929,7 +9965,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i14.Future<_i4.User?> requestUser(
+  _i15.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -9945,19 +9981,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i14.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.User?>.value(),
-      ) as _i14.Future<_i4.User?>);
+        returnValue: _i15.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.User?>.value(),
+      ) as _i15.Future<_i4.User?>);
 
   @override
-  _i14.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i15.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -9970,12 +10006,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i14.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i15.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9983,14 +10019,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -10013,14 +10049,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i14.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i15.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -10059,18 +10095,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i14.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i15.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEvent(
+  _i15.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -10084,12 +10120,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> setTyping(
+  _i15.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -10099,12 +10135,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setJoinRules(
+  _i15.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -10118,59 +10154,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i15.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setHistoryVisibility(
+  _i15.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i15.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i15.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i15.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i14.Future<List<_i4.DeviceKeys>>);
+            _i15.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i15.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i14.Future<void> requestSessionKey(
+  _i15.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -10182,12 +10218,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setSpaceChild(
+  _i15.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -10203,44 +10239,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i15.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i14.Future<Uri>.value(_FakeUri_31(
+        returnValue: _i15.Future<Uri>.value(_FakeUri_32(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_31(
+        returnValueForMissingStub: _i15.Future<Uri>.value(_FakeUri_32(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i14.Future<Uri>);
+      ) as _i15.Future<Uri>);
 
   @override
-  _i14.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<
+  _i15.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -10267,21 +10303,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i14.Future<
+        returnValue: _i15.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i14.Future<
+        returnValueForMissingStub: _i15.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i14.Future<
+      ) as _i15.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,

--- a/test/widgets/login_controller_test.mocks.dart
+++ b/test/widgets/login_controller_test.mocks.dart
@@ -3,16 +3,17 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i15;
-import 'dart:typed_data' as _i24;
-import 'dart:ui' as _i19;
+import 'dart:async' as _i16;
+import 'dart:typed_data' as _i25;
+import 'dart:ui' as _i20;
 
-import 'package:flutter/services.dart' as _i20;
-import 'package:flutter/widgets.dart' as _i21;
-import 'package:http/http.dart' as _i14;
-import 'package:kohera/core/models/server_auth_capabilities.dart' as _i17;
-import 'package:kohera/core/services/client_manager.dart' as _i22;
-import 'package:kohera/core/services/matrix_service.dart' as _i12;
+import 'package:flutter/services.dart' as _i21;
+import 'package:flutter/widgets.dart' as _i22;
+import 'package:http/http.dart' as _i15;
+import 'package:kohera/core/models/server_auth_capabilities.dart' as _i18;
+import 'package:kohera/core/services/client_manager.dart' as _i23;
+import 'package:kohera/core/services/matrix_service.dart' as _i13;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i12;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -27,12 +28,12 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i23;
+import 'package:matrix/encryption.dart' as _i24;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i16;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i13;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i17;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i14;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i18;
+import 'package:mockito/src/dummies.dart' as _i19;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -154,9 +155,9 @@ class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
         );
 }
 
-class _FakeMatrixService_10 extends _i1.SmartFake
-    implements _i12.MatrixService {
-  _FakeMatrixService_10(
+class _FakeStickerPackService_10 extends _i1.SmartFake
+    implements _i12.StickerPackService {
+  _FakeStickerPackService_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -165,8 +166,9 @@ class _FakeMatrixService_10 extends _i1.SmartFake
         );
 }
 
-class _FakeDatabaseApi_11 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_11(
+class _FakeMatrixService_11 extends _i1.SmartFake
+    implements _i13.MatrixService {
+  _FakeMatrixService_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -175,8 +177,8 @@ class _FakeDatabaseApi_11 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_12 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_12(
+class _FakeDatabaseApi_12 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -185,9 +187,19 @@ class _FakeFilter_12 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_13 extends _i1.SmartFake
+class _FakeFilter_13 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_13(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeNativeImplementations_14 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_13(
+  _FakeNativeImplementations_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -196,8 +208,8 @@ class _FakeNativeImplementations_13 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_14 extends _i1.SmartFake implements Duration {
-  _FakeDuration_14(
+class _FakeDuration_15 extends _i1.SmartFake implements Duration {
+  _FakeDuration_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -206,9 +218,9 @@ class _FakeDuration_14 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_15 extends _i1.SmartFake
+class _FakePushruleEvaluator_16 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_15(
+  _FakePushruleEvaluator_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -217,8 +229,8 @@ class _FakePushruleEvaluator_15 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_16 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_16(
+class _FakeProfile_17 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -227,9 +239,9 @@ class _FakeProfile_16 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeCachedStreamController_17<T> extends _i1.SmartFake
-    implements _i13.CachedStreamController<T> {
-  _FakeCachedStreamController_17(
+class _FakeCachedStreamController_18<T> extends _i1.SmartFake
+    implements _i14.CachedStreamController<T> {
+  _FakeCachedStreamController_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -238,8 +250,8 @@ class _FakeCachedStreamController_17<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_18 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_18(
+class _FakeDateTime_19 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -248,8 +260,8 @@ class _FakeDateTime_18 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_19 extends _i1.SmartFake implements _i14.Client {
-  _FakeClient_19(
+class _FakeClient_20 extends _i1.SmartFake implements _i15.Client {
+  _FakeClient_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -258,9 +270,9 @@ class _FakeClient_19 extends _i1.SmartFake implements _i14.Client {
         );
 }
 
-class _FakeDiscoveryInformation_20 extends _i1.SmartFake
+class _FakeDiscoveryInformation_21 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_20(
+  _FakeDiscoveryInformation_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -269,9 +281,9 @@ class _FakeDiscoveryInformation_20 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_21 extends _i1.SmartFake
+class _FakeGetVersionsResponse_22 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_21(
+  _FakeGetVersionsResponse_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -280,9 +292,9 @@ class _FakeGetVersionsResponse_21 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_22 extends _i1.SmartFake
+class _FakeRegisterResponse_23 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_22(
+  _FakeRegisterResponse_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -291,8 +303,8 @@ class _FakeRegisterResponse_22 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_23 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_23(
+class _FakeLoginResponse_24 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -301,9 +313,9 @@ class _FakeLoginResponse_23 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_24 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_25 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_24(
+  _FakeGetAuthMetadataResponse_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -312,8 +324,8 @@ class _FakeGetAuthMetadataResponse_24 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_25<T1> extends _i1.SmartFake implements _i15.Future<T1> {
-  _FakeFuture_25(
+class _FakeFuture_26<T1> extends _i1.SmartFake implements _i16.Future<T1> {
+  _FakeFuture_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -322,8 +334,8 @@ class _FakeFuture_25<T1> extends _i1.SmartFake implements _i15.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_26 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_26(
+class _FakeSyncUpdate_27 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -332,9 +344,9 @@ class _FakeSyncUpdate_26 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_27 extends _i1.SmartFake
+class _FakeCachedProfileInformation_28 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_27(
+  _FakeCachedProfileInformation_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -343,8 +355,8 @@ class _FakeCachedProfileInformation_27 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_28 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_28(
+class _FakeMediaConfig_29 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -353,8 +365,8 @@ class _FakeMediaConfig_28 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_29 extends _i1.SmartFake implements _i16.FileResponse {
-  _FakeFileResponse_29(
+class _FakeFileResponse_30 extends _i1.SmartFake implements _i17.FileResponse {
+  _FakeFileResponse_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -363,8 +375,8 @@ class _FakeFileResponse_29 extends _i1.SmartFake implements _i16.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_30 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_30(
+class _FakePreviewForUrl_31 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -373,8 +385,8 @@ class _FakePreviewForUrl_30 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeUri_31 extends _i1.SmartFake implements Uri {
-  _FakeUri_31(
+class _FakeUri_32 extends _i1.SmartFake implements Uri {
+  _FakeUri_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -383,9 +395,9 @@ class _FakeUri_31 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_32 extends _i1.SmartFake
+class _FakeCachedPresence_33 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_32(
+  _FakeCachedPresence_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -394,9 +406,9 @@ class _FakeCachedPresence_32 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_33 extends _i1.SmartFake
+class _FakeTurnServerCredentials_34 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_33(
+  _FakeTurnServerCredentials_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -405,9 +417,9 @@ class _FakeTurnServerCredentials_33 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_34 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_35 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_34(
+  _FakeRoomKeysUpdateResponse_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -416,8 +428,8 @@ class _FakeRoomKeysUpdateResponse_34 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_35 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_35(
+class _FakeKeyBackupData_36 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -426,9 +438,9 @@ class _FakeKeyBackupData_35 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_36 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_37 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_36(
+  _FakeGetWellknownSupportResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -437,9 +449,9 @@ class _FakeGetWellknownSupportResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_37 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_38 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_37(
+  _FakeGenerateLoginTokenResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -448,9 +460,9 @@ class _FakeGenerateLoginTokenResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_38 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_39 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_38(
+  _FakeGetRoomSummaryResponse$3_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -459,9 +471,9 @@ class _FakeGetRoomSummaryResponse$3_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_39 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_40 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_39(
+  _FakeGetSpaceHierarchyResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -470,9 +482,9 @@ class _FakeGetSpaceHierarchyResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_40 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_41 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_40(
+  _FakeGetRelatingEventsResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -481,9 +493,9 @@ class _FakeGetRelatingEventsResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_41 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_42 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_41(
+  _FakeGetRelatingEventsWithRelTypeResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -492,9 +504,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -503,9 +515,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_43 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_44 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_43(
+  _FakeGetThreadRootsResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -514,9 +526,9 @@ class _FakeGetThreadRootsResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_44 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_45 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_44(
+  _FakeGetEventByTimestampResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -525,9 +537,9 @@ class _FakeGetEventByTimestampResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_45 extends _i1.SmartFake
+class _FakeRequestTokenResponse_46 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_45(
+  _FakeRequestTokenResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -536,9 +548,9 @@ class _FakeRequestTokenResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_46 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_47 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_46(
+  _FakeTokenOwnerInfo_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -547,8 +559,8 @@ class _FakeTokenOwnerInfo_46 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_47 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_47(
+class _FakeWhoIsInfo_48 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -557,8 +569,8 @@ class _FakeWhoIsInfo_47 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_48 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_48(
+class _FakeCapabilities_49 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -567,8 +579,8 @@ class _FakeCapabilities_48 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_49 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_49(
+class _FakeDevice_50 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -577,9 +589,9 @@ class _FakeDevice_49 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_50 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_51 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_50(
+  _FakeGetRoomIdByAliasResponse_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -588,9 +600,9 @@ class _FakeGetRoomIdByAliasResponse_50 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_51 extends _i1.SmartFake
+class _FakeGetEventsResponse_52 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_51(
+  _FakeGetEventsResponse_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -599,9 +611,9 @@ class _FakeGetEventsResponse_51 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_52 extends _i1.SmartFake
+class _FakePeekEventsResponse_53 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_52(
+  _FakePeekEventsResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -610,8 +622,8 @@ class _FakePeekEventsResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_53 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_53(
+class _FakeMatrixEvent_54 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -620,9 +632,9 @@ class _FakeMatrixEvent_53 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_54 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_55 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_54(
+  _FakeGetKeysChangesResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -631,9 +643,9 @@ class _FakeGetKeysChangesResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_55 extends _i1.SmartFake
+class _FakeClaimKeysResponse_56 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_55(
+  _FakeClaimKeysResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -642,9 +654,9 @@ class _FakeClaimKeysResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_56 extends _i1.SmartFake
+class _FakeQueryKeysResponse_57 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_56(
+  _FakeQueryKeysResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -653,9 +665,9 @@ class _FakeQueryKeysResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_57 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_58 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_57(
+  _FakeGetNotificationsResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -664,9 +676,9 @@ class _FakeGetNotificationsResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_58 extends _i1.SmartFake
+class _FakeGetPresenceResponse_59 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_58(
+  _FakeGetPresenceResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -675,9 +687,9 @@ class _FakeGetPresenceResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_59 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_60 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_59(
+  _FakeGetPublicRoomsResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -686,9 +698,9 @@ class _FakeGetPublicRoomsResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_60 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_61 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_60(
+  _FakeQueryPublicRoomsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -697,8 +709,8 @@ class _FakeQueryPublicRoomsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_61 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_61(
+class _FakePushRuleSet_62 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -707,9 +719,9 @@ class _FakePushRuleSet_61 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_62 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_63 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_62(
+  _FakeGetPushRulesGlobalResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -718,8 +730,8 @@ class _FakeGetPushRulesGlobalResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_63 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_63(
+class _FakePushRule_64 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -728,9 +740,9 @@ class _FakePushRule_63 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_64 extends _i1.SmartFake
+class _FakeRefreshResponse_65 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_64(
+  _FakeRefreshResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -739,8 +751,8 @@ class _FakeRefreshResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_65 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_65(
+class _FakeRoomKeys_66 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -749,8 +761,8 @@ class _FakeRoomKeys_65 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_66 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_66(
+class _FakeRoomKeyBackup_67 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -759,9 +771,9 @@ class _FakeRoomKeyBackup_66 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_67 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_68 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_67(
+  _FakeGetRoomKeysVersionCurrentResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -770,9 +782,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_68 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_69 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_68(
+  _FakeGetRoomKeysVersionResponse_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -781,8 +793,8 @@ class _FakeGetRoomKeysVersionResponse_68 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_69 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_69(
+class _FakeEventContext_70 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -791,9 +803,9 @@ class _FakeEventContext_69 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_70 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_71 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_70(
+  _FakeGetRoomEventsResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -802,8 +814,8 @@ class _FakeGetRoomEventsResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_71 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_71(
+class _FakeSearchResults_72 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -812,9 +824,9 @@ class _FakeSearchResults_71 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_72 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_73 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_72(
+  _FakeGetProtocolMetadataResponse$2_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -823,9 +835,9 @@ class _FakeGetProtocolMetadataResponse$2_72 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_73 extends _i1.SmartFake
+class _FakeOpenIdCredentials_74 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_73(
+  _FakeOpenIdCredentials_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -834,9 +846,9 @@ class _FakeOpenIdCredentials_73 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_74 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_75 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_74(
+  _FakeSearchUserDirectoryResponse_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -845,9 +857,9 @@ class _FakeSearchUserDirectoryResponse_74 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_75 extends _i1.SmartFake
+class _FakeCreateContentResponse_76 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_75(
+  _FakeCreateContentResponse_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -856,9 +868,9 @@ class _FakeCreateContentResponse_75 extends _i1.SmartFake
         );
 }
 
-class _FakeServerAuthCapabilities_76 extends _i1.SmartFake
-    implements _i17.ServerAuthCapabilities {
-  _FakeServerAuthCapabilities_76(
+class _FakeServerAuthCapabilities_77 extends _i1.SmartFake
+    implements _i18.ServerAuthCapabilities {
+  _FakeServerAuthCapabilities_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -870,7 +882,7 @@ class _FakeServerAuthCapabilities_76 extends _i1.SmartFake
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i13.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -900,11 +912,11 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1029,6 +1041,19 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       ) as _i11.OutboxService);
 
   @override
+  _i12.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i12.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -1126,6 +1151,15 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
+  set stickerPacks(_i12.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -1133,14 +1167,14 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       ) as bool);
 
   @override
-  _i15.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i16.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1170,7 +1204,7 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1180,21 +1214,22 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
-  _i15.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i16.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<bool> login({
+  _i16.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1204,14 +1239,15 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<bool> completeSsoLogin({
+  _i16.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1224,12 +1260,12 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<void> completeRegistration(
+  _i16.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1239,32 +1275,32 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> logout() => (super.noSuchMethod(
+  _i16.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i16.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1273,7 +1309,7 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1282,17 +1318,17 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
-  _i15.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i16.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1303,7 +1339,7 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1340,26 +1376,26 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
-  _i15.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i16.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<bool> didPushRouteInformation(
-          _i21.RouteInformation? routeInformation) =>
+  _i16.Future<bool> didPushRouteInformation(
+          _i22.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1389,7 +1425,7 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1398,7 +1434,7 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1407,16 +1443,16 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
       );
 
   @override
-  _i15.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i16.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i15.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+            _i16.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i15.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
-      ) as _i15.Future<_i19.AppExitResponse>);
+            _i16.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+      ) as _i16.Future<_i20.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1440,13 +1476,13 @@ class MockMatrixService extends _i1.Mock implements _i12.MatrixService {
 /// A class which mocks [ClientManager].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockClientManager extends _i1.Mock implements _i22.ClientManager {
+class MockClientManager extends _i1.Mock implements _i23.ClientManager {
   @override
-  List<_i12.MatrixService> get services => (super.noSuchMethod(
+  List<_i13.MatrixService> get services => (super.noSuchMethod(
         Invocation.getter(#services),
-        returnValue: <_i12.MatrixService>[],
-        returnValueForMissingStub: <_i12.MatrixService>[],
-      ) as List<_i12.MatrixService>);
+        returnValue: <_i13.MatrixService>[],
+        returnValueForMissingStub: <_i13.MatrixService>[],
+      ) as List<_i13.MatrixService>);
 
   @override
   int get activeIndex => (super.noSuchMethod(
@@ -1456,17 +1492,17 @@ class MockClientManager extends _i1.Mock implements _i22.ClientManager {
       ) as int);
 
   @override
-  _i12.MatrixService get activeService => (super.noSuchMethod(
+  _i13.MatrixService get activeService => (super.noSuchMethod(
         Invocation.getter(#activeService),
-        returnValue: _FakeMatrixService_10(
+        returnValue: _FakeMatrixService_11(
           this,
           Invocation.getter(#activeService),
         ),
-        returnValueForMissingStub: _FakeMatrixService_10(
+        returnValueForMissingStub: _FakeMatrixService_11(
           this,
           Invocation.getter(#activeService),
         ),
-      ) as _i12.MatrixService);
+      ) as _i13.MatrixService);
 
   @override
   bool get hasMultipleAccounts => (super.noSuchMethod(
@@ -1483,14 +1519,14 @@ class MockClientManager extends _i1.Mock implements _i22.ClientManager {
       ) as bool);
 
   @override
-  _i15.Future<void> init() => (super.noSuchMethod(
+  _i16.Future<void> init() => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
   void setActiveAccount(int? index) => super.noSuchMethod(
@@ -1502,13 +1538,13 @@ class MockClientManager extends _i1.Mock implements _i22.ClientManager {
       );
 
   @override
-  _i15.Future<_i12.MatrixService> createLoginService() => (super.noSuchMethod(
+  _i16.Future<_i13.MatrixService> createLoginService() => (super.noSuchMethod(
         Invocation.method(
           #createLoginService,
           [],
         ),
         returnValue:
-            _i15.Future<_i12.MatrixService>.value(_FakeMatrixService_10(
+            _i16.Future<_i13.MatrixService>.value(_FakeMatrixService_11(
           this,
           Invocation.method(
             #createLoginService,
@@ -1516,14 +1552,14 @@ class MockClientManager extends _i1.Mock implements _i22.ClientManager {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i12.MatrixService>.value(_FakeMatrixService_10(
+            _i16.Future<_i13.MatrixService>.value(_FakeMatrixService_11(
           this,
           Invocation.method(
             #createLoginService,
             [],
           ),
         )),
-      ) as _i15.Future<_i12.MatrixService>);
+      ) as _i16.Future<_i13.MatrixService>);
 
   @override
   void commitPendingService() => super.noSuchMethod(
@@ -1544,36 +1580,36 @@ class MockClientManager extends _i1.Mock implements _i22.ClientManager {
       );
 
   @override
-  _i15.Future<void> addService(_i12.MatrixService? service) =>
+  _i16.Future<void> addService(_i13.MatrixService? service) =>
       (super.noSuchMethod(
         Invocation.method(
           #addService,
           [service],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> signOut(_i12.MatrixService? service) => (super.noSuchMethod(
+  _i16.Future<void> signOut(_i13.MatrixService? service) => (super.noSuchMethod(
         Invocation.method(
           #signOut,
           [service],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> removeService(_i12.MatrixService? service) =>
+  _i16.Future<void> removeService(_i13.MatrixService? service) =>
       (super.noSuchMethod(
         Invocation.method(
           #removeService,
           [service],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
@@ -1585,7 +1621,7 @@ class MockClientManager extends _i1.Mock implements _i22.ClientManager {
       );
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1594,7 +1630,7 @@ class MockClientManager extends _i1.Mock implements _i22.ClientManager {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1619,23 +1655,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_11(
+        returnValue: _FakeDatabaseApi_12(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_11(
+        returnValueForMissingStub: _FakeDatabaseApi_12(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i23.KeyVerificationMethod> get verificationMethods =>
+  Set<_i24.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i23.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i23.KeyVerificationMethod>{},
-      ) as Set<_i23.KeyVerificationMethod>);
+        returnValue: <_i24.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i24.KeyVerificationMethod>{},
+      ) as Set<_i24.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1696,11 +1732,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_12(
+        returnValue: _FakeFilter_13(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_12(
+        returnValueForMissingStub: _FakeFilter_13(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -1709,11 +1745,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_13(
+        returnValue: _FakeNativeImplementations_14(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_13(
+        returnValueForMissingStub: _FakeNativeImplementations_14(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -1729,11 +1765,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_14(
+        returnValue: _FakeDuration_15(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_14(
+        returnValueForMissingStub: _FakeDuration_15(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -1742,11 +1778,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_14(
+        returnValue: _FakeDuration_15(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_14(
+        returnValueForMissingStub: _FakeDuration_15(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -1755,11 +1791,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1796,11 +1832,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1830,11 +1866,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1843,11 +1879,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1870,11 +1906,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_15(
+        returnValue: _FakePushruleEvaluator_16(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_15(
+        returnValueForMissingStub: _FakePushruleEvaluator_16(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -1895,332 +1931,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i15.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i16.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_16(
+        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.Profile>.value(_FakeProfile_16(
+            _i16.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i15.Future<_i4.Profile>);
+      ) as _i16.Future<_i4.Profile>);
 
   @override
-  _i13.CachedStreamController<String> get onUserProfileUpdate =>
+  _i14.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_17<String>(
+        returnValue: _FakeCachedStreamController_18<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i13.CachedStreamController<String>);
+      ) as _i14.CachedStreamController<String>);
 
   @override
-  _i15.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i16.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i15.Future<List<_i4.Room>>);
+            _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i16.Future<List<_i4.Room>>);
 
   @override
-  _i13.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i14.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_17<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_18<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.EventUpdate>(
+            _FakeCachedStreamController_18<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i13.CachedStreamController<_i4.EventUpdate>);
+      ) as _i14.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i13.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i14.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_17<_i4.Event>(
+        returnValue: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i13.CachedStreamController<_i4.Event>);
+      ) as _i14.CachedStreamController<_i4.Event>);
 
   @override
-  _i13.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i14.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_17<_i4.Event>(
+        returnValue: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i13.CachedStreamController<_i4.Event>);
+      ) as _i14.CachedStreamController<_i4.Event>);
 
   @override
-  _i13.CachedStreamController<_i4.Event> get onNotification =>
+  _i14.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_17<_i4.Event>(
+        returnValue: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i13.CachedStreamController<_i4.Event>);
+      ) as _i14.CachedStreamController<_i4.Event>);
 
   @override
-  _i13.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i14.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_17<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_18<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_18<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i13.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i14.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i13.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i14.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_17<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_18<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_17<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_18<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i13.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i14.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i13.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i14.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_17<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_18<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.LoginState>(
+            _FakeCachedStreamController_18<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i13.CachedStreamController<_i4.LoginState>);
+      ) as _i14.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i13.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i14.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_17<bool>(
+        returnValue: _FakeCachedStreamController_18<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i13.CachedStreamController<bool>);
+      ) as _i14.CachedStreamController<bool>);
 
   @override
-  _i13.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i14.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_17<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_18<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i13.CachedStreamController<_i4.SdkError>);
+      ) as _i14.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i13.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i14.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_17<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_18<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.SyncUpdate>(
+            _FakeCachedStreamController_18<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i13.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i14.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i13.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i14.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_17<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_18<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_18<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i13.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i14.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i13.CachedStreamController<_i4.Presence> get onPresence =>
+  _i14.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_17<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_18<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i13.CachedStreamController<_i4.Presence>);
+      ) as _i14.CachedStreamController<_i4.Presence>);
 
   @override
-  _i13.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i14.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_17<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_18<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.CachedPresence>(
+            _FakeCachedStreamController_18<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i13.CachedStreamController<_i4.CachedPresence>);
+      ) as _i14.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i13.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i14.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_17<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_18<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.BasicEvent>(
+            _FakeCachedStreamController_18<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i13.CachedStreamController<_i4.BasicEvent>);
+      ) as _i14.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i13.CachedStreamController<_i23.RoomKeyRequest> get onRoomKeyRequest =>
+  _i14.CachedStreamController<_i24.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_17<_i23.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_18<_i24.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i23.RoomKeyRequest>(
+            _FakeCachedStreamController_18<_i24.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i13.CachedStreamController<_i23.RoomKeyRequest>);
+      ) as _i14.CachedStreamController<_i24.RoomKeyRequest>);
 
   @override
-  _i13.CachedStreamController<_i23.KeyVerification>
+  _i14.CachedStreamController<_i24.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_17<_i23.KeyVerification>(
+            returnValue: _FakeCachedStreamController_18<_i24.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_17<_i23.KeyVerification>(
+                _FakeCachedStreamController_18<_i24.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i13.CachedStreamController<_i23.KeyVerification>);
+          ) as _i14.CachedStreamController<_i24.KeyVerification>);
 
   @override
-  _i13.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i14.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_17<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_18<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_17<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_18<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i13.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i14.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i13.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i14.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_17<_i4.Event>(
+        returnValue: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i13.CachedStreamController<_i4.Event>);
+      ) as _i14.CachedStreamController<_i4.Event>);
 
   @override
-  _i13.CachedStreamController<String> get onCancelSendEvent =>
+  _i14.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_17<String>(
+        returnValue: _FakeCachedStreamController_18<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_17<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_18<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i13.CachedStreamController<String>);
+      ) as _i14.CachedStreamController<String>);
 
   @override
-  _i13.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i14.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_17<
+            returnValue: _FakeCachedStreamController_18<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_17<
+            returnValueForMissingStub: _FakeCachedStreamController_18<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i13.CachedStreamController<
+          ) as _i14.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -2240,11 +2276,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_18(
+        returnValue: _FakeDateTime_19(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_18(
+        returnValueForMissingStub: _FakeDateTime_19(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2317,7 +2353,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i23.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i24.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2372,7 +2408,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i15.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i16.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2383,7 +2419,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i15.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i16.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -2494,7 +2530,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i16.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -2503,7 +2539,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i16.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -2512,7 +2548,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i15.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i16.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -2539,20 +2575,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Client get httpClient => (super.noSuchMethod(
+  _i15.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_19(
+        returnValue: _FakeClient_20(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_19(
+        returnValueForMissingStub: _FakeClient_20(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i14.Client);
+      ) as _i15.Client);
 
   @override
-  set httpClient(_i14.Client? value) => super.noSuchMethod(
+  set httpClient(_i15.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -2579,7 +2615,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i15.Future<void> refreshAccessToken(
+  _i16.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2587,9 +2623,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -2607,14 +2643,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2651,33 +2687,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i15.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i16.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_20(
+        returnValue: _i16.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_21(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_20(
+        returnValueForMissingStub: _i16.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_21(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i15.Future<_i4.DiscoveryInformation>);
+      ) as _i16.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i15.Future<
+  _i16.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -2699,7 +2735,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i15.Future<
+        returnValue: _i16.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2707,7 +2743,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_21(
+          _FakeGetVersionsResponse_22(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2722,7 +2758,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i15.Future<
+        returnValueForMissingStub: _i16.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -2730,7 +2766,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_21(
+          _FakeGetVersionsResponse_22(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -2745,7 +2781,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i15.Future<
+      ) as _i16.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -2754,7 +2790,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i15.Future<_i4.DiscoveryInformation> getWellknown({
+  _i16.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2767,8 +2803,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_20(
+        returnValue: _i16.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_21(
           this,
           Invocation.method(
             #getWellknown,
@@ -2779,8 +2815,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_20(
+        returnValueForMissingStub: _i16.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_21(
           this,
           Invocation.method(
             #getWellknown,
@@ -2791,10 +2827,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.DiscoveryInformation>);
+      ) as _i16.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i15.Future<_i4.RegisterResponse> register({
+  _i16.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -2822,7 +2858,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_22(
+            _i16.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_23(
           this,
           Invocation.method(
             #register,
@@ -2841,7 +2877,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_22(
+            _i16.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_23(
           this,
           Invocation.method(
             #register,
@@ -2859,10 +2895,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.RegisterResponse>);
+      ) as _i16.Future<_i4.RegisterResponse>);
 
   @override
-  _i15.Future<_i4.LoginResponse> login(
+  _i16.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -2892,7 +2928,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_23(
+        returnValue: _i16.Future<_i4.LoginResponse>.value(_FakeLoginResponse_24(
           this,
           Invocation.method(
             #login,
@@ -2912,7 +2948,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_23(
+            _i16.Future<_i4.LoginResponse>.value(_FakeLoginResponse_24(
           this,
           Invocation.method(
             #login,
@@ -2931,10 +2967,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.LoginResponse>);
+      ) as _i16.Future<_i4.LoginResponse>);
 
   @override
-  _i15.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i16.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -2947,8 +2983,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i15.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_24(
+        returnValue: _i16.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_25(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2960,8 +2996,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_24(
+            _i16.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_25(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -2972,74 +3008,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i16.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i15.Future<void> logout() => (super.noSuchMethod(
+  _i16.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> logoutAll() => (super.noSuchMethod(
+  _i16.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<T> uiaRequestBackground<T>(
-          _i15.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i16.Future<T> uiaRequestBackground<T>(
+          _i16.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValue: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i15.Future<T>.value(v),
+              (T v) => _i16.Future<T>.value(v),
             ) ??
-            _FakeFuture_25<T>(
+            _FakeFuture_26<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i15.Future<T>.value(v),
+              (T v) => _i16.Future<T>.value(v),
             ) ??
-            _FakeFuture_25<T>(
+            _FakeFuture_26<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i15.Future<T>);
+      ) as _i16.Future<T>);
 
   @override
-  _i15.Future<String> startDirectChat(
+  _i16.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -3061,7 +3097,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3077,7 +3113,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i18.dummyValue<String>(
+            _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3092,10 +3128,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<String> createGroupChat({
+  _i16.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -3126,7 +3162,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3147,7 +3183,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i18.dummyValue<String>(
+            _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3167,10 +3203,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i16.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -3186,7 +3222,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
+        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3199,7 +3235,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
+            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3211,21 +3247,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.SyncUpdate>);
+      ) as _i16.Future<_i4.SyncUpdate>);
 
   @override
-  _i15.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i16.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<String> createSpace({
+  _i16.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -3250,7 +3286,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3268,7 +3304,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i18.dummyValue<String>(
+            _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3285,10 +3321,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i16.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3296,7 +3332,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_16(
+        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3305,7 +3341,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.Profile>.value(_FakeProfile_16(
+            _i16.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3313,10 +3349,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i15.Future<_i4.Profile>);
+      ) as _i16.Future<_i4.Profile>);
 
   @override
-  _i15.Future<_i4.Profile> fetchOwnProfile({
+  _i16.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3329,7 +3365,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_16(
+        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3341,7 +3377,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.Profile>.value(_FakeProfile_16(
+            _i16.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3352,10 +3388,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.Profile>);
+      ) as _i16.Future<_i4.Profile>);
 
   @override
-  _i15.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i16.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3369,8 +3405,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i15.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_27(
+        returnValue: _i16.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_28(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3382,8 +3418,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_27(
+            _i16.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_28(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3394,10 +3430,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.CachedProfileInformation>);
+      ) as _i16.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i15.Future<_i4.Profile> getProfileFromUserId(
+  _i16.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3415,7 +3451,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_16(
+        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3429,7 +3465,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.Profile>.value(_FakeProfile_16(
+            _i16.Future<_i4.Profile>.value(_FakeProfile_17(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3442,7 +3478,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.Profile>);
+      ) as _i16.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -3464,31 +3500,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i15.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i16.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i15.Future<List<_i4.Room>>);
+            _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i16.Future<List<_i4.Room>>);
 
   @override
-  _i15.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i16.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i16.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i15.Future<List<_i4.ArchivedRoom>>);
+            _i16.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i16.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i15.Future<_i4.GetVersionsResponse> getVersions({
+  _i16.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3501,8 +3537,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i15.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_21(
+        returnValue: _i16.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_22(
           this,
           Invocation.method(
             #getVersions,
@@ -3513,8 +3549,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_21(
+        returnValueForMissingStub: _i16.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_22(
           this,
           Invocation.method(
             #getVersions,
@@ -3525,20 +3561,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.GetVersionsResponse>);
+      ) as _i16.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i15.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i16.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<_i4.MediaConfig> getConfig({
+  _i16.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3551,7 +3587,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
+        returnValue: _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
           this,
           Invocation.method(
             #getConfig,
@@ -3563,7 +3599,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
+            _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
           this,
           Invocation.method(
             #getConfig,
@@ -3574,10 +3610,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.MediaConfig>);
+      ) as _i16.Future<_i4.MediaConfig>);
 
   @override
-  _i15.Future<_i16.FileResponse> getContent(
+  _i16.Future<_i17.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -3597,7 +3633,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
+        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContent,
@@ -3613,7 +3649,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
+            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContent,
@@ -3628,10 +3664,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i16.FileResponse>);
+      ) as _i16.Future<_i17.FileResponse>);
 
   @override
-  _i15.Future<_i16.FileResponse> getContentOverrideName(
+  _i16.Future<_i17.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -3653,7 +3689,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
+        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3670,7 +3706,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
+            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -3686,10 +3722,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i16.FileResponse>);
+      ) as _i16.Future<_i17.FileResponse>);
 
   @override
-  _i15.Future<_i16.FileResponse> getContentThumbnail(
+  _i16.Future<_i17.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -3717,7 +3753,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
+        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3737,7 +3773,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
+            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -3756,10 +3792,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i16.FileResponse>);
+      ) as _i16.Future<_i17.FileResponse>);
 
   @override
-  _i15.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i16.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -3769,7 +3805,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
+        returnValue: _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3778,7 +3814,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
+            _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -3786,11 +3822,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i15.Future<_i4.PreviewForUrl>);
+      ) as _i16.Future<_i4.PreviewForUrl>);
 
   @override
-  _i15.Future<Uri> uploadContent(
-    _i24.Uint8List? file, {
+  _i16.Future<Uri> uploadContent(
+    _i25.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3803,7 +3839,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i15.Future<Uri>.value(_FakeUri_31(
+        returnValue: _i16.Future<Uri>.value(_FakeUri_32(
           this,
           Invocation.method(
             #uploadContent,
@@ -3814,7 +3850,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<Uri>.value(_FakeUri_31(
+        returnValueForMissingStub: _i16.Future<Uri>.value(_FakeUri_32(
           this,
           Invocation.method(
             #uploadContent,
@@ -3825,10 +3861,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<Uri>);
+      ) as _i16.Future<Uri>);
 
   @override
-  _i15.Future<void> setTyping(
+  _i16.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -3844,42 +3880,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<String?> exportDump() => (super.noSuchMethod(
+  _i16.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i15.Future<String?>.value(),
-        returnValueForMissingStub: _i15.Future<String?>.value(),
-      ) as _i15.Future<String?>);
+        returnValue: _i16.Future<String?>.value(),
+        returnValueForMissingStub: _i16.Future<String?>.value(),
+      ) as _i16.Future<String?>);
 
   @override
-  _i15.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i16.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i16.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.Event?> getEventByPushNotification(
+  _i16.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -3895,12 +3931,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i15.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
-      ) as _i15.Future<_i4.Event?>);
+        returnValue: _i16.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
+      ) as _i16.Future<_i4.Event?>);
 
   @override
-  _i15.Future<void> init({
+  _i16.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -3935,9 +3971,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -3949,40 +3985,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i15.Future<void> clear() => (super.noSuchMethod(
+  _i16.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i16.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> ensureNotSoftLoggedOut(
+  _i16.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> handleSync(
+  _i16.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -3992,9 +4028,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -4007,29 +4043,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i15.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i16.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i16.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> sendToDevice(
+  _i16.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -4043,12 +4079,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> sendToDevicesOfUserIds(
+  _i16.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4064,12 +4100,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> sendToDeviceEncrypted(
+  _i16.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4089,12 +4125,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> sendToDeviceEncryptedChunked(
+  _i16.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -4108,23 +4144,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i16.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<String> joinRoom(
+  _i16.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -4142,7 +4178,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4156,7 +4192,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i18.dummyValue<String>(
+            _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4169,10 +4205,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<void> changePassword(
+  _i16.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -4188,22 +4224,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> clearCache() => (super.noSuchMethod(
+  _i16.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> ignoreUser(
+  _i16.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4213,22 +4249,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i16.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i16.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4239,7 +4275,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_32(
+            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4248,7 +4284,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_32(
+            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_33(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4256,32 +4292,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i15.Future<_i4.CachedPresence>);
+      ) as _i16.Future<_i4.CachedPresence>);
 
   @override
-  _i15.Future<void> abortSync() => (super.noSuchMethod(
+  _i16.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i16.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<String?> redactEventWithMetadata(
+  _i16.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4301,14 +4337,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i15.Future<String?>.value(),
-        returnValueForMissingStub: _i15.Future<String?>.value(),
-      ) as _i15.Future<String?>);
+        returnValue: _i16.Future<String?>.value(),
+        returnValueForMissingStub: _i16.Future<String?>.value(),
+      ) as _i16.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i14.BaseResponse? response,
-    _i24.Uint8List? body,
+    _i15.BaseResponse? response,
+    _i25.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4340,7 +4376,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i15.Future<Map<String, Object?>> request(
+  _i16.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -4361,13 +4397,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 
   @override
-  _i15.Future<void> postPusher(
+  _i16.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -4377,57 +4413,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i16.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i16.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i16.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i15.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_33(
+        returnValue: _i16.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_34(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_33(
+        returnValueForMissingStub: _i16.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_34(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i15.Future<_i4.TurnServerCredentials>);
+      ) as _i16.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4441,8 +4477,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4454,8 +4490,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4466,10 +4502,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4485,8 +4521,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4499,8 +4535,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -4512,10 +4548,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i15.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i16.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4529,7 +4565,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
+        returnValue: _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4541,7 +4577,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
+            _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -4552,17 +4588,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.KeyBackupData>);
+      ) as _i16.Future<_i4.KeyBackupData>);
 
   @override
-  _i15.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i16.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i15.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_36(
+        returnValue: _i16.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_37(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -4570,18 +4606,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_36(
+            _i16.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_37(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i15.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i16.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i15.Future<int> pingAppservice(
+  _i16.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -4591,12 +4627,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i15.Future<int>.value(0),
-        returnValueForMissingStub: _i15.Future<int>.value(0),
-      ) as _i15.Future<int>);
+        returnValue: _i16.Future<int>.value(0),
+        returnValueForMissingStub: _i16.Future<int>.value(0),
+      ) as _i16.Future<int>);
 
   @override
-  _i15.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i16.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4604,8 +4640,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i15.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_37(
+        returnValue: _i16.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_38(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4614,8 +4650,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_37(
+            _i16.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_38(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -4623,15 +4659,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i15.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i16.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i15.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i16.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
+        returnValue: _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -4639,17 +4675,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_28(
+            _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_29(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i15.Future<_i4.MediaConfig>);
+      ) as _i16.Future<_i4.MediaConfig>);
 
   @override
-  _i15.Future<_i16.FileResponse> getContentAuthed(
+  _i16.Future<_i17.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -4663,7 +4699,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
+        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4675,7 +4711,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
+            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -4686,10 +4722,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i15.Future<_i16.FileResponse>);
+      ) as _i16.Future<_i17.FileResponse>);
 
   @override
-  _i15.Future<_i16.FileResponse> getContentOverrideNameAuthed(
+  _i16.Future<_i17.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4705,7 +4741,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
+        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4718,7 +4754,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
+            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -4730,10 +4766,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i15.Future<_i16.FileResponse>);
+      ) as _i16.Future<_i17.FileResponse>);
 
   @override
-  _i15.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i16.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -4743,7 +4779,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
+        returnValue: _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4752,7 +4788,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_30(
+            _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_31(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -4760,10 +4796,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i15.Future<_i4.PreviewForUrl>);
+      ) as _i16.Future<_i4.PreviewForUrl>);
 
   @override
-  _i15.Future<_i16.FileResponse> getContentThumbnailAuthed(
+  _i16.Future<_i17.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -4787,7 +4823,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
+        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4805,7 +4841,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_29(
+            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_30(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -4822,21 +4858,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i16.FileResponse>);
+      ) as _i16.Future<_i17.FileResponse>);
 
   @override
-  _i15.Future<bool> registrationTokenValidity(String? token) =>
+  _i16.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i16.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -4846,8 +4882,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_38(
+        returnValue: _i16.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_39(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4856,8 +4892,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_38(
+            _i16.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_39(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -4865,10 +4901,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i15.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i16.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i15.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i16.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -4886,8 +4922,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_39(
+        returnValue: _i16.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_40(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4901,8 +4937,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_39(
+            _i16.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_40(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -4915,10 +4951,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i16.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i15.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i16.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -4942,8 +4978,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i15.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_40(
+        returnValue: _i16.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_41(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4961,8 +4997,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_40(
+            _i16.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_41(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -4979,10 +5015,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i16.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -5010,8 +5046,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_41(
+                _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5030,8 +5066,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_41(
+                _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_42(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5049,10 +5085,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i15.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i16.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -5081,9 +5117,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i15.Future<
+            returnValue: _i16.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5102,9 +5138,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i15.Future<
+            returnValueForMissingStub: _i16.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_42(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_43(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5123,11 +5159,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i15
+          ) as _i16
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i15.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i16.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -5143,8 +5179,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i15.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_43(
+        returnValue: _i16.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_44(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5157,8 +5193,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_43(
+            _i16.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_44(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5170,10 +5206,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.GetThreadRootsResponse>);
+      ) as _i16.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i15.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i16.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -5187,8 +5223,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i15.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_44(
+        returnValue: _i16.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_45(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5200,8 +5236,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_44(
+            _i16.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_45(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5212,33 +5248,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i16.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i15.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i16.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i16.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i15.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i16.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i16.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i15.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i16.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i15.Future<Uri?>.value(),
-        returnValueForMissingStub: _i15.Future<Uri?>.value(),
-      ) as _i15.Future<Uri?>);
+        returnValue: _i16.Future<Uri?>.value(),
+        returnValueForMissingStub: _i16.Future<Uri?>.value(),
+      ) as _i16.Future<Uri?>);
 
   @override
-  _i15.Future<void> add3PID(
+  _i16.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -5252,12 +5288,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> bind3PID(
+  _i16.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5273,12 +5309,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i16.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5292,14 +5328,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i15.Future<_i4.IdServerUnbindResult>);
+      ) as _i16.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i16.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5321,8 +5357,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5338,8 +5374,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5355,10 +5391,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.RequestTokenResponse>);
+      ) as _i16.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i16.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5382,8 +5418,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5400,8 +5436,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5418,10 +5454,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.RequestTokenResponse>);
+      ) as _i16.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i15.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i16.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5435,14 +5471,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i15.Future<_i4.IdServerUnbindResult>);
+      ) as _i16.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i15.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i16.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -5457,14 +5493,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i15.Future<_i4.IdServerUnbindResult>);
+      ) as _i16.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i16.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5486,8 +5522,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5503,8 +5539,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -5520,10 +5556,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.RequestTokenResponse>);
+      ) as _i16.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i16.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5547,8 +5583,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5565,8 +5601,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -5583,16 +5619,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.RequestTokenResponse>);
+      ) as _i16.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i15.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i16.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
+            _i16.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -5600,22 +5636,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_46(
+            _i16.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_47(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i15.Future<_i4.TokenOwnerInfo>);
+      ) as _i16.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i15.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i16.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_47(
+        returnValue: _i16.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
           this,
           Invocation.method(
             #getWhoIs,
@@ -5623,22 +5659,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_47(
+            _i16.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_48(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i15.Future<_i4.WhoIsInfo>);
+      ) as _i16.Future<_i4.WhoIsInfo>);
 
   @override
-  _i15.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i16.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_48(
+        returnValue: _i16.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
           this,
           Invocation.method(
             #getCapabilities,
@@ -5646,17 +5682,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_48(
+            _i16.Future<_i4.Capabilities>.value(_FakeCapabilities_49(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i15.Future<_i4.Capabilities>);
+      ) as _i16.Future<_i4.Capabilities>);
 
   @override
-  _i15.Future<String> createRoom({
+  _i16.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -5689,7 +5725,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5711,7 +5747,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i18.dummyValue<String>(
+            _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5732,10 +5768,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<void> deleteDevices(
+  _i16.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5745,22 +5781,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i16.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i15.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i15.Future<List<_i4.Device>?>.value(),
-      ) as _i15.Future<List<_i4.Device>?>);
+        returnValue: _i16.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i16.Future<List<_i4.Device>?>.value(),
+      ) as _i16.Future<List<_i4.Device>?>);
 
   @override
-  _i15.Future<void> deleteDevice(
+  _i16.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -5770,34 +5806,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i16.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i15.Future<_i4.Device>.value(_FakeDevice_49(
+        returnValue: _i16.Future<_i4.Device>.value(_FakeDevice_50(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.Device>.value(_FakeDevice_49(
+        returnValueForMissingStub: _i16.Future<_i4.Device>.value(_FakeDevice_50(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i15.Future<_i4.Device>);
+      ) as _i16.Future<_i4.Device>);
 
   @override
-  _i15.Future<void> updateDevice(
+  _i16.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -5807,12 +5843,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i16.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -5827,24 +5863,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 
   @override
-  _i15.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i16.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i15.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i15.Future<_i4.Visibility?>.value(),
-      ) as _i15.Future<_i4.Visibility?>);
+        returnValue: _i16.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i16.Future<_i4.Visibility?>.value(),
+      ) as _i16.Future<_i4.Visibility?>);
 
   @override
-  _i15.Future<void> setRoomVisibilityOnDirectory(
+  _i16.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -5854,30 +5890,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i16.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i16.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_50(
+        returnValue: _i16.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_51(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -5885,18 +5921,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_50(
+            _i16.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_51(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i15.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i16.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i15.Future<void> setRoomAlias(
+  _i16.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -5908,12 +5944,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.GetEventsResponse> getEvents({
+  _i16.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -5927,7 +5963,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_51(
+            _i16.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
           this,
           Invocation.method(
             #getEvents,
@@ -5939,7 +5975,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_51(
+            _i16.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_52(
           this,
           Invocation.method(
             #getEvents,
@@ -5950,10 +5986,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.GetEventsResponse>);
+      ) as _i16.Future<_i4.GetEventsResponse>);
 
   @override
-  _i15.Future<_i4.PeekEventsResponse> peekEvents({
+  _i16.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -5968,8 +6004,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i15.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_52(
+        returnValue: _i16.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_53(
           this,
           Invocation.method(
             #peekEvents,
@@ -5981,8 +6017,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_52(
+        returnValueForMissingStub: _i16.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_53(
           this,
           Invocation.method(
             #peekEvents,
@@ -5994,16 +6030,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.PeekEventsResponse>);
+      ) as _i16.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i15.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i16.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
+        returnValue: _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneEvent,
@@ -6011,27 +6047,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
+            _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i15.Future<_i4.MatrixEvent>);
+      ) as _i16.Future<_i4.MatrixEvent>);
 
   @override
-  _i15.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i16.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i15.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
-      ) as _i15.Future<List<String>>);
+        returnValue: _i16.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
+      ) as _i16.Future<List<String>>);
 
   @override
-  _i15.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i16.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -6043,8 +6079,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i15.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_54(
+        returnValue: _i16.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_55(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6055,8 +6091,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_54(
+            _i16.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_55(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6066,10 +6102,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.GetKeysChangesResponse>);
+      ) as _i16.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i15.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i16.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -6080,7 +6116,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
+            _i16.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
           this,
           Invocation.method(
             #claimKeys,
@@ -6089,7 +6125,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_55(
+            _i16.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_56(
           this,
           Invocation.method(
             #claimKeys,
@@ -6097,10 +6133,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i15.Future<_i4.ClaimKeysResponse>);
+      ) as _i16.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i15.Future<void> uploadCrossSigningKeys({
+  _i16.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -6117,12 +6153,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.QueryKeysResponse> queryKeys(
+  _i16.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -6133,7 +6169,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
+            _i16.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
           this,
           Invocation.method(
             #queryKeys,
@@ -6142,7 +6178,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_56(
+            _i16.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_57(
           this,
           Invocation.method(
             #queryKeys,
@@ -6150,10 +6186,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i15.Future<_i4.QueryKeysResponse>);
+      ) as _i16.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i16.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -6161,14 +6197,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i15.Future<
+            returnValue: _i16.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i15.Future<
+            returnValueForMissingStub: _i16.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i16.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i15.Future<Map<String, int>> uploadKeys({
+  _i16.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -6183,13 +6219,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i15.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i16.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i15.Future<Map<String, int>>);
+            _i16.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i16.Future<Map<String, int>>);
 
   @override
-  _i15.Future<String> knockRoom(
+  _i16.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -6203,7 +6239,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6215,7 +6251,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i18.dummyValue<String>(
+            _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6226,20 +6262,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i16.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i15.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i15.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i15.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i16.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i16.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i16.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i15.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i16.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6254,8 +6290,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i15.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_57(
+        returnValue: _i16.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_58(
           this,
           Invocation.method(
             #getNotifications,
@@ -6268,8 +6304,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_57(
+            _i16.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_58(
           this,
           Invocation.method(
             #getNotifications,
@@ -6281,35 +6317,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.GetNotificationsResponse>);
+      ) as _i16.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i15.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i16.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i15.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_58(
+        returnValue: _i16.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_59(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_58(
+        returnValueForMissingStub: _i16.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_59(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i15.Future<_i4.GetPresenceResponse>);
+      ) as _i16.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i15.Future<void> setPresence(
+  _i16.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -6323,12 +6359,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<Map<String, Object?>> deleteProfileField(
+  _i16.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6341,13 +6377,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 
   @override
-  _i15.Future<Map<String, Object?>> getProfileField(
+  _i16.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6360,13 +6396,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 
   @override
-  _i15.Future<Map<String, Object?>> setProfileField(
+  _i16.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6381,13 +6417,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 
   @override
-  _i15.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i16.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6402,8 +6438,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i15.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_59(
+        returnValue: _i16.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_60(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6416,8 +6452,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_59(
+            _i16.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_60(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6429,10 +6465,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i16.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i15.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i16.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -6453,8 +6489,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i15.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_60(
+        returnValue: _i16.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_61(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6470,8 +6506,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_60(
+            _i16.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_61(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6486,25 +6522,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i16.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i15.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i16.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i15.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i15.Future<List<_i4.Pusher>?>.value(),
-      ) as _i15.Future<List<_i4.Pusher>?>);
+        returnValue: _i16.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i16.Future<List<_i4.Pusher>?>.value(),
+      ) as _i16.Future<List<_i4.Pusher>?>);
 
   @override
-  _i15.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i16.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_61(
+        returnValue: _i16.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
           this,
           Invocation.method(
             #getPushRules,
@@ -6512,24 +6548,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_61(
+            _i16.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_62(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i15.Future<_i4.PushRuleSet>);
+      ) as _i16.Future<_i4.PushRuleSet>);
 
   @override
-  _i15.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i16.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_62(
+        returnValue: _i16.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_63(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -6537,18 +6573,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_62(
+            _i16.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_63(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i15.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i16.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i15.Future<void> deletePushRule(
+  _i16.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6560,12 +6596,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.PushRule> getPushRule(
+  _i16.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6577,7 +6613,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i15.Future<_i4.PushRule>.value(_FakePushRule_63(
+        returnValue: _i16.Future<_i4.PushRule>.value(_FakePushRule_64(
           this,
           Invocation.method(
             #getPushRule,
@@ -6588,7 +6624,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.PushRule>.value(_FakePushRule_63(
+            _i16.Future<_i4.PushRule>.value(_FakePushRule_64(
           this,
           Invocation.method(
             #getPushRule,
@@ -6598,10 +6634,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.PushRule>);
+      ) as _i16.Future<_i4.PushRule>);
 
   @override
-  _i15.Future<void> setPushRule(
+  _i16.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -6625,12 +6661,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<List<Object?>> getPushRuleActions(
+  _i16.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6642,13 +6678,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i15.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i16.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i15.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i15.Future<List<Object?>>);
+            _i16.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i16.Future<List<Object?>>);
 
   @override
-  _i15.Future<void> setPushRuleActions(
+  _i16.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -6662,12 +6698,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<bool> isPushRuleEnabled(
+  _i16.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -6679,12 +6715,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<void> setPushRuleEnabled(
+  _i16.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -6698,19 +6734,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i16.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_64(
+            _i16.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
           this,
           Invocation.method(
             #refresh,
@@ -6718,28 +6754,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_64(
+            _i16.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_65(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i15.Future<_i4.RefreshResponse>);
+      ) as _i16.Future<_i4.RefreshResponse>);
 
   @override
-  _i15.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i16.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i15.Future<bool?>.value(),
-        returnValueForMissingStub: _i15.Future<bool?>.value(),
-      ) as _i15.Future<bool?>);
+        returnValue: _i16.Future<bool?>.value(),
+        returnValueForMissingStub: _i16.Future<bool?>.value(),
+      ) as _i16.Future<bool?>);
 
   @override
-  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i16.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6761,8 +6797,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6778,8 +6814,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -6795,10 +6831,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.RequestTokenResponse>);
+      ) as _i16.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i16.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6822,8 +6858,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6840,8 +6876,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_45(
+        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_46(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -6858,17 +6894,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.RequestTokenResponse>);
+      ) as _i16.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -6876,23 +6912,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i15.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i16.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_65(
+        returnValue: _i16.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -6900,17 +6936,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_65(
+            _i16.Future<_i4.RoomKeys>.value(_FakeRoomKeys_66(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i15.Future<_i4.RoomKeys>);
+      ) as _i16.Future<_i4.RoomKeys>);
 
   @override
-  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -6922,8 +6958,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6934,8 +6970,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -6945,10 +6981,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6960,8 +6996,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6972,8 +7008,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -6983,10 +7019,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i15.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i16.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -6998,7 +7034,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
+        returnValue: _i16.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -7009,7 +7045,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_66(
+            _i16.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_67(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -7019,10 +7055,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.RoomKeyBackup>);
+      ) as _i16.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -7036,8 +7072,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7049,8 +7085,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7061,10 +7097,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7078,8 +7114,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7091,8 +7127,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7103,10 +7139,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i15.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i16.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7120,7 +7156,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
+        returnValue: _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7132,7 +7168,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_35(
+            _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_36(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7143,10 +7179,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.KeyBackupData>);
+      ) as _i16.Future<_i4.KeyBackupData>);
 
   @override
-  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7162,8 +7198,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_34(
+        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7176,8 +7212,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_34(
+            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_35(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7189,18 +7225,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_67(
+                _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_68(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -7208,18 +7244,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_67(
+                _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_68(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i15.Future<String> postRoomKeysVersion(
+  _i16.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -7231,7 +7267,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7242,7 +7278,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i18.dummyValue<String>(
+            _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7252,29 +7288,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i16.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i16.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_68(
+        returnValue: _i16.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_69(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7282,18 +7318,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_68(
+            _i16.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_69(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i15.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i16.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i15.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i16.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -7308,24 +7344,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 
   @override
-  _i15.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i16.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i15.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
-      ) as _i15.Future<List<String>>);
+        returnValue: _i16.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
+      ) as _i16.Future<List<String>>);
 
   @override
-  _i15.Future<void> ban(
+  _i16.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7339,12 +7375,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.EventContext> getEventContext(
+  _i16.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7362,7 +7398,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i15.Future<_i4.EventContext>.value(_FakeEventContext_69(
+        returnValue: _i16.Future<_i4.EventContext>.value(_FakeEventContext_70(
           this,
           Invocation.method(
             #getEventContext,
@@ -7377,7 +7413,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.EventContext>.value(_FakeEventContext_69(
+            _i16.Future<_i4.EventContext>.value(_FakeEventContext_70(
           this,
           Invocation.method(
             #getEventContext,
@@ -7391,10 +7427,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.EventContext>);
+      ) as _i16.Future<_i4.EventContext>);
 
   @override
-  _i15.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i16.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7406,7 +7442,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
+        returnValue: _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7417,7 +7453,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_53(
+            _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_54(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7427,20 +7463,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.MatrixEvent>);
+      ) as _i16.Future<_i4.MatrixEvent>);
 
   @override
-  _i15.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i16.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> inviteBy3PID(
+  _i16.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -7452,12 +7488,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> inviteUser(
+  _i16.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7471,12 +7507,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<String> joinRoomById(
+  _i16.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -7490,7 +7526,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7502,7 +7538,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i18.dummyValue<String>(
+            _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7513,23 +7549,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i16.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i15.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i16.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i15.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i15.Future<Map<String, _i4.RoomMember>?>);
+            _i16.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i16.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i15.Future<void> kick(
+  _i16.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7543,12 +7579,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> leaveRoom(
+  _i16.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -7558,12 +7594,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i16.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -7579,12 +7615,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i15.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i15.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i15.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i16.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i16.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i16.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i15.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i16.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -7606,8 +7642,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i15.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_70(
+        returnValue: _i16.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_71(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7623,8 +7659,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_70(
+        returnValueForMissingStub: _i16.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_71(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -7640,10 +7676,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.GetRoomEventsResponse>);
+      ) as _i16.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i15.Future<void> setReadMarker(
+  _i16.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -7659,12 +7695,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> postReceipt(
+  _i16.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -7680,12 +7716,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<String?> redactEvent(
+  _i16.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -7701,12 +7737,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i15.Future<String?>.value(),
-        returnValueForMissingStub: _i15.Future<String?>.value(),
-      ) as _i15.Future<String?>);
+        returnValue: _i16.Future<String?>.value(),
+        returnValueForMissingStub: _i16.Future<String?>.value(),
+      ) as _i16.Future<String?>);
 
   @override
-  _i15.Future<void> reportRoom(
+  _i16.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -7718,12 +7754,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> reportEvent(
+  _i16.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -7741,12 +7777,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<String> sendMessage(
+  _i16.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -7762,7 +7798,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7775,7 +7811,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i18.dummyValue<String>(
+            _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7787,23 +7823,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i16.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i16.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i15.Future<List<_i4.MatrixEvent>>);
+            _i16.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i16.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i15.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i16.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -7820,13 +7856,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 
   @override
-  _i15.Future<String> setRoomStateWithKey(
+  _i16.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -7842,7 +7878,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7855,7 +7891,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i18.dummyValue<String>(
+            _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7867,10 +7903,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<void> unban(
+  _i16.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7884,12 +7920,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<String> upgradeRoom(
+  _i16.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -7903,7 +7939,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7915,7 +7951,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i18.dummyValue<String>(
+            _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7926,10 +7962,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<_i4.SearchResults> search(
+  _i16.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -7939,7 +7975,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_71(
+        returnValue: _i16.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
           this,
           Invocation.method(
             #search,
@@ -7948,7 +7984,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_71(
+            _i16.Future<_i4.SearchResults>.value(_FakeSearchResults_72(
           this,
           Invocation.method(
             #search,
@@ -7956,10 +7992,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i15.Future<_i4.SearchResults>);
+      ) as _i16.Future<_i4.SearchResults>);
 
   @override
-  _i15.Future<_i4.SyncUpdate> sync({
+  _i16.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -7980,7 +8016,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
+        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
           this,
           Invocation.method(
             #sync,
@@ -7996,7 +8032,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_26(
+            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_27(
           this,
           Invocation.method(
             #sync,
@@ -8011,22 +8047,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.SyncUpdate>);
+      ) as _i16.Future<_i4.SyncUpdate>);
 
   @override
-  _i15.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i16.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i15.Future<List<_i4.Location>>);
+            _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i16.Future<List<_i4.Location>>);
 
   @override
-  _i15.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i16.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8036,21 +8072,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i15.Future<List<_i4.Location>>);
+            _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i16.Future<List<_i4.Location>>);
 
   @override
-  _i15.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i16.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_72(
+        returnValue: _i16.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_73(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -8058,45 +8094,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_72(
+            _i16.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_73(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i15.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i16.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i15.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i16.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i16.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
+            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i16.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i16.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8107,13 +8143,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
+            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i16.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i15.Future<Map<String, Object?>> getAccountData(
+  _i16.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -8126,13 +8162,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 
   @override
-  _i15.Future<void> setAccountData(
+  _i16.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -8146,12 +8182,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<String> defineFilter(
+  _i16.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -8163,7 +8199,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8174,7 +8210,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i18.dummyValue<String>(
+            _i16.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8184,10 +8220,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<_i4.Filter> getFilter(
+  _i16.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -8199,7 +8235,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i15.Future<_i4.Filter>.value(_FakeFilter_12(
+        returnValue: _i16.Future<_i4.Filter>.value(_FakeFilter_13(
           this,
           Invocation.method(
             #getFilter,
@@ -8209,7 +8245,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.Filter>.value(_FakeFilter_12(
+        returnValueForMissingStub: _i16.Future<_i4.Filter>.value(_FakeFilter_13(
           this,
           Invocation.method(
             #getFilter,
@@ -8219,10 +8255,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.Filter>);
+      ) as _i16.Future<_i4.Filter>);
 
   @override
-  _i15.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i16.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8235,7 +8271,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
+            _i16.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8246,7 +8282,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_73(
+            _i16.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_74(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8256,10 +8292,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.OpenIdCredentials>);
+      ) as _i16.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i15.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i16.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8274,13 +8310,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 
   @override
-  _i15.Future<void> setAccountDataPerRoom(
+  _i16.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8296,12 +8332,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i16.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8313,12 +8349,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i15.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i15.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i15.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i16.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i16.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i16.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i15.Future<void> deleteRoomTag(
+  _i16.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8332,12 +8368,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> setRoomTag(
+  _i16.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8353,12 +8389,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i16.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8368,8 +8404,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i15.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_74(
+        returnValue: _i16.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_75(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8378,8 +8414,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_74(
+            _i16.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_75(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8387,10 +8423,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i15.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i16.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i15.Future<Map<String, Object?>> reportUser(
+  _i16.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8403,40 +8439,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 
   @override
-  _i15.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i16.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i15.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_75(
+        returnValue: _i16.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_76(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_75(
+        returnValueForMissingStub: _i16.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_76(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i15.Future<_i4.CreateContentResponse>);
+      ) as _i16.Future<_i4.CreateContentResponse>);
 
   @override
-  _i15.Future<Map<String, Object?>> uploadContentToMXC(
+  _i16.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i24.Uint8List? body, {
+    _i25.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8454,10 +8490,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [AuthService].
@@ -8497,10 +8533,11 @@ class MockAuthService extends _i1.Mock implements _i10.AuthService {
       ) as bool);
 
   @override
-  _i15.Future<bool> login({
+  _i16.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8510,14 +8547,15 @@ class MockAuthService extends _i1.Mock implements _i10.AuthService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<bool> completeSsoLogin({
+  _i16.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -8530,12 +8568,12 @@ class MockAuthService extends _i1.Mock implements _i10.AuthService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<void> completeRegistration(
+  _i16.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -8545,9 +8583,9 @@ class MockAuthService extends _i1.Mock implements _i10.AuthService {
           [response],
           {#password: password},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
   void activateRestoredSession() => super.noSuchMethod(
@@ -8559,37 +8597,37 @@ class MockAuthService extends _i1.Mock implements _i10.AuthService {
       );
 
   @override
-  _i15.Future<void> logout() => (super.noSuchMethod(
+  _i16.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> handleServerLogout() => (super.noSuchMethod(
+  _i16.Future<void> handleServerLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleServerLogout,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> saveSessionBackup() => (super.noSuchMethod(
+  _i16.Future<void> saveSessionBackup() => (super.noSuchMethod(
         Invocation.method(
           #saveSessionBackup,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i17.ServerAuthCapabilities> getServerAuthCapabilities(
+  _i16.Future<_i18.ServerAuthCapabilities> getServerAuthCapabilities(
     String? homeserver, {
     required bool? isLoggedIn,
   }) =>
@@ -8599,8 +8637,8 @@ class MockAuthService extends _i1.Mock implements _i10.AuthService {
           [homeserver],
           {#isLoggedIn: isLoggedIn},
         ),
-        returnValue: _i15.Future<_i17.ServerAuthCapabilities>.value(
-            _FakeServerAuthCapabilities_76(
+        returnValue: _i16.Future<_i18.ServerAuthCapabilities>.value(
+            _FakeServerAuthCapabilities_77(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -8609,8 +8647,8 @@ class MockAuthService extends _i1.Mock implements _i10.AuthService {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i17.ServerAuthCapabilities>.value(
-                _FakeServerAuthCapabilities_76(
+            _i16.Future<_i18.ServerAuthCapabilities>.value(
+                _FakeServerAuthCapabilities_77(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -8618,7 +8656,7 @@ class MockAuthService extends _i1.Mock implements _i10.AuthService {
             {#isLoggedIn: isLoggedIn},
           ),
         )),
-      ) as _i15.Future<_i17.ServerAuthCapabilities>);
+      ) as _i16.Future<_i18.ServerAuthCapabilities>);
 
   @override
   bool isPermanentAuthFailure(Object? error) => (super.noSuchMethod(
@@ -8631,37 +8669,81 @@ class MockAuthService extends _i1.Mock implements _i10.AuthService {
       ) as bool);
 
   @override
-  _i15.Future<void> clearSessionKeys() => (super.noSuchMethod(
+  _i16.Future<void> clearSessionKeys() => (super.noSuchMethod(
         Invocation.method(
           #clearSessionKeys,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> migrateStorageKeys() => (super.noSuchMethod(
+  _i16.Future<void> saveLoginCredentials({
+    required String? homeserver,
+    required String? username,
+    required String? password,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #saveLoginCredentials,
+          [],
+          {
+            #homeserver: homeserver,
+            #username: username,
+            #password: password,
+          },
+        ),
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
+
+  @override
+  _i16.Future<({String password, String username})?> loadLoginCredentials(
+          String? homeserver) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #loadLoginCredentials,
+          [homeserver],
+        ),
+        returnValue: _i16.Future<({String password, String username})?>.value(),
+        returnValueForMissingStub:
+            _i16.Future<({String password, String username})?>.value(),
+      ) as _i16.Future<({String password, String username})?>);
+
+  @override
+  _i16.Future<void> clearLoginCredentials(String? homeserver) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #clearLoginCredentials,
+          [homeserver],
+        ),
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
+
+  @override
+  _i16.Future<void> migrateStorageKeys() => (super.noSuchMethod(
         Invocation.method(
           #migrateStorageKeys,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> persistCredentials() => (super.noSuchMethod(
+  _i16.Future<void> persistCredentials() => (super.noSuchMethod(
         Invocation.method(
           #persistCredentials,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8670,7 +8752,7 @@ class MockAuthService extends _i1.Mock implements _i10.AuthService {
       );
 
   @override
-  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/test/widgets/message_reply_test.mocks.dart
+++ b/test/widgets/message_reply_test.mocks.dart
@@ -4,13 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i19;
-import 'dart:ui' as _i21;
+import 'dart:typed_data' as _i20;
+import 'dart:ui' as _i22;
 
-import 'package:flutter/services.dart' as _i22;
-import 'package:flutter/widgets.dart' as _i23;
+import 'package:flutter/services.dart' as _i23;
+import 'package:flutter/widgets.dart' as _i24;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/matrix_service.dart' as _i21;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -25,14 +26,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i18;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i16;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i17;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i24;
+import 'package:matrix/src/utils/space_child.dart' as _i25;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i18;
+import 'package:mockito/src/dummies.dart' as _i19;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -846,8 +847,9 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_75(
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -856,9 +858,19 @@ class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_76 extends _i1.SmartFake
+class _FakeRoomSummary_76 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_76(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_77 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_76(
+  _FakeLatestReceiptState_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,8 +879,8 @@ class _FakeLatestReceiptState_76 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_77(
+class _FakeTimeline_78 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -877,8 +889,8 @@ class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_78(
+class _FakeUser_79 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -887,8 +899,8 @@ class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_79 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_79(
+class _FakeRoom_80 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -897,9 +909,9 @@ class _FakeRoom_79 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeTimelineChunk_80 extends _i1.SmartFake
-    implements _i16.TimelineChunk {
-  _FakeTimelineChunk_80(
+class _FakeTimelineChunk_81 extends _i1.SmartFake
+    implements _i17.TimelineChunk {
+  _FakeTimelineChunk_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -908,8 +920,8 @@ class _FakeTimelineChunk_80 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixFile_81 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_81(
+class _FakeMatrixFile_82 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -918,8 +930,8 @@ class _FakeMatrixFile_81 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_82 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_82(
+class _FakeEvent_83 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -946,12 +958,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i17.KeyVerificationMethod> get verificationMethods =>
+  Set<_i18.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i17.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
-      ) as Set<_i17.KeyVerificationMethod>);
+        returnValue: <_i18.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
+      ) as Set<_i18.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1071,11 +1083,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1112,11 +1124,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1146,11 +1158,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1159,11 +1171,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1449,34 +1461,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i17.KeyVerification>
+  _i3.CachedStreamController<_i18.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i17.KeyVerification>(
+                _FakeCachedStreamController_6<_i18.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i17.KeyVerification>);
+          ) as _i3.CachedStreamController<_i18.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1632,7 +1644,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1921,14 +1933,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2316,8 +2328,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValue: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2333,8 +2345,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2375,7 +2387,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2391,7 +2403,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2440,7 +2452,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2461,7 +2473,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2564,7 +2576,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2582,7 +2594,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3101,7 +3113,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i19.Uint8List? file, {
+    _i20.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3453,7 +3465,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3467,7 +3479,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3618,7 +3630,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i19.Uint8List? body,
+    _i20.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4996,7 +5008,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5018,7 +5030,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5512,7 +5524,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5524,7 +5536,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6532,7 +6544,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6543,7 +6555,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6791,7 +6803,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6803,7 +6815,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7063,7 +7075,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7076,7 +7088,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7143,7 +7155,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7156,7 +7168,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7204,7 +7216,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7216,7 +7228,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7464,7 +7476,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7475,7 +7487,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7737,7 +7749,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i19.Uint8List? body, {
+    _i20.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7764,7 +7776,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7794,11 +7806,11 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7923,6 +7935,19 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -8020,6 +8045,15 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -8064,7 +8098,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8089,6 +8123,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8098,6 +8133,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8158,7 +8194,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8167,7 +8203,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8186,7 +8222,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8197,7 +8233,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8245,7 +8281,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i23.RouteInformation? routeInformation) =>
+          _i24.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8283,7 +8319,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8292,7 +8328,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8301,16 +8337,16 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
-      ) as _i5.Future<_i21.AppExitResponse>);
+            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+      ) as _i5.Future<_i22.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8338,11 +8374,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8372,11 +8408,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_75(
+        returnValue: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_75(
+        returnValueForMissingStub: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
@@ -8429,11 +8465,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8469,11 +8505,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8489,11 +8525,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8502,11 +8538,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8549,11 +8585,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8596,11 +8632,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_76(
+        returnValue: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_76(
+        returnValueForMissingStub: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8819,18 +8855,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i24.SpaceParent>[],
-        returnValueForMissingStub: <_i24.SpaceParent>[],
-      ) as List<_i24.SpaceParent>);
+        returnValue: <_i25.SpaceParent>[],
+        returnValueForMissingStub: <_i25.SpaceParent>[],
+      ) as List<_i25.SpaceParent>);
 
   @override
-  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i24.SpaceChild>[],
-        returnValueForMissingStub: <_i24.SpaceChild>[],
-      ) as List<_i24.SpaceChild>);
+        returnValue: <_i25.SpaceChild>[],
+        returnValueForMissingStub: <_i25.SpaceChild>[],
+      ) as List<_i25.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8997,14 +9033,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9052,7 +9088,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9060,7 +9096,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9075,7 +9111,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9083,7 +9119,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9177,7 +9213,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9185,7 +9221,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9427,7 +9463,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9438,7 +9474,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9527,15 +9563,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i16.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i17.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i16.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i16.TimelineChunk?>.value(),
-      ) as _i5.Future<_i16.TimelineChunk?>);
+        returnValue: _i5.Future<_i17.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i17.TimelineChunk?>.value(),
+      ) as _i5.Future<_i17.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9576,7 +9612,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9593,7 +9629,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9657,14 +9693,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9680,14 +9716,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9743,7 +9779,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9751,7 +9787,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10063,11 +10099,11 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_79(
+        returnValue: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_79(
+        returnValueForMissingStub: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
@@ -10117,17 +10153,17 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       ) as bool);
 
   @override
-  _i16.TimelineChunk get chunk => (super.noSuchMethod(
+  _i17.TimelineChunk get chunk => (super.noSuchMethod(
         Invocation.getter(#chunk),
-        returnValue: _FakeTimelineChunk_80(
+        returnValue: _FakeTimelineChunk_81(
           this,
           Invocation.getter(#chunk),
         ),
-        returnValueForMissingStub: _FakeTimelineChunk_80(
+        returnValueForMissingStub: _FakeTimelineChunk_81(
           this,
           Invocation.getter(#chunk),
         ),
-      ) as _i16.TimelineChunk);
+      ) as _i17.TimelineChunk);
 
   @override
   bool get canRequestHistory => (super.noSuchMethod(
@@ -10230,7 +10266,7 @@ class MockTimeline extends _i1.Mock implements _i2.Timeline {
       );
 
   @override
-  set chunk(_i16.TimelineChunk? value) => super.noSuchMethod(
+  set chunk(_i17.TimelineChunk? value) => super.noSuchMethod(
         Invocation.setter(
           #chunk,
           value,
@@ -10429,11 +10465,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.getter(#sender),
         ),
@@ -10442,11 +10478,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10455,11 +10491,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_79(
+        returnValue: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_79(
+        returnValueForMissingStub: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
@@ -10482,11 +10518,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10495,11 +10531,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10508,11 +10544,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10521,11 +10557,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10534,11 +10570,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10547,11 +10583,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10616,11 +10652,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10629,11 +10665,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10686,11 +10722,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10775,11 +10811,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10797,11 +10833,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11012,7 +11048,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i19.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i20.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -11027,7 +11063,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_81(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_82(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -11041,7 +11077,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_81(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_82(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -11077,7 +11113,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11092,7 +11128,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -11129,7 +11165,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11143,7 +11179,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -11180,7 +11216,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11194,7 +11230,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -11228,7 +11264,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11241,7 +11277,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -11317,14 +11353,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_82(
+        returnValue: _FakeEvent_83(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_82(
+        returnValueForMissingStub: _FakeEvent_83(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -11341,11 +11377,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_79(
+        returnValue: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_79(
+        returnValueForMissingStub: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
@@ -11354,11 +11390,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -11424,11 +11460,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11453,11 +11489,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11475,11 +11511,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11526,7 +11562,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11538,7 +11574,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11608,7 +11644,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11621,7 +11657,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/widgets/new_dm_dialog_test.mocks.dart
+++ b/test/widgets/new_dm_dialog_test.mocks.dart
@@ -4,13 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -25,14 +26,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i25;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i23;
+import 'package:matrix/src/utils/space_child.dart' as _i24;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -846,8 +847,9 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_75(
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -856,9 +858,19 @@ class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_76 extends _i1.SmartFake
+class _FakeRoomSummary_76 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_76(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_77 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_76(
+  _FakeLatestReceiptState_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,8 +879,8 @@ class _FakeLatestReceiptState_76 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_77(
+class _FakeTimeline_78 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -877,8 +889,8 @@ class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_78(
+class _FakeUser_79 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -905,12 +917,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1030,11 +1042,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1071,11 +1083,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1105,11 +1117,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1118,11 +1130,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1408,34 +1420,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1591,7 +1603,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1880,14 +1892,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2275,8 +2287,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2292,8 +2304,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2334,7 +2346,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2350,7 +2362,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2399,7 +2411,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2420,7 +2432,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2523,7 +2535,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2541,7 +2553,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3060,7 +3072,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3412,7 +3424,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3426,7 +3438,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3577,7 +3589,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4955,7 +4967,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4977,7 +4989,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5471,7 +5483,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5483,7 +5495,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6491,7 +6503,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6502,7 +6514,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6750,7 +6762,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6762,7 +6774,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7022,7 +7034,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7035,7 +7047,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7102,7 +7114,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7115,7 +7127,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7163,7 +7175,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7175,7 +7187,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7423,7 +7435,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7434,7 +7446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7696,7 +7708,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7723,7 +7735,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7753,11 +7765,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7882,6 +7894,19 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7979,6 +8004,15 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -8023,7 +8057,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8048,6 +8082,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8057,6 +8092,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8117,7 +8153,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8126,7 +8162,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8145,7 +8181,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8156,7 +8192,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8204,7 +8240,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8242,7 +8278,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8251,7 +8287,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8260,16 +8296,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8297,11 +8333,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8331,11 +8367,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_75(
+        returnValue: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_75(
+        returnValueForMissingStub: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
@@ -8388,11 +8424,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8428,11 +8464,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8448,11 +8484,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8461,11 +8497,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8508,11 +8544,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8555,11 +8591,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_76(
+        returnValue: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_76(
+        returnValueForMissingStub: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8778,18 +8814,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i23.SpaceParent>[],
-        returnValueForMissingStub: <_i23.SpaceParent>[],
-      ) as List<_i23.SpaceParent>);
+        returnValue: <_i24.SpaceParent>[],
+        returnValueForMissingStub: <_i24.SpaceParent>[],
+      ) as List<_i24.SpaceParent>);
 
   @override
-  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i23.SpaceChild>[],
-        returnValueForMissingStub: <_i23.SpaceChild>[],
-      ) as List<_i23.SpaceChild>);
+        returnValue: <_i24.SpaceChild>[],
+        returnValueForMissingStub: <_i24.SpaceChild>[],
+      ) as List<_i24.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8956,14 +8992,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9011,7 +9047,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9019,7 +9055,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9034,7 +9070,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9042,7 +9078,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9136,7 +9172,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9144,7 +9180,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9386,7 +9422,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9397,7 +9433,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9486,15 +9522,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i25.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i24.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i24.TimelineChunk?>.value(),
-      ) as _i5.Future<_i24.TimelineChunk?>);
+        returnValue: _i5.Future<_i25.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i25.TimelineChunk?>.value(),
+      ) as _i5.Future<_i25.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9535,7 +9571,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9552,7 +9588,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9616,14 +9652,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9639,14 +9675,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9702,7 +9738,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9710,7 +9746,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/new_room_dialog_test.mocks.dart
+++ b/test/widgets/new_room_dialog_test.mocks.dart
@@ -4,14 +4,15 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/models/join_mode.dart' as _i23;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/models/join_mode.dart' as _i24;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -26,14 +27,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i25;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i26;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i24;
+import 'package:matrix/src/utils/space_child.dart' as _i25;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -847,8 +848,9 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
-class _FakeStateEvent_75 extends _i1.SmartFake implements _i2.StateEvent {
-  _FakeStateEvent_75(
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -857,8 +859,8 @@ class _FakeStateEvent_75 extends _i1.SmartFake implements _i2.StateEvent {
         );
 }
 
-class _FakeRoomSummary_76 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_76(
+class _FakeStateEvent_76 extends _i1.SmartFake implements _i2.StateEvent {
+  _FakeStateEvent_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,9 +869,19 @@ class _FakeRoomSummary_76 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_77 extends _i1.SmartFake
+class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_77(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_78 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_77(
+  _FakeLatestReceiptState_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -878,8 +890,8 @@ class _FakeLatestReceiptState_77 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_78 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_78(
+class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -888,8 +900,8 @@ class _FakeTimeline_78 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_79 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_79(
+class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -916,12 +928,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1041,11 +1053,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1082,11 +1094,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1116,11 +1128,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1129,11 +1141,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1419,34 +1431,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1602,7 +1614,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1891,14 +1903,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2286,8 +2298,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2303,8 +2315,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2345,7 +2357,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2361,7 +2373,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2410,7 +2422,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2431,7 +2443,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2534,7 +2546,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2552,7 +2564,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3071,7 +3083,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3423,7 +3435,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3437,7 +3449,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3588,7 +3600,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4966,7 +4978,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4988,7 +5000,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5482,7 +5494,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5494,7 +5506,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6502,7 +6514,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6513,7 +6525,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6761,7 +6773,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6773,7 +6785,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7033,7 +7045,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7046,7 +7058,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7113,7 +7125,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7126,7 +7138,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7174,7 +7186,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7186,7 +7198,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7434,7 +7446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7445,7 +7457,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7707,7 +7719,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7734,7 +7746,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7764,11 +7776,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7893,6 +7905,19 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7990,6 +8015,15 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -8034,7 +8068,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8059,6 +8093,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8068,6 +8103,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8128,7 +8164,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8137,7 +8173,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8156,7 +8192,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8167,7 +8203,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8215,7 +8251,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8253,7 +8289,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8262,7 +8298,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8271,16 +8307,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8307,14 +8343,14 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 class MockSpaceAccessService extends _i1.Mock
     implements _i12.SpaceAccessService {
   @override
-  _i23.JoinMode getJoinMode(_i2.Room? room) => (super.noSuchMethod(
+  _i24.JoinMode getJoinMode(_i2.Room? room) => (super.noSuchMethod(
         Invocation.method(
           #getJoinMode,
           [room],
         ),
-        returnValue: _i23.JoinMode.invite,
-        returnValueForMissingStub: _i23.JoinMode.invite,
-      ) as _i23.JoinMode);
+        returnValue: _i24.JoinMode.invite,
+        returnValueForMissingStub: _i24.JoinMode.invite,
+      ) as _i24.JoinMode);
 
   @override
   List<String> allowedSpaceIds(_i2.Room? room) => (super.noSuchMethod(
@@ -8398,7 +8434,7 @@ class MockSpaceAccessService extends _i1.Mock
   @override
   _i5.Future<void> applyJoinMode({
     required String? roomId,
-    required _i23.JoinMode? mode,
+    required _i24.JoinMode? mode,
     List<String>? allowSpaceIds = const [],
   }) =>
       (super.noSuchMethod(
@@ -8417,7 +8453,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   Map<String, Object?> buildJoinRulesPayload(
-    _i23.JoinMode? mode,
+    _i24.JoinMode? mode,
     List<String>? allowSpaceIds, {
     List<Map<String, Object?>>? preserveEntries = const [],
   }) =>
@@ -8436,7 +8472,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   _i2.StateEvent buildJoinRulesStateEvent(
-    _i23.JoinMode? mode,
+    _i24.JoinMode? mode,
     List<String>? allowSpaceIds,
   ) =>
       (super.noSuchMethod(
@@ -8447,7 +8483,7 @@ class MockSpaceAccessService extends _i1.Mock
             allowSpaceIds,
           ],
         ),
-        returnValue: _FakeStateEvent_75(
+        returnValue: _FakeStateEvent_76(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -8457,7 +8493,7 @@ class MockSpaceAccessService extends _i1.Mock
             ],
           ),
         ),
-        returnValueForMissingStub: _FakeStateEvent_75(
+        returnValueForMissingStub: _FakeStateEvent_76(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -8482,7 +8518,7 @@ class MockSpaceAccessService extends _i1.Mock
             newVersion,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,
@@ -8493,7 +8529,7 @@ class MockSpaceAccessService extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,
@@ -8555,11 +8591,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8589,11 +8625,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_76(
+        returnValue: _FakeRoomSummary_77(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_76(
+        returnValueForMissingStub: _FakeRoomSummary_77(
           this,
           Invocation.getter(#summary),
         ),
@@ -8646,11 +8682,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8686,11 +8722,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8706,11 +8742,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8719,11 +8755,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8766,11 +8802,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8813,11 +8849,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_77(
+        returnValue: _FakeLatestReceiptState_78(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_77(
+        returnValueForMissingStub: _FakeLatestReceiptState_78(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -9036,18 +9072,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i25.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i24.SpaceParent>[],
-        returnValueForMissingStub: <_i24.SpaceParent>[],
-      ) as List<_i24.SpaceParent>);
+        returnValue: <_i25.SpaceParent>[],
+        returnValueForMissingStub: <_i25.SpaceParent>[],
+      ) as List<_i25.SpaceParent>);
 
   @override
-  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i25.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i24.SpaceChild>[],
-        returnValueForMissingStub: <_i24.SpaceChild>[],
-      ) as List<_i24.SpaceChild>);
+        returnValue: <_i25.SpaceChild>[],
+        returnValueForMissingStub: <_i25.SpaceChild>[],
+      ) as List<_i25.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9214,14 +9250,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9269,7 +9305,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9277,7 +9313,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9292,7 +9328,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9300,7 +9336,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9394,7 +9430,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9402,7 +9438,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9644,7 +9680,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9655,7 +9691,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9744,15 +9780,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i25.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i26.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i25.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i25.TimelineChunk?>.value(),
-      ) as _i5.Future<_i25.TimelineChunk?>);
+        returnValue: _i5.Future<_i26.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i26.TimelineChunk?>.value(),
+      ) as _i5.Future<_i26.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9793,7 +9829,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
           this,
           Invocation.method(
             #getTimeline,
@@ -9810,7 +9846,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
           this,
           Invocation.method(
             #getTimeline,
@@ -9874,14 +9910,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_79(
+        returnValue: _FakeUser_80(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_79(
+        returnValueForMissingStub: _FakeUser_80(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9897,14 +9933,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_79(
+        returnValue: _FakeUser_80(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_79(
+        returnValueForMissingStub: _FakeUser_80(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9960,7 +9996,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9968,7 +10004,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/recovery_key_handler_test.mocks.dart
+++ b/test/widgets/recovery_key_handler_test.mocks.dart
@@ -3,14 +3,15 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i15;
-import 'dart:typed_data' as _i25;
-import 'dart:ui' as _i22;
+import 'dart:async' as _i16;
+import 'dart:typed_data' as _i26;
+import 'dart:ui' as _i23;
 
-import 'package:flutter/services.dart' as _i23;
-import 'package:flutter/widgets.dart' as _i24;
-import 'package:http/http.dart' as _i14;
-import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:flutter/services.dart' as _i24;
+import 'package:flutter/widgets.dart' as _i25;
+import 'package:http/http.dart' as _i15;
+import 'package:kohera/core/services/matrix_service.dart' as _i21;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i12;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -25,15 +26,15 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:matrix/encryption.dart' as _i12;
-import 'package:matrix/encryption/cross_signing.dart' as _i19;
-import 'package:matrix/encryption/key_verification_manager.dart' as _i18;
-import 'package:matrix/encryption/olm_manager.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i13;
+import 'package:matrix/encryption/cross_signing.dart' as _i20;
+import 'package:matrix/encryption/key_verification_manager.dart' as _i19;
+import 'package:matrix/encryption/olm_manager.dart' as _i18;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i16;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i13;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i17;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i14;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i21;
+import 'package:mockito/src/dummies.dart' as _i22;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -155,8 +156,9 @@ class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
         );
 }
 
-class _FakeEncryption_10 extends _i1.SmartFake implements _i12.Encryption {
-  _FakeEncryption_10(
+class _FakeStickerPackService_10 extends _i1.SmartFake
+    implements _i12.StickerPackService {
+  _FakeStickerPackService_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -165,8 +167,8 @@ class _FakeEncryption_10 extends _i1.SmartFake implements _i12.Encryption {
         );
 }
 
-class _FakeSSSS_11 extends _i1.SmartFake implements _i12.SSSS {
-  _FakeSSSS_11(
+class _FakeEncryption_11 extends _i1.SmartFake implements _i13.Encryption {
+  _FakeEncryption_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -175,9 +177,19 @@ class _FakeSSSS_11 extends _i1.SmartFake implements _i12.SSSS {
         );
 }
 
-class _FakeSecretStorageKeyContent_12 extends _i1.SmartFake
+class _FakeSSSS_12 extends _i1.SmartFake implements _i13.SSSS {
+  _FakeSSSS_12(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeSecretStorageKeyContent_13 extends _i1.SmartFake
     implements _i4.SecretStorageKeyContent {
-  _FakeSecretStorageKeyContent_12(
+  _FakeSecretStorageKeyContent_13(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -186,8 +198,8 @@ class _FakeSecretStorageKeyContent_12 extends _i1.SmartFake
         );
 }
 
-class _FakeDatabaseApi_13 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_13(
+class _FakeDatabaseApi_14 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -196,8 +208,8 @@ class _FakeDatabaseApi_13 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_14 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_14(
+class _FakeFilter_15 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -206,9 +218,9 @@ class _FakeFilter_14 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_15 extends _i1.SmartFake
+class _FakeNativeImplementations_16 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_15(
+  _FakeNativeImplementations_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -217,8 +229,8 @@ class _FakeNativeImplementations_15 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_16 extends _i1.SmartFake implements Duration {
-  _FakeDuration_16(
+class _FakeDuration_17 extends _i1.SmartFake implements Duration {
+  _FakeDuration_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -227,9 +239,9 @@ class _FakeDuration_16 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_17 extends _i1.SmartFake
+class _FakePushruleEvaluator_18 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_17(
+  _FakePushruleEvaluator_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -238,8 +250,8 @@ class _FakePushruleEvaluator_17 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_18 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_18(
+class _FakeProfile_19 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -248,9 +260,9 @@ class _FakeProfile_18 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeCachedStreamController_19<T> extends _i1.SmartFake
-    implements _i13.CachedStreamController<T> {
-  _FakeCachedStreamController_19(
+class _FakeCachedStreamController_20<T> extends _i1.SmartFake
+    implements _i14.CachedStreamController<T> {
+  _FakeCachedStreamController_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -259,8 +271,8 @@ class _FakeCachedStreamController_19<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_20 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_20(
+class _FakeDateTime_21 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -269,8 +281,8 @@ class _FakeDateTime_20 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeClient_21 extends _i1.SmartFake implements _i14.Client {
-  _FakeClient_21(
+class _FakeClient_22 extends _i1.SmartFake implements _i15.Client {
+  _FakeClient_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -279,9 +291,9 @@ class _FakeClient_21 extends _i1.SmartFake implements _i14.Client {
         );
 }
 
-class _FakeDiscoveryInformation_22 extends _i1.SmartFake
+class _FakeDiscoveryInformation_23 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_22(
+  _FakeDiscoveryInformation_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -290,9 +302,9 @@ class _FakeDiscoveryInformation_22 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_23 extends _i1.SmartFake
+class _FakeGetVersionsResponse_24 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_23(
+  _FakeGetVersionsResponse_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -301,9 +313,9 @@ class _FakeGetVersionsResponse_23 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_24 extends _i1.SmartFake
+class _FakeRegisterResponse_25 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_24(
+  _FakeRegisterResponse_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -312,8 +324,8 @@ class _FakeRegisterResponse_24 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_25 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_25(
+class _FakeLoginResponse_26 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -322,9 +334,9 @@ class _FakeLoginResponse_25 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_26 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_27 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_26(
+  _FakeGetAuthMetadataResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -333,8 +345,8 @@ class _FakeGetAuthMetadataResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_27<T1> extends _i1.SmartFake implements _i15.Future<T1> {
-  _FakeFuture_27(
+class _FakeFuture_28<T1> extends _i1.SmartFake implements _i16.Future<T1> {
+  _FakeFuture_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -343,8 +355,8 @@ class _FakeFuture_27<T1> extends _i1.SmartFake implements _i15.Future<T1> {
         );
 }
 
-class _FakeSyncUpdate_28 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_28(
+class _FakeSyncUpdate_29 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -353,9 +365,9 @@ class _FakeSyncUpdate_28 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeCachedProfileInformation_29 extends _i1.SmartFake
+class _FakeCachedProfileInformation_30 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_29(
+  _FakeCachedProfileInformation_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -364,8 +376,8 @@ class _FakeCachedProfileInformation_29 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_30(
+class _FakeMediaConfig_31 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -374,8 +386,8 @@ class _FakeMediaConfig_30 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_31 extends _i1.SmartFake implements _i16.FileResponse {
-  _FakeFileResponse_31(
+class _FakeFileResponse_32 extends _i1.SmartFake implements _i17.FileResponse {
+  _FakeFileResponse_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -384,8 +396,8 @@ class _FakeFileResponse_31 extends _i1.SmartFake implements _i16.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_32(
+class _FakePreviewForUrl_33 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -394,8 +406,8 @@ class _FakePreviewForUrl_32 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeUri_33 extends _i1.SmartFake implements Uri {
-  _FakeUri_33(
+class _FakeUri_34 extends _i1.SmartFake implements Uri {
+  _FakeUri_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -404,9 +416,9 @@ class _FakeUri_33 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeCachedPresence_34 extends _i1.SmartFake
+class _FakeCachedPresence_35 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_34(
+  _FakeCachedPresence_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -415,9 +427,9 @@ class _FakeCachedPresence_34 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_35 extends _i1.SmartFake
+class _FakeTurnServerCredentials_36 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_35(
+  _FakeTurnServerCredentials_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -426,9 +438,9 @@ class _FakeTurnServerCredentials_35 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_37 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_36(
+  _FakeRoomKeysUpdateResponse_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -437,8 +449,8 @@ class _FakeRoomKeysUpdateResponse_36 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_37(
+class _FakeKeyBackupData_38 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -447,9 +459,9 @@ class _FakeKeyBackupData_37 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_39 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_38(
+  _FakeGetWellknownSupportResponse_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -458,9 +470,9 @@ class _FakeGetWellknownSupportResponse_38 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_40 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_39(
+  _FakeGenerateLoginTokenResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -469,9 +481,9 @@ class _FakeGenerateLoginTokenResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_41 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_40(
+  _FakeGetRoomSummaryResponse$3_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -480,9 +492,9 @@ class _FakeGetRoomSummaryResponse$3_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_42 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_41(
+  _FakeGetSpaceHierarchyResponse_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -491,9 +503,9 @@ class _FakeGetSpaceHierarchyResponse_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_43 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_42(
+  _FakeGetRelatingEventsResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -502,9 +514,9 @@ class _FakeGetRelatingEventsResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_44 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_43(
+  _FakeGetRelatingEventsWithRelTypeResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -513,9 +525,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -524,9 +536,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_46 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_45(
+  _FakeGetThreadRootsResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -535,9 +547,9 @@ class _FakeGetThreadRootsResponse_45 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_47 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_46(
+  _FakeGetEventByTimestampResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -546,9 +558,9 @@ class _FakeGetEventByTimestampResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_47 extends _i1.SmartFake
+class _FakeRequestTokenResponse_48 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_47(
+  _FakeRequestTokenResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -557,9 +569,9 @@ class _FakeRequestTokenResponse_47 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_49 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_48(
+  _FakeTokenOwnerInfo_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -568,8 +580,8 @@ class _FakeTokenOwnerInfo_48 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_49(
+class _FakeWhoIsInfo_50 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -578,8 +590,8 @@ class _FakeWhoIsInfo_49 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_50(
+class _FakeCapabilities_51 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -588,8 +600,8 @@ class _FakeCapabilities_50 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_51(
+class _FakeDevice_52 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -598,9 +610,9 @@ class _FakeDevice_51 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_53 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_52(
+  _FakeGetRoomIdByAliasResponse_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -609,9 +621,9 @@ class _FakeGetRoomIdByAliasResponse_52 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_53 extends _i1.SmartFake
+class _FakeGetEventsResponse_54 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_53(
+  _FakeGetEventsResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -620,9 +632,9 @@ class _FakeGetEventsResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_54 extends _i1.SmartFake
+class _FakePeekEventsResponse_55 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_54(
+  _FakePeekEventsResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -631,8 +643,8 @@ class _FakePeekEventsResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_55(
+class _FakeMatrixEvent_56 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -641,9 +653,9 @@ class _FakeMatrixEvent_55 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_57 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_56(
+  _FakeGetKeysChangesResponse_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -652,9 +664,9 @@ class _FakeGetKeysChangesResponse_56 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_57 extends _i1.SmartFake
+class _FakeClaimKeysResponse_58 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_57(
+  _FakeClaimKeysResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -663,9 +675,9 @@ class _FakeClaimKeysResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_58 extends _i1.SmartFake
+class _FakeQueryKeysResponse_59 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_58(
+  _FakeQueryKeysResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -674,9 +686,9 @@ class _FakeQueryKeysResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_60 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_59(
+  _FakeGetNotificationsResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -685,9 +697,9 @@ class _FakeGetNotificationsResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_60 extends _i1.SmartFake
+class _FakeGetPresenceResponse_61 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_60(
+  _FakeGetPresenceResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -696,9 +708,9 @@ class _FakeGetPresenceResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_62 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_61(
+  _FakeGetPublicRoomsResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -707,9 +719,9 @@ class _FakeGetPublicRoomsResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_63 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_62(
+  _FakeQueryPublicRoomsResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -718,8 +730,8 @@ class _FakeQueryPublicRoomsResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_63(
+class _FakePushRuleSet_64 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -728,9 +740,9 @@ class _FakePushRuleSet_63 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_65 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_64(
+  _FakeGetPushRulesGlobalResponse_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -739,8 +751,8 @@ class _FakeGetPushRulesGlobalResponse_64 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_65(
+class _FakePushRule_66 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -749,9 +761,9 @@ class _FakePushRule_65 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_66 extends _i1.SmartFake
+class _FakeRefreshResponse_67 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_66(
+  _FakeRefreshResponse_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -760,8 +772,8 @@ class _FakeRefreshResponse_66 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_67(
+class _FakeRoomKeys_68 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -770,8 +782,8 @@ class _FakeRoomKeys_67 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_68(
+class _FakeRoomKeyBackup_69 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -780,9 +792,9 @@ class _FakeRoomKeyBackup_68 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_70 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_69(
+  _FakeGetRoomKeysVersionCurrentResponse_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -791,9 +803,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_69 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_71 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_70(
+  _FakeGetRoomKeysVersionResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -802,8 +814,8 @@ class _FakeGetRoomKeysVersionResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_71(
+class _FakeEventContext_72 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -812,9 +824,9 @@ class _FakeEventContext_71 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_73 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_72(
+  _FakeGetRoomEventsResponse_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -823,8 +835,8 @@ class _FakeGetRoomEventsResponse_72 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_73(
+class _FakeSearchResults_74 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -833,9 +845,9 @@ class _FakeSearchResults_73 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_75 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_74(
+  _FakeGetProtocolMetadataResponse$2_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -844,9 +856,9 @@ class _FakeGetProtocolMetadataResponse$2_74 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_75 extends _i1.SmartFake
+class _FakeOpenIdCredentials_76 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_75(
+  _FakeOpenIdCredentials_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -855,9 +867,9 @@ class _FakeOpenIdCredentials_75 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_77 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_76(
+  _FakeSearchUserDirectoryResponse_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -866,9 +878,9 @@ class _FakeSearchUserDirectoryResponse_76 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_77 extends _i1.SmartFake
+class _FakeCreateContentResponse_78 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_77(
+  _FakeCreateContentResponse_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -877,8 +889,8 @@ class _FakeCreateContentResponse_77 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyManager_78 extends _i1.SmartFake implements _i12.KeyManager {
-  _FakeKeyManager_78(
+class _FakeKeyManager_79 extends _i1.SmartFake implements _i13.KeyManager {
+  _FakeKeyManager_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -887,8 +899,8 @@ class _FakeKeyManager_78 extends _i1.SmartFake implements _i12.KeyManager {
         );
 }
 
-class _FakeOlmManager_79 extends _i1.SmartFake implements _i17.OlmManager {
-  _FakeOlmManager_79(
+class _FakeOlmManager_80 extends _i1.SmartFake implements _i18.OlmManager {
+  _FakeOlmManager_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -897,9 +909,9 @@ class _FakeOlmManager_79 extends _i1.SmartFake implements _i17.OlmManager {
         );
 }
 
-class _FakeKeyVerificationManager_80 extends _i1.SmartFake
-    implements _i18.KeyVerificationManager {
-  _FakeKeyVerificationManager_80(
+class _FakeKeyVerificationManager_81 extends _i1.SmartFake
+    implements _i19.KeyVerificationManager {
+  _FakeKeyVerificationManager_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -908,8 +920,8 @@ class _FakeKeyVerificationManager_80 extends _i1.SmartFake
         );
 }
 
-class _FakeCrossSigning_81 extends _i1.SmartFake implements _i19.CrossSigning {
-  _FakeCrossSigning_81(
+class _FakeCrossSigning_82 extends _i1.SmartFake implements _i20.CrossSigning {
+  _FakeCrossSigning_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -918,8 +930,8 @@ class _FakeCrossSigning_81 extends _i1.SmartFake implements _i19.CrossSigning {
         );
 }
 
-class _FakeBootstrap_82 extends _i1.SmartFake implements _i12.Bootstrap {
-  _FakeBootstrap_82(
+class _FakeBootstrap_83 extends _i1.SmartFake implements _i13.Bootstrap {
+  _FakeBootstrap_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -928,8 +940,8 @@ class _FakeBootstrap_82 extends _i1.SmartFake implements _i12.Bootstrap {
         );
 }
 
-class _FakeToDeviceEvent_83 extends _i1.SmartFake implements _i4.ToDeviceEvent {
-  _FakeToDeviceEvent_83(
+class _FakeToDeviceEvent_84 extends _i1.SmartFake implements _i4.ToDeviceEvent {
+  _FakeToDeviceEvent_84(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -938,8 +950,8 @@ class _FakeToDeviceEvent_83 extends _i1.SmartFake implements _i4.ToDeviceEvent {
         );
 }
 
-class _FakeEvent_84 extends _i1.SmartFake implements _i4.Event {
-  _FakeEvent_84(
+class _FakeEvent_85 extends _i1.SmartFake implements _i4.Event {
+  _FakeEvent_85(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -951,7 +963,7 @@ class _FakeEvent_84 extends _i1.SmartFake implements _i4.Event {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -981,11 +993,11 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1110,6 +1122,19 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i11.OutboxService);
 
   @override
+  _i12.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i12.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -1207,6 +1232,15 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
+  set stickerPacks(_i12.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -1214,14 +1248,14 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as bool);
 
   @override
-  _i15.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i16.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1251,7 +1285,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i23.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1261,21 +1295,22 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  _i15.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i16.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<bool> login({
+  _i16.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1285,14 +1320,15 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<bool> completeSsoLogin({
+  _i16.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1305,12 +1341,12 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<void> completeRegistration(
+  _i16.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1320,32 +1356,32 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> logout() => (super.noSuchMethod(
+  _i16.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i16.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1354,7 +1390,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1363,17 +1399,17 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  _i15.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i16.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i24.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1384,7 +1420,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i24.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1421,26 +1457,26 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  _i15.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i16.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<bool> didPushRouteInformation(
-          _i24.RouteInformation? routeInformation) =>
+  _i16.Future<bool> didPushRouteInformation(
+          _i25.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1470,7 +1506,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i23.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1479,7 +1515,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i23.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1488,16 +1524,16 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  _i15.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i16.Future<_i23.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i15.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+            _i16.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i15.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
-      ) as _i15.Future<_i22.AppExitResponse>);
+            _i16.Future<_i23.AppExitResponse>.value(_i23.AppExitResponse.exit),
+      ) as _i16.Future<_i23.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1544,24 +1580,24 @@ class MockChatBackupService extends _i1.Mock implements _i6.ChatBackupService {
       ) as bool);
 
   @override
-  _i15.Future<void> checkChatBackupStatus() => (super.noSuchMethod(
+  _i16.Future<void> checkChatBackupStatus() => (super.noSuchMethod(
         Invocation.method(
           #checkChatBackupStatus,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> disableChatBackup() => (super.noSuchMethod(
+  _i16.Future<void> disableChatBackup() => (super.noSuchMethod(
         Invocation.method(
           #disableChatBackup,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
   void resetChatBackupState() => super.noSuchMethod(
@@ -1573,71 +1609,71 @@ class MockChatBackupService extends _i1.Mock implements _i6.ChatBackupService {
       );
 
   @override
-  _i15.Future<void> tryAutoUnlockBackup() => (super.noSuchMethod(
+  _i16.Future<void> tryAutoUnlockBackup() => (super.noSuchMethod(
         Invocation.method(
           #tryAutoUnlockBackup,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> runKeyRecovery({_i12.OpenSSSS? ssssKey}) =>
+  _i16.Future<void> runKeyRecovery({_i13.OpenSSSS? ssssKey}) =>
       (super.noSuchMethod(
         Invocation.method(
           #runKeyRecovery,
           [],
           {#ssssKey: ssssKey},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> requestMissingRoomKeys({bool? force = false}) =>
+  _i16.Future<void> requestMissingRoomKeys({bool? force = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #requestMissingRoomKeys,
           [],
           {#force: force},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<String?> getStoredRecoveryKey() => (super.noSuchMethod(
+  _i16.Future<String?> getStoredRecoveryKey() => (super.noSuchMethod(
         Invocation.method(
           #getStoredRecoveryKey,
           [],
         ),
-        returnValue: _i15.Future<String?>.value(),
-        returnValueForMissingStub: _i15.Future<String?>.value(),
-      ) as _i15.Future<String?>);
+        returnValue: _i16.Future<String?>.value(),
+        returnValueForMissingStub: _i16.Future<String?>.value(),
+      ) as _i16.Future<String?>);
 
   @override
-  _i15.Future<void> storeRecoveryKey(String? key) => (super.noSuchMethod(
+  _i16.Future<void> storeRecoveryKey(String? key) => (super.noSuchMethod(
         Invocation.method(
           #storeRecoveryKey,
           [key],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> deleteStoredRecoveryKey() => (super.noSuchMethod(
+  _i16.Future<void> deleteStoredRecoveryKey() => (super.noSuchMethod(
         Invocation.method(
           #deleteStoredRecoveryKey,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1646,7 +1682,7 @@ class MockChatBackupService extends _i1.Mock implements _i6.ChatBackupService {
       );
 
   @override
-  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i23.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1676,19 +1712,19 @@ class MockChatBackupService extends _i1.Mock implements _i6.ChatBackupService {
 /// A class which mocks [Bootstrap].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBootstrap extends _i1.Mock implements _i12.Bootstrap {
+class MockBootstrap extends _i1.Mock implements _i13.Bootstrap {
   @override
-  _i12.Encryption get encryption => (super.noSuchMethod(
+  _i13.Encryption get encryption => (super.noSuchMethod(
         Invocation.getter(#encryption),
-        returnValue: _FakeEncryption_10(
+        returnValue: _FakeEncryption_11(
           this,
           Invocation.getter(#encryption),
         ),
-        returnValueForMissingStub: _FakeEncryption_10(
+        returnValueForMissingStub: _FakeEncryption_11(
           this,
           Invocation.getter(#encryption),
         ),
-      ) as _i12.Encryption);
+      ) as _i13.Encryption);
 
   @override
   _i4.Client get client => (super.noSuchMethod(
@@ -1704,14 +1740,14 @@ class MockBootstrap extends _i1.Mock implements _i12.Bootstrap {
       ) as _i4.Client);
 
   @override
-  _i12.BootstrapState get state => (super.noSuchMethod(
+  _i13.BootstrapState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i12.BootstrapState.loading,
-        returnValueForMissingStub: _i12.BootstrapState.loading,
-      ) as _i12.BootstrapState);
+        returnValue: _i13.BootstrapState.loading,
+        returnValueForMissingStub: _i13.BootstrapState.loading,
+      ) as _i13.BootstrapState);
 
   @override
-  set onUpdate(void Function(_i12.Bootstrap)? value) => super.noSuchMethod(
+  set onUpdate(void Function(_i13.Bootstrap)? value) => super.noSuchMethod(
         Invocation.setter(
           #onUpdate,
           value,
@@ -1720,7 +1756,7 @@ class MockBootstrap extends _i1.Mock implements _i12.Bootstrap {
       );
 
   @override
-  set oldSsssKeys(Map<String, _i12.OpenSSSS>? value) => super.noSuchMethod(
+  set oldSsssKeys(Map<String, _i13.OpenSSSS>? value) => super.noSuchMethod(
         Invocation.setter(
           #oldSsssKeys,
           value,
@@ -1729,7 +1765,7 @@ class MockBootstrap extends _i1.Mock implements _i12.Bootstrap {
       );
 
   @override
-  set newSsssKey(_i12.OpenSSSS? value) => super.noSuchMethod(
+  set newSsssKey(_i13.OpenSSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #newSsssKey,
           value,
@@ -1747,7 +1783,7 @@ class MockBootstrap extends _i1.Mock implements _i12.Bootstrap {
       );
 
   @override
-  set state(_i12.BootstrapState? newState) => super.noSuchMethod(
+  set state(_i13.BootstrapState? newState) => super.noSuchMethod(
         Invocation.setter(
           #state,
           newState,
@@ -1781,14 +1817,14 @@ class MockBootstrap extends _i1.Mock implements _i12.Bootstrap {
           #mostUsedKey,
           [secrets],
         ),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
             [secrets],
           ),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.method(
             #mostUsedKey,
@@ -1858,7 +1894,7 @@ class MockBootstrap extends _i1.Mock implements _i12.Bootstrap {
       );
 
   @override
-  _i15.Future<void> newSsss([
+  _i16.Future<void> newSsss([
     String? passphrase,
     String? name,
   ]) =>
@@ -1870,19 +1906,19 @@ class MockBootstrap extends _i1.Mock implements _i12.Bootstrap {
             name,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> openExistingSsss() => (super.noSuchMethod(
+  _i16.Future<void> openExistingSsss() => (super.noSuchMethod(
         Invocation.method(
           #openExistingSsss,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
   void checkCrossSigning() => super.noSuchMethod(
@@ -1894,17 +1930,17 @@ class MockBootstrap extends _i1.Mock implements _i12.Bootstrap {
       );
 
   @override
-  _i15.Future<void> wipeCrossSigning(bool? wipe) => (super.noSuchMethod(
+  _i16.Future<void> wipeCrossSigning(bool? wipe) => (super.noSuchMethod(
         Invocation.method(
           #wipeCrossSigning,
           [wipe],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> askSetupCrossSigning({
+  _i16.Future<void> askSetupCrossSigning({
     bool? setupMasterKey = false,
     bool? setupSelfSigningKey = false,
     bool? setupUserSigningKey = false,
@@ -1919,9 +1955,9 @@ class MockBootstrap extends _i1.Mock implements _i12.Bootstrap {
             #setupUserSigningKey: setupUserSigningKey,
           },
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
   void checkOnlineKeyBackup() => super.noSuchMethod(
@@ -1942,41 +1978,41 @@ class MockBootstrap extends _i1.Mock implements _i12.Bootstrap {
       );
 
   @override
-  _i15.Future<void> askSetupOnlineKeyBackup(bool? setup) => (super.noSuchMethod(
+  _i16.Future<void> askSetupOnlineKeyBackup(bool? setup) => (super.noSuchMethod(
         Invocation.method(
           #askSetupOnlineKeyBackup,
           [setup],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 }
 
 /// A class which mocks [OpenSSSS].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockOpenSSSS extends _i1.Mock implements _i12.OpenSSSS {
+class MockOpenSSSS extends _i1.Mock implements _i13.OpenSSSS {
   @override
-  _i12.SSSS get ssss => (super.noSuchMethod(
+  _i13.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_11(
+        returnValue: _FakeSSSS_12(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_11(
+        returnValueForMissingStub: _FakeSSSS_12(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i12.SSSS);
+      ) as _i13.SSSS);
 
   @override
   String get keyId => (super.noSuchMethod(
         Invocation.getter(#keyId),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#keyId),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#keyId),
         ),
@@ -1985,11 +2021,11 @@ class MockOpenSSSS extends _i1.Mock implements _i12.OpenSSSS {
   @override
   _i4.SecretStorageKeyContent get keyData => (super.noSuchMethod(
         Invocation.getter(#keyData),
-        returnValue: _FakeSecretStorageKeyContent_12(
+        returnValue: _FakeSecretStorageKeyContent_13(
           this,
           Invocation.getter(#keyData),
         ),
-        returnValueForMissingStub: _FakeSecretStorageKeyContent_12(
+        returnValueForMissingStub: _FakeSecretStorageKeyContent_13(
           this,
           Invocation.getter(#keyData),
         ),
@@ -2010,7 +2046,7 @@ class MockOpenSSSS extends _i1.Mock implements _i12.OpenSSSS {
       ) as bool);
 
   @override
-  set privateKey(_i25.Uint8List? value) => super.noSuchMethod(
+  set privateKey(_i26.Uint8List? value) => super.noSuchMethod(
         Invocation.setter(
           #privateKey,
           value,
@@ -2019,7 +2055,7 @@ class MockOpenSSSS extends _i1.Mock implements _i12.OpenSSSS {
       );
 
   @override
-  _i15.Future<void> unlock({
+  _i16.Future<void> unlock({
     String? passphrase,
     String? recoveryKey,
     String? keyOrPassphrase,
@@ -2036,27 +2072,27 @@ class MockOpenSSSS extends _i1.Mock implements _i12.OpenSSSS {
             #postUnlock: postUnlock,
           },
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> setPrivateKey(_i25.Uint8List? key) => (super.noSuchMethod(
+  _i16.Future<void> setPrivateKey(_i26.Uint8List? key) => (super.noSuchMethod(
         Invocation.method(
           #setPrivateKey,
           [key],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<String> getStored(String? type) => (super.noSuchMethod(
+  _i16.Future<String> getStored(String? type) => (super.noSuchMethod(
         Invocation.method(
           #getStored,
           [type],
         ),
-        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #getStored,
@@ -2064,17 +2100,17 @@ class MockOpenSSSS extends _i1.Mock implements _i12.OpenSSSS {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i21.dummyValue<String>(
+            _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #getStored,
             [type],
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<void> store(
+  _i16.Future<void> store(
     String? type,
     String? secret, {
     bool? add = false,
@@ -2088,12 +2124,12 @@ class MockOpenSSSS extends _i1.Mock implements _i12.OpenSSSS {
           ],
           {#add: add},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> validateAndStripOtherKeys(
+  _i16.Future<void> validateAndStripOtherKeys(
     String? type,
     String? secret,
   ) =>
@@ -2105,19 +2141,19 @@ class MockOpenSSSS extends _i1.Mock implements _i12.OpenSSSS {
             secret,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> maybeCacheAll() => (super.noSuchMethod(
+  _i16.Future<void> maybeCacheAll() => (super.noSuchMethod(
         Invocation.method(
           #maybeCacheAll,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 }
 
 /// A class which mocks [Client].
@@ -2127,23 +2163,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_13(
+        returnValue: _FakeDatabaseApi_14(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_13(
+        returnValueForMissingStub: _FakeDatabaseApi_14(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i12.KeyVerificationMethod> get verificationMethods =>
+  Set<_i13.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i12.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i12.KeyVerificationMethod>{},
-      ) as Set<_i12.KeyVerificationMethod>);
+        returnValue: <_i13.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i13.KeyVerificationMethod>{},
+      ) as Set<_i13.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -2204,11 +2240,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_14(
+        returnValue: _FakeFilter_15(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_14(
+        returnValueForMissingStub: _FakeFilter_15(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -2217,11 +2253,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_15(
+        returnValue: _FakeNativeImplementations_16(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_15(
+        returnValueForMissingStub: _FakeNativeImplementations_16(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -2237,11 +2273,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_16(
+        returnValue: _FakeDuration_17(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_16(
+        returnValueForMissingStub: _FakeDuration_17(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -2250,11 +2286,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_16(
+        returnValue: _FakeDuration_17(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_16(
+        returnValueForMissingStub: _FakeDuration_17(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -2263,11 +2299,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -2304,11 +2340,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -2338,11 +2374,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -2351,11 +2387,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -2378,11 +2414,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_17(
+        returnValue: _FakePushruleEvaluator_18(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_17(
+        returnValueForMissingStub: _FakePushruleEvaluator_18(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -2403,332 +2439,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i15.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i16.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_18(
+        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.Profile>.value(_FakeProfile_18(
+            _i16.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i15.Future<_i4.Profile>);
+      ) as _i16.Future<_i4.Profile>);
 
   @override
-  _i13.CachedStreamController<String> get onUserProfileUpdate =>
+  _i14.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_19<String>(
+        returnValue: _FakeCachedStreamController_20<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i13.CachedStreamController<String>);
+      ) as _i14.CachedStreamController<String>);
 
   @override
-  _i15.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i16.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i15.Future<List<_i4.Room>>);
+            _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i16.Future<List<_i4.Room>>);
 
   @override
-  _i13.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i14.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_19<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_20<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.EventUpdate>(
+            _FakeCachedStreamController_20<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i13.CachedStreamController<_i4.EventUpdate>);
+      ) as _i14.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i13.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i14.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_19<_i4.Event>(
+        returnValue: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i13.CachedStreamController<_i4.Event>);
+      ) as _i14.CachedStreamController<_i4.Event>);
 
   @override
-  _i13.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i14.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_19<_i4.Event>(
+        returnValue: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i13.CachedStreamController<_i4.Event>);
+      ) as _i14.CachedStreamController<_i4.Event>);
 
   @override
-  _i13.CachedStreamController<_i4.Event> get onNotification =>
+  _i14.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_19<_i4.Event>(
+        returnValue: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i13.CachedStreamController<_i4.Event>);
+      ) as _i14.CachedStreamController<_i4.Event>);
 
   @override
-  _i13.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i14.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_19<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_20<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_20<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i13.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i14.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i13.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i14.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_19<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_20<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_19<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_20<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i13.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i14.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i13.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i14.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_19<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_20<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.LoginState>(
+            _FakeCachedStreamController_20<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i13.CachedStreamController<_i4.LoginState>);
+      ) as _i14.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i13.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i14.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_19<bool>(
+        returnValue: _FakeCachedStreamController_20<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i13.CachedStreamController<bool>);
+      ) as _i14.CachedStreamController<bool>);
 
   @override
-  _i13.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i14.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_19<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_20<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i13.CachedStreamController<_i4.SdkError>);
+      ) as _i14.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i13.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i14.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_19<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_20<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.SyncUpdate>(
+            _FakeCachedStreamController_20<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i13.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i14.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i13.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i14.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_19<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_20<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_20<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i13.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i14.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i13.CachedStreamController<_i4.Presence> get onPresence =>
+  _i14.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_19<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_20<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i13.CachedStreamController<_i4.Presence>);
+      ) as _i14.CachedStreamController<_i4.Presence>);
 
   @override
-  _i13.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i14.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_19<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_20<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.CachedPresence>(
+            _FakeCachedStreamController_20<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i13.CachedStreamController<_i4.CachedPresence>);
+      ) as _i14.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i13.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i14.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_19<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_20<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.BasicEvent>(
+            _FakeCachedStreamController_20<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i13.CachedStreamController<_i4.BasicEvent>);
+      ) as _i14.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i13.CachedStreamController<_i12.RoomKeyRequest> get onRoomKeyRequest =>
+  _i14.CachedStreamController<_i13.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_19<_i12.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_20<_i13.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i12.RoomKeyRequest>(
+            _FakeCachedStreamController_20<_i13.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i13.CachedStreamController<_i12.RoomKeyRequest>);
+      ) as _i14.CachedStreamController<_i13.RoomKeyRequest>);
 
   @override
-  _i13.CachedStreamController<_i12.KeyVerification>
+  _i14.CachedStreamController<_i13.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_19<_i12.KeyVerification>(
+            returnValue: _FakeCachedStreamController_20<_i13.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_19<_i12.KeyVerification>(
+                _FakeCachedStreamController_20<_i13.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i13.CachedStreamController<_i12.KeyVerification>);
+          ) as _i14.CachedStreamController<_i13.KeyVerification>);
 
   @override
-  _i13.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i14.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_19<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_20<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_19<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_20<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i13.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i14.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i13.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i14.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_19<_i4.Event>(
+        returnValue: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i13.CachedStreamController<_i4.Event>);
+      ) as _i14.CachedStreamController<_i4.Event>);
 
   @override
-  _i13.CachedStreamController<String> get onCancelSendEvent =>
+  _i14.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_19<String>(
+        returnValue: _FakeCachedStreamController_20<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_19<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_20<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i13.CachedStreamController<String>);
+      ) as _i14.CachedStreamController<String>);
 
   @override
-  _i13.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i14.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_19<
+            returnValue: _FakeCachedStreamController_20<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_19<
+            returnValueForMissingStub: _FakeCachedStreamController_20<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i13.CachedStreamController<
+          ) as _i14.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -2748,11 +2784,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_20(
+        returnValue: _FakeDateTime_21(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_20(
+        returnValueForMissingStub: _FakeDateTime_21(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -2825,7 +2861,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i12.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i13.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -2880,7 +2916,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i15.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i16.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -2891,7 +2927,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i15.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i16.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -3002,7 +3038,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i16.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -3011,7 +3047,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i16.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -3020,7 +3056,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i15.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i16.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -3047,20 +3083,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Client get httpClient => (super.noSuchMethod(
+  _i15.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_21(
+        returnValue: _FakeClient_22(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_21(
+        returnValueForMissingStub: _FakeClient_22(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i14.Client);
+      ) as _i15.Client);
 
   @override
-  set httpClient(_i14.Client? value) => super.noSuchMethod(
+  set httpClient(_i15.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -3087,7 +3123,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i15.Future<void> refreshAccessToken(
+  _i16.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3095,9 +3131,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -3115,14 +3151,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -3159,33 +3195,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i15.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i16.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValue: _i16.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValueForMissingStub: _i16.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i15.Future<_i4.DiscoveryInformation>);
+      ) as _i16.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i15.Future<
+  _i16.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -3207,7 +3243,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i15.Future<
+        returnValue: _i16.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -3215,7 +3251,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_23(
+          _FakeGetVersionsResponse_24(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -3230,7 +3266,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i15.Future<
+        returnValueForMissingStub: _i16.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -3238,7 +3274,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_23(
+          _FakeGetVersionsResponse_24(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -3253,7 +3289,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i15.Future<
+      ) as _i16.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -3262,7 +3298,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i15.Future<_i4.DiscoveryInformation> getWellknown({
+  _i16.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3275,8 +3311,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValue: _i16.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getWellknown,
@@ -3287,8 +3323,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_22(
+        returnValueForMissingStub: _i16.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_23(
           this,
           Invocation.method(
             #getWellknown,
@@ -3299,10 +3335,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.DiscoveryInformation>);
+      ) as _i16.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i15.Future<_i4.RegisterResponse> register({
+  _i16.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -3330,7 +3366,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_24(
+            _i16.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
           this,
           Invocation.method(
             #register,
@@ -3349,7 +3385,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_24(
+            _i16.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_25(
           this,
           Invocation.method(
             #register,
@@ -3367,10 +3403,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.RegisterResponse>);
+      ) as _i16.Future<_i4.RegisterResponse>);
 
   @override
-  _i15.Future<_i4.LoginResponse> login(
+  _i16.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -3400,7 +3436,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_25(
+        returnValue: _i16.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
           this,
           Invocation.method(
             #login,
@@ -3420,7 +3456,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_25(
+            _i16.Future<_i4.LoginResponse>.value(_FakeLoginResponse_26(
           this,
           Invocation.method(
             #login,
@@ -3439,10 +3475,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.LoginResponse>);
+      ) as _i16.Future<_i4.LoginResponse>);
 
   @override
-  _i15.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i16.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -3455,8 +3491,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i15.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_26(
+        returnValue: _i16.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_27(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -3468,8 +3504,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_26(
+            _i16.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_27(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -3480,74 +3516,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i16.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i15.Future<void> logout() => (super.noSuchMethod(
+  _i16.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> logoutAll() => (super.noSuchMethod(
+  _i16.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<T> uiaRequestBackground<T>(
-          _i15.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i16.Future<T> uiaRequestBackground<T>(
+          _i16.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i21.ifNotNull(
-              _i21.dummyValueOrNull<T>(
+        returnValue: _i22.ifNotNull(
+              _i22.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i15.Future<T>.value(v),
+              (T v) => _i16.Future<T>.value(v),
             ) ??
-            _FakeFuture_27<T>(
+            _FakeFuture_28<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i21.ifNotNull(
-              _i21.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i22.ifNotNull(
+              _i22.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i15.Future<T>.value(v),
+              (T v) => _i16.Future<T>.value(v),
             ) ??
-            _FakeFuture_27<T>(
+            _FakeFuture_28<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i15.Future<T>);
+      ) as _i16.Future<T>);
 
   @override
-  _i15.Future<String> startDirectChat(
+  _i16.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -3569,7 +3605,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3585,7 +3621,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i21.dummyValue<String>(
+            _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -3600,10 +3636,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<String> createGroupChat({
+  _i16.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -3634,7 +3670,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3655,7 +3691,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i21.dummyValue<String>(
+            _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -3675,10 +3711,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i16.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -3694,7 +3730,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
+        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_29(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3707,7 +3743,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
+            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_29(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -3719,21 +3755,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.SyncUpdate>);
+      ) as _i16.Future<_i4.SyncUpdate>);
 
   @override
-  _i15.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i16.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<String> createSpace({
+  _i16.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -3758,7 +3794,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3776,7 +3812,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i21.dummyValue<String>(
+            _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3793,10 +3829,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i16.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -3804,7 +3840,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_18(
+        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3813,7 +3849,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.Profile>.value(_FakeProfile_18(
+            _i16.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -3821,10 +3857,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i15.Future<_i4.Profile>);
+      ) as _i16.Future<_i4.Profile>);
 
   @override
-  _i15.Future<_i4.Profile> fetchOwnProfile({
+  _i16.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -3837,7 +3873,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_18(
+        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3849,7 +3885,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.Profile>.value(_FakeProfile_18(
+            _i16.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -3860,10 +3896,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.Profile>);
+      ) as _i16.Future<_i4.Profile>);
 
   @override
-  _i15.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i16.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -3877,8 +3913,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i15.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_29(
+        returnValue: _i16.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_30(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3890,8 +3926,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_29(
+            _i16.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_30(
           this,
           Invocation.method(
             #getUserProfile,
@@ -3902,10 +3938,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.CachedProfileInformation>);
+      ) as _i16.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i15.Future<_i4.Profile> getProfileFromUserId(
+  _i16.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -3923,7 +3959,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_18(
+        returnValue: _i16.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3937,7 +3973,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.Profile>.value(_FakeProfile_18(
+            _i16.Future<_i4.Profile>.value(_FakeProfile_19(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -3950,7 +3986,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.Profile>);
+      ) as _i16.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -3972,31 +4008,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i15.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i16.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i15.Future<List<_i4.Room>>);
+            _i16.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i16.Future<List<_i4.Room>>);
 
   @override
-  _i15.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i16.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i16.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i15.Future<List<_i4.ArchivedRoom>>);
+            _i16.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i16.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i15.Future<_i4.GetVersionsResponse> getVersions({
+  _i16.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4009,8 +4045,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i15.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_23(
+        returnValue: _i16.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_24(
           this,
           Invocation.method(
             #getVersions,
@@ -4021,8 +4057,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_23(
+        returnValueForMissingStub: _i16.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_24(
           this,
           Invocation.method(
             #getVersions,
@@ -4033,20 +4069,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.GetVersionsResponse>);
+      ) as _i16.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i15.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i16.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<_i4.MediaConfig> getConfig({
+  _i16.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4059,7 +4095,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+        returnValue: _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfig,
@@ -4071,7 +4107,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+            _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfig,
@@ -4082,10 +4118,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.MediaConfig>);
+      ) as _i16.Future<_i4.MediaConfig>);
 
   @override
-  _i15.Future<_i16.FileResponse> getContent(
+  _i16.Future<_i17.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -4105,7 +4141,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContent,
@@ -4121,7 +4157,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
+            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContent,
@@ -4136,10 +4172,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i16.FileResponse>);
+      ) as _i16.Future<_i17.FileResponse>);
 
   @override
-  _i15.Future<_i16.FileResponse> getContentOverrideName(
+  _i16.Future<_i17.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -4161,7 +4197,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -4178,7 +4214,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
+            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -4194,10 +4230,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i16.FileResponse>);
+      ) as _i16.Future<_i17.FileResponse>);
 
   @override
-  _i15.Future<_i16.FileResponse> getContentThumbnail(
+  _i16.Future<_i17.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -4225,7 +4261,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -4245,7 +4281,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
+            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -4264,10 +4300,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i16.FileResponse>);
+      ) as _i16.Future<_i17.FileResponse>);
 
   @override
-  _i15.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i16.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -4277,7 +4313,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+        returnValue: _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -4286,7 +4322,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+            _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -4294,11 +4330,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i15.Future<_i4.PreviewForUrl>);
+      ) as _i16.Future<_i4.PreviewForUrl>);
 
   @override
-  _i15.Future<Uri> uploadContent(
-    _i25.Uint8List? file, {
+  _i16.Future<Uri> uploadContent(
+    _i26.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -4311,7 +4347,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i15.Future<Uri>.value(_FakeUri_33(
+        returnValue: _i16.Future<Uri>.value(_FakeUri_34(
           this,
           Invocation.method(
             #uploadContent,
@@ -4322,7 +4358,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<Uri>.value(_FakeUri_33(
+        returnValueForMissingStub: _i16.Future<Uri>.value(_FakeUri_34(
           this,
           Invocation.method(
             #uploadContent,
@@ -4333,10 +4369,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<Uri>);
+      ) as _i16.Future<Uri>);
 
   @override
-  _i15.Future<void> setTyping(
+  _i16.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -4352,42 +4388,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<String?> exportDump() => (super.noSuchMethod(
+  _i16.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i15.Future<String?>.value(),
-        returnValueForMissingStub: _i15.Future<String?>.value(),
-      ) as _i15.Future<String?>);
+        returnValue: _i16.Future<String?>.value(),
+        returnValueForMissingStub: _i16.Future<String?>.value(),
+      ) as _i16.Future<String?>);
 
   @override
-  _i15.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i16.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i16.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.Event?> getEventByPushNotification(
+  _i16.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -4403,12 +4439,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i15.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
-      ) as _i15.Future<_i4.Event?>);
+        returnValue: _i16.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i16.Future<_i4.Event?>.value(),
+      ) as _i16.Future<_i4.Event?>);
 
   @override
-  _i15.Future<void> init({
+  _i16.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -4443,9 +4479,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -4457,40 +4493,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i15.Future<void> clear() => (super.noSuchMethod(
+  _i16.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i16.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> ensureNotSoftLoggedOut(
+  _i16.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> handleSync(
+  _i16.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -4500,9 +4536,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -4515,29 +4551,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i15.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i16.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i16.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> sendToDevice(
+  _i16.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -4551,12 +4587,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> sendToDevicesOfUserIds(
+  _i16.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4572,12 +4608,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> sendToDeviceEncrypted(
+  _i16.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -4597,12 +4633,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> sendToDeviceEncryptedChunked(
+  _i16.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -4616,23 +4652,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i16.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<String> joinRoom(
+  _i16.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -4650,7 +4686,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4664,7 +4700,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i21.dummyValue<String>(
+            _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -4677,10 +4713,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<void> changePassword(
+  _i16.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -4696,22 +4732,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> clearCache() => (super.noSuchMethod(
+  _i16.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> ignoreUser(
+  _i16.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -4721,22 +4757,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i16.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i16.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -4747,7 +4783,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
+            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4756,7 +4792,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_34(
+            _i16.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -4764,32 +4800,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i15.Future<_i4.CachedPresence>);
+      ) as _i16.Future<_i4.CachedPresence>);
 
   @override
-  _i15.Future<void> abortSync() => (super.noSuchMethod(
+  _i16.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i16.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<String?> redactEventWithMetadata(
+  _i16.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -4809,14 +4845,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i15.Future<String?>.value(),
-        returnValueForMissingStub: _i15.Future<String?>.value(),
-      ) as _i15.Future<String?>);
+        returnValue: _i16.Future<String?>.value(),
+        returnValueForMissingStub: _i16.Future<String?>.value(),
+      ) as _i16.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i14.BaseResponse? response,
-    _i25.Uint8List? body,
+    _i15.BaseResponse? response,
+    _i26.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4848,7 +4884,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i15.Future<Map<String, Object?>> request(
+  _i16.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -4869,13 +4905,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 
   @override
-  _i15.Future<void> postPusher(
+  _i16.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -4885,57 +4921,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i16.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i16.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i16.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i15.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_35(
+        returnValue: _i16.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_36(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_35(
+        returnValueForMissingStub: _i16.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_36(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i15.Future<_i4.TurnServerCredentials>);
+      ) as _i16.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4949,8 +4985,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4962,8 +4998,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -4974,10 +5010,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -4993,8 +5029,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5007,8 +5043,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -5020,10 +5056,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i15.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i16.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -5037,7 +5073,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+        returnValue: _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -5049,7 +5085,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+            _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -5060,17 +5096,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.KeyBackupData>);
+      ) as _i16.Future<_i4.KeyBackupData>);
 
   @override
-  _i15.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i16.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i15.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_38(
+        returnValue: _i16.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_39(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -5078,18 +5114,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_38(
+            _i16.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_39(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i15.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i16.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i15.Future<int> pingAppservice(
+  _i16.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -5099,12 +5135,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i15.Future<int>.value(0),
-        returnValueForMissingStub: _i15.Future<int>.value(0),
-      ) as _i15.Future<int>);
+        returnValue: _i16.Future<int>.value(0),
+        returnValueForMissingStub: _i16.Future<int>.value(0),
+      ) as _i16.Future<int>);
 
   @override
-  _i15.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i16.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5112,8 +5148,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i15.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_39(
+        returnValue: _i16.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_40(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -5122,8 +5158,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_39(
+            _i16.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_40(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -5131,15 +5167,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i15.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i16.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i15.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i16.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+        returnValue: _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -5147,17 +5183,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_30(
+            _i16.Future<_i4.MediaConfig>.value(_FakeMediaConfig_31(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i15.Future<_i4.MediaConfig>);
+      ) as _i16.Future<_i4.MediaConfig>);
 
   @override
-  _i15.Future<_i16.FileResponse> getContentAuthed(
+  _i16.Future<_i17.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -5171,7 +5207,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -5183,7 +5219,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
+            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -5194,10 +5230,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i15.Future<_i16.FileResponse>);
+      ) as _i16.Future<_i17.FileResponse>);
 
   @override
-  _i15.Future<_i16.FileResponse> getContentOverrideNameAuthed(
+  _i16.Future<_i17.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5213,7 +5249,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -5226,7 +5262,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
+            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -5238,10 +5274,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i15.Future<_i16.FileResponse>);
+      ) as _i16.Future<_i17.FileResponse>);
 
   @override
-  _i15.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i16.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -5251,7 +5287,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+        returnValue: _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -5260,7 +5296,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_32(
+            _i16.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_33(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -5268,10 +5304,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i15.Future<_i4.PreviewForUrl>);
+      ) as _i16.Future<_i4.PreviewForUrl>);
 
   @override
-  _i15.Future<_i16.FileResponse> getContentThumbnailAuthed(
+  _i16.Future<_i17.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5295,7 +5331,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
+        returnValue: _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -5313,7 +5349,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_31(
+            _i16.Future<_i17.FileResponse>.value(_FakeFileResponse_32(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -5330,21 +5366,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i16.FileResponse>);
+      ) as _i16.Future<_i17.FileResponse>);
 
   @override
-  _i15.Future<bool> registrationTokenValidity(String? token) =>
+  _i16.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i16.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -5354,8 +5390,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_40(
+        returnValue: _i16.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_41(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -5364,8 +5400,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_40(
+            _i16.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_41(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -5373,10 +5409,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i15.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i16.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i15.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i16.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -5394,8 +5430,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_41(
+        returnValue: _i16.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_42(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -5409,8 +5445,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_41(
+            _i16.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_42(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -5423,10 +5459,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i16.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i15.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i16.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -5450,8 +5486,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i15.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_42(
+        returnValue: _i16.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_43(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -5469,8 +5505,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_42(
+            _i16.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_43(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -5487,10 +5523,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i16.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -5518,8 +5554,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_43(
+                _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5538,8 +5574,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_43(
+                _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_44(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -5557,10 +5593,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i16.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i15.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i16.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -5589,9 +5625,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i15.Future<
+            returnValue: _i16.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5610,9 +5646,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i15.Future<
+            returnValueForMissingStub: _i16.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_44(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -5631,11 +5667,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i15
+          ) as _i16
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i15.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i16.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -5651,8 +5687,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i15.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_45(
+        returnValue: _i16.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_46(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5665,8 +5701,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_45(
+            _i16.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_46(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -5678,10 +5714,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.GetThreadRootsResponse>);
+      ) as _i16.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i15.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i16.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -5695,8 +5731,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i15.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_46(
+        returnValue: _i16.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_47(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5708,8 +5744,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_46(
+            _i16.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_47(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -5720,33 +5756,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i16.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i15.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i16.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i16.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i15.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i16.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i16.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i15.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i16.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i15.Future<Uri?>.value(),
-        returnValueForMissingStub: _i15.Future<Uri?>.value(),
-      ) as _i15.Future<Uri?>);
+        returnValue: _i16.Future<Uri?>.value(),
+        returnValueForMissingStub: _i16.Future<Uri?>.value(),
+      ) as _i16.Future<Uri?>);
 
   @override
-  _i15.Future<void> add3PID(
+  _i16.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -5760,12 +5796,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> bind3PID(
+  _i16.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -5781,12 +5817,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i16.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5800,14 +5836,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i15.Future<_i4.IdServerUnbindResult>);
+      ) as _i16.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i16.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5829,8 +5865,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5846,8 +5882,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -5863,10 +5899,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.RequestTokenResponse>);
+      ) as _i16.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i16.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -5890,8 +5926,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5908,8 +5944,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -5926,10 +5962,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.RequestTokenResponse>);
+      ) as _i16.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i15.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i16.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -5943,14 +5979,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i15.Future<_i4.IdServerUnbindResult>);
+      ) as _i16.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i15.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i16.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -5965,14 +6001,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i16.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i16.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i15.Future<_i4.IdServerUnbindResult>);
+      ) as _i16.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i16.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -5994,8 +6030,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -6011,8 +6047,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -6028,10 +6064,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.RequestTokenResponse>);
+      ) as _i16.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i16.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -6055,8 +6091,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -6073,8 +6109,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -6091,16 +6127,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.RequestTokenResponse>);
+      ) as _i16.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i15.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i16.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
+            _i16.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -6108,22 +6144,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_48(
+            _i16.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i15.Future<_i4.TokenOwnerInfo>);
+      ) as _i16.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i15.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i16.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
+        returnValue: _i16.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
           this,
           Invocation.method(
             #getWhoIs,
@@ -6131,22 +6167,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_49(
+            _i16.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i15.Future<_i4.WhoIsInfo>);
+      ) as _i16.Future<_i4.WhoIsInfo>);
 
   @override
-  _i15.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i16.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
+        returnValue: _i16.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
           this,
           Invocation.method(
             #getCapabilities,
@@ -6154,17 +6190,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_50(
+            _i16.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i15.Future<_i4.Capabilities>);
+      ) as _i16.Future<_i4.Capabilities>);
 
   @override
-  _i15.Future<String> createRoom({
+  _i16.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -6197,7 +6233,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -6219,7 +6255,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i21.dummyValue<String>(
+            _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -6240,10 +6276,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<void> deleteDevices(
+  _i16.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -6253,22 +6289,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i16.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i15.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i15.Future<List<_i4.Device>?>.value(),
-      ) as _i15.Future<List<_i4.Device>?>);
+        returnValue: _i16.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i16.Future<List<_i4.Device>?>.value(),
+      ) as _i16.Future<List<_i4.Device>?>);
 
   @override
-  _i15.Future<void> deleteDevice(
+  _i16.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -6278,34 +6314,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i16.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i15.Future<_i4.Device>.value(_FakeDevice_51(
+        returnValue: _i16.Future<_i4.Device>.value(_FakeDevice_52(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.Device>.value(_FakeDevice_51(
+        returnValueForMissingStub: _i16.Future<_i4.Device>.value(_FakeDevice_52(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i15.Future<_i4.Device>);
+      ) as _i16.Future<_i4.Device>);
 
   @override
-  _i15.Future<void> updateDevice(
+  _i16.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -6315,12 +6351,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i16.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -6335,24 +6371,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 
   @override
-  _i15.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i16.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i15.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i15.Future<_i4.Visibility?>.value(),
-      ) as _i15.Future<_i4.Visibility?>);
+        returnValue: _i16.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i16.Future<_i4.Visibility?>.value(),
+      ) as _i16.Future<_i4.Visibility?>);
 
   @override
-  _i15.Future<void> setRoomVisibilityOnDirectory(
+  _i16.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -6362,30 +6398,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i16.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i16.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_52(
+        returnValue: _i16.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_53(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -6393,18 +6429,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_52(
+            _i16.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_53(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i15.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i16.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i15.Future<void> setRoomAlias(
+  _i16.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -6416,12 +6452,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.GetEventsResponse> getEvents({
+  _i16.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -6435,7 +6471,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
+            _i16.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
           this,
           Invocation.method(
             #getEvents,
@@ -6447,7 +6483,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_53(
+            _i16.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
           this,
           Invocation.method(
             #getEvents,
@@ -6458,10 +6494,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.GetEventsResponse>);
+      ) as _i16.Future<_i4.GetEventsResponse>);
 
   @override
-  _i15.Future<_i4.PeekEventsResponse> peekEvents({
+  _i16.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -6476,8 +6512,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i15.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_54(
+        returnValue: _i16.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_55(
           this,
           Invocation.method(
             #peekEvents,
@@ -6489,8 +6525,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_54(
+        returnValueForMissingStub: _i16.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_55(
           this,
           Invocation.method(
             #peekEvents,
@@ -6502,16 +6538,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.PeekEventsResponse>);
+      ) as _i16.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i15.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i16.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+        returnValue: _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneEvent,
@@ -6519,27 +6555,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+            _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i15.Future<_i4.MatrixEvent>);
+      ) as _i16.Future<_i4.MatrixEvent>);
 
   @override
-  _i15.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i16.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i15.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
-      ) as _i15.Future<List<String>>);
+        returnValue: _i16.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
+      ) as _i16.Future<List<String>>);
 
   @override
-  _i15.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i16.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -6551,8 +6587,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i15.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_56(
+        returnValue: _i16.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_57(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6563,8 +6599,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_56(
+            _i16.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_57(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -6574,10 +6610,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.GetKeysChangesResponse>);
+      ) as _i16.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i15.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i16.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -6588,7 +6624,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
+            _i16.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
           this,
           Invocation.method(
             #claimKeys,
@@ -6597,7 +6633,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_57(
+            _i16.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
           this,
           Invocation.method(
             #claimKeys,
@@ -6605,10 +6641,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i15.Future<_i4.ClaimKeysResponse>);
+      ) as _i16.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i15.Future<void> uploadCrossSigningKeys({
+  _i16.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -6625,12 +6661,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.QueryKeysResponse> queryKeys(
+  _i16.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -6641,7 +6677,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
+            _i16.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
           this,
           Invocation.method(
             #queryKeys,
@@ -6650,7 +6686,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_58(
+            _i16.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
           this,
           Invocation.method(
             #queryKeys,
@@ -6658,10 +6694,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i15.Future<_i4.QueryKeysResponse>);
+      ) as _i16.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i16.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -6669,14 +6705,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i15.Future<
+            returnValue: _i16.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i15.Future<
+            returnValueForMissingStub: _i16.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i16.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i15.Future<Map<String, int>> uploadKeys({
+  _i16.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -6691,13 +6727,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i15.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i16.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i15.Future<Map<String, int>>);
+            _i16.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i16.Future<Map<String, int>>);
 
   @override
-  _i15.Future<String> knockRoom(
+  _i16.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -6711,7 +6747,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6723,7 +6759,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i21.dummyValue<String>(
+            _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6734,20 +6770,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i16.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i15.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i15.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i15.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i16.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i16.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i16.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i15.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i16.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -6762,8 +6798,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i15.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_59(
+        returnValue: _i16.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_60(
           this,
           Invocation.method(
             #getNotifications,
@@ -6776,8 +6812,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_59(
+            _i16.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_60(
           this,
           Invocation.method(
             #getNotifications,
@@ -6789,35 +6825,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.GetNotificationsResponse>);
+      ) as _i16.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i15.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i16.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i15.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_60(
+        returnValue: _i16.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_61(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_60(
+        returnValueForMissingStub: _i16.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_61(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i15.Future<_i4.GetPresenceResponse>);
+      ) as _i16.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i15.Future<void> setPresence(
+  _i16.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -6831,12 +6867,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<Map<String, Object?>> deleteProfileField(
+  _i16.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6849,13 +6885,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 
   @override
-  _i15.Future<Map<String, Object?>> getProfileField(
+  _i16.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -6868,13 +6904,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 
   @override
-  _i15.Future<Map<String, Object?>> setProfileField(
+  _i16.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -6889,13 +6925,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 
   @override
-  _i15.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i16.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -6910,8 +6946,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i15.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_61(
+        returnValue: _i16.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_62(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6924,8 +6960,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_61(
+            _i16.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_62(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -6937,10 +6973,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i16.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i15.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i16.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -6961,8 +6997,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i15.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_62(
+        returnValue: _i16.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_63(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6978,8 +7014,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_62(
+            _i16.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_63(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -6994,25 +7030,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i16.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i15.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i16.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i15.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i15.Future<List<_i4.Pusher>?>.value(),
-      ) as _i15.Future<List<_i4.Pusher>?>);
+        returnValue: _i16.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i16.Future<List<_i4.Pusher>?>.value(),
+      ) as _i16.Future<List<_i4.Pusher>?>);
 
   @override
-  _i15.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i16.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
+        returnValue: _i16.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
           this,
           Invocation.method(
             #getPushRules,
@@ -7020,24 +7056,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_63(
+            _i16.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i15.Future<_i4.PushRuleSet>);
+      ) as _i16.Future<_i4.PushRuleSet>);
 
   @override
-  _i15.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i16.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_64(
+        returnValue: _i16.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_65(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -7045,18 +7081,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_64(
+            _i16.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_65(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i15.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i16.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i15.Future<void> deletePushRule(
+  _i16.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -7068,12 +7104,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.PushRule> getPushRule(
+  _i16.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -7085,7 +7121,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i15.Future<_i4.PushRule>.value(_FakePushRule_65(
+        returnValue: _i16.Future<_i4.PushRule>.value(_FakePushRule_66(
           this,
           Invocation.method(
             #getPushRule,
@@ -7096,7 +7132,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.PushRule>.value(_FakePushRule_65(
+            _i16.Future<_i4.PushRule>.value(_FakePushRule_66(
           this,
           Invocation.method(
             #getPushRule,
@@ -7106,10 +7142,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.PushRule>);
+      ) as _i16.Future<_i4.PushRule>);
 
   @override
-  _i15.Future<void> setPushRule(
+  _i16.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -7133,12 +7169,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<List<Object?>> getPushRuleActions(
+  _i16.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -7150,13 +7186,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i15.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i16.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i15.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i15.Future<List<Object?>>);
+            _i16.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i16.Future<List<Object?>>);
 
   @override
-  _i15.Future<void> setPushRuleActions(
+  _i16.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -7170,12 +7206,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<bool> isPushRuleEnabled(
+  _i16.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -7187,12 +7223,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<void> setPushRuleEnabled(
+  _i16.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -7206,19 +7242,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i16.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
+            _i16.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
           this,
           Invocation.method(
             #refresh,
@@ -7226,28 +7262,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_66(
+            _i16.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i15.Future<_i4.RefreshResponse>);
+      ) as _i16.Future<_i4.RefreshResponse>);
 
   @override
-  _i15.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i16.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i15.Future<bool?>.value(),
-        returnValueForMissingStub: _i15.Future<bool?>.value(),
-      ) as _i15.Future<bool?>);
+        returnValue: _i16.Future<bool?>.value(),
+        returnValueForMissingStub: _i16.Future<bool?>.value(),
+      ) as _i16.Future<bool?>);
 
   @override
-  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i16.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7269,8 +7305,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -7286,8 +7322,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -7303,10 +7339,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.RequestTokenResponse>);
+      ) as _i16.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i16.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7330,8 +7366,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValue: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -7348,8 +7384,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_47(
+        returnValueForMissingStub: _i16.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_48(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -7366,17 +7402,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.RequestTokenResponse>);
+      ) as _i16.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -7384,23 +7420,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i15.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i16.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
+        returnValue: _i16.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -7408,17 +7444,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_67(
+            _i16.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i15.Future<_i4.RoomKeys>);
+      ) as _i16.Future<_i4.RoomKeys>);
 
   @override
-  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -7430,8 +7466,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -7442,8 +7478,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -7453,10 +7489,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -7468,8 +7504,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -7480,8 +7516,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -7491,10 +7527,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i15.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i16.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -7506,7 +7542,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
+        returnValue: _i16.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -7517,7 +7553,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_68(
+            _i16.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -7527,10 +7563,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.RoomKeyBackup>);
+      ) as _i16.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -7544,8 +7580,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7557,8 +7593,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -7569,10 +7605,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i16.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7586,8 +7622,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7599,8 +7635,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -7611,10 +7647,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i15.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i16.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7628,7 +7664,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+        returnValue: _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7640,7 +7676,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_37(
+            _i16.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -7651,10 +7687,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.KeyBackupData>);
+      ) as _i16.Future<_i4.KeyBackupData>);
 
   @override
-  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i16.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -7670,8 +7706,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_36(
+        returnValue: _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7684,8 +7720,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_36(
+            _i16.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_37(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -7697,18 +7733,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i16.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_69(
+                _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_70(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -7716,18 +7752,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_69(
+                _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_70(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i16.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i15.Future<String> postRoomKeysVersion(
+  _i16.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -7739,7 +7775,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7750,7 +7786,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i21.dummyValue<String>(
+            _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -7760,29 +7796,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i16.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i16.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_70(
+        returnValue: _i16.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_71(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -7790,18 +7826,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_70(
+            _i16.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_71(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i15.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i16.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i15.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i16.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -7816,24 +7852,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 
   @override
-  _i15.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i16.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i15.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
-      ) as _i15.Future<List<String>>);
+        returnValue: _i16.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i16.Future<List<String>>.value(<String>[]),
+      ) as _i16.Future<List<String>>);
 
   @override
-  _i15.Future<void> ban(
+  _i16.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7847,12 +7883,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.EventContext> getEventContext(
+  _i16.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -7870,7 +7906,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i15.Future<_i4.EventContext>.value(_FakeEventContext_71(
+        returnValue: _i16.Future<_i4.EventContext>.value(_FakeEventContext_72(
           this,
           Invocation.method(
             #getEventContext,
@@ -7885,7 +7921,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.EventContext>.value(_FakeEventContext_71(
+            _i16.Future<_i4.EventContext>.value(_FakeEventContext_72(
           this,
           Invocation.method(
             #getEventContext,
@@ -7899,10 +7935,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.EventContext>);
+      ) as _i16.Future<_i4.EventContext>);
 
   @override
-  _i15.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i16.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -7914,7 +7950,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+        returnValue: _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7925,7 +7961,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_55(
+            _i16.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -7935,20 +7971,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.MatrixEvent>);
+      ) as _i16.Future<_i4.MatrixEvent>);
 
   @override
-  _i15.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i16.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> inviteBy3PID(
+  _i16.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -7960,12 +7996,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> inviteUser(
+  _i16.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -7979,12 +8015,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<String> joinRoomById(
+  _i16.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -7998,7 +8034,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8010,7 +8046,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i21.dummyValue<String>(
+            _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -8021,23 +8057,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i16.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i15.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i16.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i15.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i15.Future<Map<String, _i4.RoomMember>?>);
+            _i16.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i16.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i15.Future<void> kick(
+  _i16.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8051,12 +8087,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> leaveRoom(
+  _i16.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -8066,12 +8102,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i16.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -8087,12 +8123,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i15.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i15.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i15.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i16.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i16.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i16.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i15.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i16.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -8114,8 +8150,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i15.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_72(
+        returnValue: _i16.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_73(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -8131,8 +8167,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_72(
+        returnValueForMissingStub: _i16.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_73(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -8148,10 +8184,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.GetRoomEventsResponse>);
+      ) as _i16.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i15.Future<void> setReadMarker(
+  _i16.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -8167,12 +8203,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> postReceipt(
+  _i16.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -8188,12 +8224,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<String?> redactEvent(
+  _i16.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -8209,12 +8245,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i15.Future<String?>.value(),
-        returnValueForMissingStub: _i15.Future<String?>.value(),
-      ) as _i15.Future<String?>);
+        returnValue: _i16.Future<String?>.value(),
+        returnValueForMissingStub: _i16.Future<String?>.value(),
+      ) as _i16.Future<String?>);
 
   @override
-  _i15.Future<void> reportRoom(
+  _i16.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -8226,12 +8262,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> reportEvent(
+  _i16.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -8249,12 +8285,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<String> sendMessage(
+  _i16.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -8270,7 +8306,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -8283,7 +8319,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i21.dummyValue<String>(
+            _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -8295,23 +8331,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i16.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i16.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i15.Future<List<_i4.MatrixEvent>>);
+            _i16.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i16.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i15.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i16.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -8328,13 +8364,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 
   @override
-  _i15.Future<String> setRoomStateWithKey(
+  _i16.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -8350,7 +8386,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -8363,7 +8399,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i21.dummyValue<String>(
+            _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -8375,10 +8411,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<void> unban(
+  _i16.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8392,12 +8428,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<String> upgradeRoom(
+  _i16.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -8411,7 +8447,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -8423,7 +8459,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i21.dummyValue<String>(
+            _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -8434,10 +8470,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<_i4.SearchResults> search(
+  _i16.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -8447,7 +8483,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
+        returnValue: _i16.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
           this,
           Invocation.method(
             #search,
@@ -8456,7 +8492,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_73(
+            _i16.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
           this,
           Invocation.method(
             #search,
@@ -8464,10 +8500,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i15.Future<_i4.SearchResults>);
+      ) as _i16.Future<_i4.SearchResults>);
 
   @override
-  _i15.Future<_i4.SyncUpdate> sync({
+  _i16.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -8488,7 +8524,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
+        returnValue: _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_29(
           this,
           Invocation.method(
             #sync,
@@ -8504,7 +8540,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_28(
+            _i16.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_29(
           this,
           Invocation.method(
             #sync,
@@ -8519,22 +8555,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i15.Future<_i4.SyncUpdate>);
+      ) as _i16.Future<_i4.SyncUpdate>);
 
   @override
-  _i15.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i16.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i15.Future<List<_i4.Location>>);
+            _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i16.Future<List<_i4.Location>>);
 
   @override
-  _i15.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i16.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8544,21 +8580,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i15.Future<List<_i4.Location>>);
+            _i16.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i16.Future<List<_i4.Location>>);
 
   @override
-  _i15.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i16.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_74(
+        returnValue: _i16.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_75(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -8566,45 +8602,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_74(
+            _i16.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_75(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i15.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i16.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i15.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i16.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i16.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i16.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
+            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i16.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i16.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -8615,13 +8651,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
+            _i16.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i16.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i15.Future<Map<String, Object?>> getAccountData(
+  _i16.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -8634,13 +8670,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 
   @override
-  _i15.Future<void> setAccountData(
+  _i16.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -8654,12 +8690,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<String> defineFilter(
+  _i16.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -8671,7 +8707,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i15.Future<String>.value(_i21.dummyValue<String>(
+        returnValue: _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8682,7 +8718,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<String>.value(_i21.dummyValue<String>(
+            _i16.Future<String>.value(_i22.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -8692,10 +8728,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<String>);
+      ) as _i16.Future<String>);
 
   @override
-  _i15.Future<_i4.Filter> getFilter(
+  _i16.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -8707,7 +8743,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i15.Future<_i4.Filter>.value(_FakeFilter_14(
+        returnValue: _i16.Future<_i4.Filter>.value(_FakeFilter_15(
           this,
           Invocation.method(
             #getFilter,
@@ -8717,7 +8753,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.Filter>.value(_FakeFilter_14(
+        returnValueForMissingStub: _i16.Future<_i4.Filter>.value(_FakeFilter_15(
           this,
           Invocation.method(
             #getFilter,
@@ -8727,10 +8763,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.Filter>);
+      ) as _i16.Future<_i4.Filter>);
 
   @override
-  _i15.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i16.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -8743,7 +8779,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
+            _i16.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8754,7 +8790,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_75(
+            _i16.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -8764,10 +8800,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i15.Future<_i4.OpenIdCredentials>);
+      ) as _i16.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i15.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i16.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8782,13 +8818,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 
   @override
-  _i15.Future<void> setAccountDataPerRoom(
+  _i16.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -8804,12 +8840,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i16.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -8821,12 +8857,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i15.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i15.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i15.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i16.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i16.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i16.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i15.Future<void> deleteRoomTag(
+  _i16.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8840,12 +8876,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> setRoomTag(
+  _i16.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -8861,12 +8897,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i16.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -8876,8 +8912,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i15.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_76(
+        returnValue: _i16.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_77(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8886,8 +8922,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_76(
+            _i16.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_77(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -8895,10 +8931,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i15.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i16.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i15.Future<Map<String, Object?>> reportUser(
+  _i16.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -8911,40 +8947,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 
   @override
-  _i15.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i16.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i15.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_77(
+        returnValue: _i16.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_78(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_77(
+        returnValueForMissingStub: _i16.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_78(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i15.Future<_i4.CreateContentResponse>);
+      ) as _i16.Future<_i4.CreateContentResponse>);
 
   @override
-  _i15.Future<Map<String, Object?>> uploadContentToMXC(
+  _i16.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i25.Uint8List? body, {
+    _i26.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -8962,16 +8998,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i15.Future<Map<String, Object?>>);
+            _i16.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i16.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [Encryption].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEncryption extends _i1.Mock implements _i12.Encryption {
+class MockEncryption extends _i1.Mock implements _i13.Encryption {
   @override
   _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -9000,85 +9036,85 @@ class MockEncryption extends _i1.Mock implements _i12.Encryption {
       ) as bool);
 
   @override
-  _i12.KeyManager get keyManager => (super.noSuchMethod(
+  _i13.KeyManager get keyManager => (super.noSuchMethod(
         Invocation.getter(#keyManager),
-        returnValue: _FakeKeyManager_78(
+        returnValue: _FakeKeyManager_79(
           this,
           Invocation.getter(#keyManager),
         ),
-        returnValueForMissingStub: _FakeKeyManager_78(
+        returnValueForMissingStub: _FakeKeyManager_79(
           this,
           Invocation.getter(#keyManager),
         ),
-      ) as _i12.KeyManager);
+      ) as _i13.KeyManager);
 
   @override
-  _i17.OlmManager get olmManager => (super.noSuchMethod(
+  _i18.OlmManager get olmManager => (super.noSuchMethod(
         Invocation.getter(#olmManager),
-        returnValue: _FakeOlmManager_79(
+        returnValue: _FakeOlmManager_80(
           this,
           Invocation.getter(#olmManager),
         ),
-        returnValueForMissingStub: _FakeOlmManager_79(
+        returnValueForMissingStub: _FakeOlmManager_80(
           this,
           Invocation.getter(#olmManager),
         ),
-      ) as _i17.OlmManager);
+      ) as _i18.OlmManager);
 
   @override
-  _i18.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
+  _i19.KeyVerificationManager get keyVerificationManager => (super.noSuchMethod(
         Invocation.getter(#keyVerificationManager),
-        returnValue: _FakeKeyVerificationManager_80(
+        returnValue: _FakeKeyVerificationManager_81(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-        returnValueForMissingStub: _FakeKeyVerificationManager_80(
+        returnValueForMissingStub: _FakeKeyVerificationManager_81(
           this,
           Invocation.getter(#keyVerificationManager),
         ),
-      ) as _i18.KeyVerificationManager);
+      ) as _i19.KeyVerificationManager);
 
   @override
-  _i19.CrossSigning get crossSigning => (super.noSuchMethod(
+  _i20.CrossSigning get crossSigning => (super.noSuchMethod(
         Invocation.getter(#crossSigning),
-        returnValue: _FakeCrossSigning_81(
+        returnValue: _FakeCrossSigning_82(
           this,
           Invocation.getter(#crossSigning),
         ),
-        returnValueForMissingStub: _FakeCrossSigning_81(
+        returnValueForMissingStub: _FakeCrossSigning_82(
           this,
           Invocation.getter(#crossSigning),
         ),
-      ) as _i19.CrossSigning);
+      ) as _i20.CrossSigning);
 
   @override
-  _i12.SSSS get ssss => (super.noSuchMethod(
+  _i13.SSSS get ssss => (super.noSuchMethod(
         Invocation.getter(#ssss),
-        returnValue: _FakeSSSS_11(
+        returnValue: _FakeSSSS_12(
           this,
           Invocation.getter(#ssss),
         ),
-        returnValueForMissingStub: _FakeSSSS_11(
+        returnValueForMissingStub: _FakeSSSS_12(
           this,
           Invocation.getter(#ssss),
         ),
-      ) as _i12.SSSS);
+      ) as _i13.SSSS);
 
   @override
   String get ourDeviceId => (super.noSuchMethod(
         Invocation.getter(#ourDeviceId),
-        returnValue: _i21.dummyValue<String>(
+        returnValue: _i22.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
-        returnValueForMissingStub: _i21.dummyValue<String>(
+        returnValueForMissingStub: _i22.dummyValue<String>(
           this,
           Invocation.getter(#ourDeviceId),
         ),
       ) as String);
 
   @override
-  set keyManager(_i12.KeyManager? value) => super.noSuchMethod(
+  set keyManager(_i13.KeyManager? value) => super.noSuchMethod(
         Invocation.setter(
           #keyManager,
           value,
@@ -9087,7 +9123,7 @@ class MockEncryption extends _i1.Mock implements _i12.Encryption {
       );
 
   @override
-  set olmManager(_i17.OlmManager? value) => super.noSuchMethod(
+  set olmManager(_i18.OlmManager? value) => super.noSuchMethod(
         Invocation.setter(
           #olmManager,
           value,
@@ -9096,7 +9132,7 @@ class MockEncryption extends _i1.Mock implements _i12.Encryption {
       );
 
   @override
-  set keyVerificationManager(_i18.KeyVerificationManager? value) =>
+  set keyVerificationManager(_i19.KeyVerificationManager? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #keyVerificationManager,
@@ -9106,7 +9142,7 @@ class MockEncryption extends _i1.Mock implements _i12.Encryption {
       );
 
   @override
-  set crossSigning(_i19.CrossSigning? value) => super.noSuchMethod(
+  set crossSigning(_i20.CrossSigning? value) => super.noSuchMethod(
         Invocation.setter(
           #crossSigning,
           value,
@@ -9115,7 +9151,7 @@ class MockEncryption extends _i1.Mock implements _i12.Encryption {
       );
 
   @override
-  set ssss(_i12.SSSS? value) => super.noSuchMethod(
+  set ssss(_i13.SSSS? value) => super.noSuchMethod(
         Invocation.setter(
           #ssss,
           value,
@@ -9133,7 +9169,7 @@ class MockEncryption extends _i1.Mock implements _i12.Encryption {
       );
 
   @override
-  _i15.Future<void> init(
+  _i16.Future<void> init(
     String? olmAccount, {
     String? deviceId,
     String? pickleKey,
@@ -9149,19 +9185,19 @@ class MockEncryption extends _i1.Mock implements _i12.Encryption {
             #dehydratedDeviceAlgorithm: dehydratedDeviceAlgorithm,
           },
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i12.Bootstrap bootstrap({void Function(_i12.Bootstrap)? onUpdate}) =>
+  _i13.Bootstrap bootstrap({void Function(_i13.Bootstrap)? onUpdate}) =>
       (super.noSuchMethod(
         Invocation.method(
           #bootstrap,
           [],
           {#onUpdate: onUpdate},
         ),
-        returnValue: _FakeBootstrap_82(
+        returnValue: _FakeBootstrap_83(
           this,
           Invocation.method(
             #bootstrap,
@@ -9169,7 +9205,7 @@ class MockEncryption extends _i1.Mock implements _i12.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-        returnValueForMissingStub: _FakeBootstrap_82(
+        returnValueForMissingStub: _FakeBootstrap_83(
           this,
           Invocation.method(
             #bootstrap,
@@ -9177,7 +9213,7 @@ class MockEncryption extends _i1.Mock implements _i12.Encryption {
             {#onUpdate: onUpdate},
           ),
         ),
-      ) as _i12.Bootstrap);
+      ) as _i13.Bootstrap);
 
   @override
   void handleDeviceOneTimeKeysCount(
@@ -9205,18 +9241,18 @@ class MockEncryption extends _i1.Mock implements _i12.Encryption {
       );
 
   @override
-  _i15.Future<void> handleToDeviceEvent(_i4.ToDeviceEvent? event) =>
+  _i16.Future<void> handleToDeviceEvent(_i4.ToDeviceEvent? event) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleToDeviceEvent,
           [event],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> handleEventUpdate(
+  _i16.Future<void> handleEventUpdate(
     _i4.Event? event,
     _i4.EventUpdateType? type,
   ) =>
@@ -9228,19 +9264,19 @@ class MockEncryption extends _i1.Mock implements _i12.Encryption {
             type,
           ],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<_i4.ToDeviceEvent> decryptToDeviceEvent(
+  _i16.Future<_i4.ToDeviceEvent> decryptToDeviceEvent(
           _i4.ToDeviceEvent? event) =>
       (super.noSuchMethod(
         Invocation.method(
           #decryptToDeviceEvent,
           [event],
         ),
-        returnValue: _i15.Future<_i4.ToDeviceEvent>.value(_FakeToDeviceEvent_83(
+        returnValue: _i16.Future<_i4.ToDeviceEvent>.value(_FakeToDeviceEvent_84(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
@@ -9248,14 +9284,14 @@ class MockEncryption extends _i1.Mock implements _i12.Encryption {
           ),
         )),
         returnValueForMissingStub:
-            _i15.Future<_i4.ToDeviceEvent>.value(_FakeToDeviceEvent_83(
+            _i16.Future<_i4.ToDeviceEvent>.value(_FakeToDeviceEvent_84(
           this,
           Invocation.method(
             #decryptToDeviceEvent,
             [event],
           ),
         )),
-      ) as _i15.Future<_i4.ToDeviceEvent>);
+      ) as _i16.Future<_i4.ToDeviceEvent>);
 
   @override
   _i4.Event decryptRoomEventSync(_i4.Event? event) => (super.noSuchMethod(
@@ -9263,14 +9299,14 @@ class MockEncryption extends _i1.Mock implements _i12.Encryption {
           #decryptRoomEventSync,
           [event],
         ),
-        returnValue: _FakeEvent_84(
+        returnValue: _FakeEvent_85(
           this,
           Invocation.method(
             #decryptRoomEventSync,
             [event],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_84(
+        returnValueForMissingStub: _FakeEvent_85(
           this,
           Invocation.method(
             #decryptRoomEventSync,
@@ -9280,7 +9316,7 @@ class MockEncryption extends _i1.Mock implements _i12.Encryption {
       ) as _i4.Event);
 
   @override
-  _i15.Future<_i4.Event> decryptRoomEvent(
+  _i16.Future<_i4.Event> decryptRoomEvent(
     _i4.Event? event, {
     bool? store = false,
     _i4.EventUpdateType? updateType = _i4.EventUpdateType.timeline,
@@ -9294,7 +9330,7 @@ class MockEncryption extends _i1.Mock implements _i12.Encryption {
             #updateType: updateType,
           },
         ),
-        returnValue: _i15.Future<_i4.Event>.value(_FakeEvent_84(
+        returnValue: _i16.Future<_i4.Event>.value(_FakeEvent_85(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -9305,7 +9341,7 @@ class MockEncryption extends _i1.Mock implements _i12.Encryption {
             },
           ),
         )),
-        returnValueForMissingStub: _i15.Future<_i4.Event>.value(_FakeEvent_84(
+        returnValueForMissingStub: _i16.Future<_i4.Event>.value(_FakeEvent_85(
           this,
           Invocation.method(
             #decryptRoomEvent,
@@ -9316,10 +9352,10 @@ class MockEncryption extends _i1.Mock implements _i12.Encryption {
             },
           ),
         )),
-      ) as _i15.Future<_i4.Event>);
+      ) as _i16.Future<_i4.Event>);
 
   @override
-  _i15.Future<Map<String, dynamic>> encryptGroupMessagePayload(
+  _i16.Future<Map<String, dynamic>> encryptGroupMessagePayload(
     String? roomId,
     Map<String, dynamic>? payload, {
     String? type = 'm.room.message',
@@ -9334,13 +9370,13 @@ class MockEncryption extends _i1.Mock implements _i12.Encryption {
           {#type: type},
         ),
         returnValue:
-            _i15.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
+            _i16.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
-      ) as _i15.Future<Map<String, dynamic>>);
+            _i16.Future<Map<String, dynamic>>.value(<String, dynamic>{}),
+      ) as _i16.Future<Map<String, dynamic>>);
 
   @override
-  _i15.Future<
+  _i16.Future<
       Map<String, Map<String, Map<String, dynamic>>>> encryptToDeviceMessage(
     List<_i4.DeviceKeys>? deviceKeys,
     String? type,
@@ -9356,50 +9392,50 @@ class MockEncryption extends _i1.Mock implements _i12.Encryption {
           ],
         ),
         returnValue:
-            _i15.Future<Map<String, Map<String, Map<String, dynamic>>>>.value(
+            _i16.Future<Map<String, Map<String, Map<String, dynamic>>>>.value(
                 <String, Map<String, Map<String, dynamic>>>{}),
         returnValueForMissingStub:
-            _i15.Future<Map<String, Map<String, Map<String, dynamic>>>>.value(
+            _i16.Future<Map<String, Map<String, Map<String, dynamic>>>>.value(
                 <String, Map<String, Map<String, dynamic>>>{}),
-      ) as _i15.Future<Map<String, Map<String, Map<String, dynamic>>>>);
+      ) as _i16.Future<Map<String, Map<String, Map<String, dynamic>>>>);
 
   @override
-  _i15.Future<void> autovalidateMasterOwnKey() => (super.noSuchMethod(
+  _i16.Future<void> autovalidateMasterOwnKey() => (super.noSuchMethod(
         Invocation.method(
           #autovalidateMasterOwnKey,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
-  _i15.Future<void> dispose() => (super.noSuchMethod(
+  _i16.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 }
 
 /// A class which mocks [CrossSigning].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCrossSigning extends _i1.Mock implements _i19.CrossSigning {
+class MockCrossSigning extends _i1.Mock implements _i20.CrossSigning {
   @override
-  _i12.Encryption get encryption => (super.noSuchMethod(
+  _i13.Encryption get encryption => (super.noSuchMethod(
         Invocation.getter(#encryption),
-        returnValue: _FakeEncryption_10(
+        returnValue: _FakeEncryption_11(
           this,
           Invocation.getter(#encryption),
         ),
-        returnValueForMissingStub: _FakeEncryption_10(
+        returnValueForMissingStub: _FakeEncryption_11(
           this,
           Invocation.getter(#encryption),
         ),
-      ) as _i12.Encryption);
+      ) as _i13.Encryption);
 
   @override
   _i4.Client get client => (super.noSuchMethod(
@@ -9422,21 +9458,21 @@ class MockCrossSigning extends _i1.Mock implements _i19.CrossSigning {
       ) as bool);
 
   @override
-  _i15.Future<bool> isCached() => (super.noSuchMethod(
+  _i16.Future<bool> isCached() => (super.noSuchMethod(
         Invocation.method(
           #isCached,
           [],
         ),
-        returnValue: _i15.Future<bool>.value(false),
-        returnValueForMissingStub: _i15.Future<bool>.value(false),
-      ) as _i15.Future<bool>);
+        returnValue: _i16.Future<bool>.value(false),
+        returnValueForMissingStub: _i16.Future<bool>.value(false),
+      ) as _i16.Future<bool>);
 
   @override
-  _i15.Future<void> selfSign({
+  _i16.Future<void> selfSign({
     String? passphrase,
     String? recoveryKey,
     String? keyOrPassphrase,
-    _i12.OpenSSSS? openSsss,
+    _i13.OpenSSSS? openSsss,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -9449,9 +9485,9 @@ class MockCrossSigning extends _i1.Mock implements _i19.CrossSigning {
             #openSsss: openSsss,
           },
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 
   @override
   bool signable(List<_i4.SignableKey>? keys) => (super.noSuchMethod(
@@ -9464,12 +9500,12 @@ class MockCrossSigning extends _i1.Mock implements _i19.CrossSigning {
       ) as bool);
 
   @override
-  _i15.Future<void> sign(List<_i4.SignableKey>? keys) => (super.noSuchMethod(
+  _i16.Future<void> sign(List<_i4.SignableKey>? keys) => (super.noSuchMethod(
         Invocation.method(
           #sign,
           [keys],
         ),
-        returnValue: _i15.Future<void>.value(),
-        returnValueForMissingStub: _i15.Future<void>.value(),
-      ) as _i15.Future<void>);
+        returnValue: _i16.Future<void>.value(),
+        returnValueForMissingStub: _i16.Future<void>.value(),
+      ) as _i16.Future<void>);
 }

--- a/test/widgets/registration_controller_test.mocks.dart
+++ b/test/widgets/registration_controller_test.mocks.dart
@@ -4,14 +4,15 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i19;
-import 'dart:ui' as _i21;
+import 'dart:typed_data' as _i20;
+import 'dart:ui' as _i22;
 
-import 'package:flutter/services.dart' as _i22;
-import 'package:flutter/widgets.dart' as _i23;
+import 'package:flutter/services.dart' as _i23;
+import 'package:flutter/widgets.dart' as _i24;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/models/server_auth_capabilities.dart' as _i16;
-import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/models/server_auth_capabilities.dart' as _i17;
+import 'package:kohera/core/services/matrix_service.dart' as _i21;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -26,12 +27,12 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i18;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i18;
+import 'package:mockito/src/dummies.dart' as _i19;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -845,9 +846,20 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
-class _FakeServerAuthCapabilities_75 extends _i1.SmartFake
-    implements _i16.ServerAuthCapabilities {
-  _FakeServerAuthCapabilities_75(
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeServerAuthCapabilities_76 extends _i1.SmartFake
+    implements _i17.ServerAuthCapabilities {
+  _FakeServerAuthCapabilities_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -874,12 +886,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i17.KeyVerificationMethod> get verificationMethods =>
+  Set<_i18.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i17.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
-      ) as Set<_i17.KeyVerificationMethod>);
+        returnValue: <_i18.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
+      ) as Set<_i18.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -999,11 +1011,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1040,11 +1052,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1074,11 +1086,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1087,11 +1099,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1377,34 +1389,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i17.KeyVerification>
+  _i3.CachedStreamController<_i18.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i17.KeyVerification>(
+                _FakeCachedStreamController_6<_i18.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i17.KeyVerification>);
+          ) as _i3.CachedStreamController<_i18.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1560,7 +1572,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1849,14 +1861,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2244,8 +2256,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValue: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2261,8 +2273,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2303,7 +2315,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2319,7 +2331,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2368,7 +2380,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2389,7 +2401,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2492,7 +2504,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2510,7 +2522,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3029,7 +3041,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i19.Uint8List? file, {
+    _i20.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3381,7 +3393,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3395,7 +3407,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3546,7 +3558,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i19.Uint8List? body,
+    _i20.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4924,7 +4936,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4946,7 +4958,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5440,7 +5452,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5452,7 +5464,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6460,7 +6472,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6471,7 +6483,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6719,7 +6731,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6731,7 +6743,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6991,7 +7003,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7004,7 +7016,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7071,7 +7083,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7084,7 +7096,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7132,7 +7144,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7144,7 +7156,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7392,7 +7404,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7403,7 +7415,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7665,7 +7677,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i19.Uint8List? body, {
+    _i20.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7692,7 +7704,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7722,11 +7734,11 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7851,6 +7863,19 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7948,6 +7973,15 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7992,7 +8026,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8017,6 +8051,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8026,6 +8061,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8086,7 +8122,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8095,7 +8131,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8114,7 +8150,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8125,7 +8161,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8173,7 +8209,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i23.RouteInformation? routeInformation) =>
+          _i24.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8211,7 +8247,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8220,7 +8256,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8229,16 +8265,16 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
-      ) as _i5.Future<_i21.AppExitResponse>);
+            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+      ) as _i5.Future<_i22.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8300,6 +8336,7 @@ class MockAuthService extends _i1.Mock implements _i14.AuthService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8309,6 +8346,7 @@ class MockAuthService extends _i1.Mock implements _i14.AuthService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8388,7 +8426,7 @@ class MockAuthService extends _i1.Mock implements _i14.AuthService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i16.ServerAuthCapabilities> getServerAuthCapabilities(
+  _i5.Future<_i17.ServerAuthCapabilities> getServerAuthCapabilities(
     String? homeserver, {
     required bool? isLoggedIn,
   }) =>
@@ -8398,8 +8436,8 @@ class MockAuthService extends _i1.Mock implements _i14.AuthService {
           [homeserver],
           {#isLoggedIn: isLoggedIn},
         ),
-        returnValue: _i5.Future<_i16.ServerAuthCapabilities>.value(
-            _FakeServerAuthCapabilities_75(
+        returnValue: _i5.Future<_i17.ServerAuthCapabilities>.value(
+            _FakeServerAuthCapabilities_76(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -8408,8 +8446,8 @@ class MockAuthService extends _i1.Mock implements _i14.AuthService {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i16.ServerAuthCapabilities>.value(
-                _FakeServerAuthCapabilities_75(
+            _i5.Future<_i17.ServerAuthCapabilities>.value(
+                _FakeServerAuthCapabilities_76(
           this,
           Invocation.method(
             #getServerAuthCapabilities,
@@ -8417,7 +8455,7 @@ class MockAuthService extends _i1.Mock implements _i14.AuthService {
             {#isLoggedIn: isLoggedIn},
           ),
         )),
-      ) as _i5.Future<_i16.ServerAuthCapabilities>);
+      ) as _i5.Future<_i17.ServerAuthCapabilities>);
 
   @override
   bool isPermanentAuthFailure(Object? error) => (super.noSuchMethod(
@@ -8434,6 +8472,50 @@ class MockAuthService extends _i1.Mock implements _i14.AuthService {
         Invocation.method(
           #clearSessionKeys,
           [],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> saveLoginCredentials({
+    required String? homeserver,
+    required String? username,
+    required String? password,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #saveLoginCredentials,
+          [],
+          {
+            #homeserver: homeserver,
+            #username: username,
+            #password: password,
+          },
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<({String password, String username})?> loadLoginCredentials(
+          String? homeserver) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #loadLoginCredentials,
+          [homeserver],
+        ),
+        returnValue: _i5.Future<({String password, String username})?>.value(),
+        returnValueForMissingStub:
+            _i5.Future<({String password, String username})?>.value(),
+      ) as _i5.Future<({String password, String username})?>);
+
+  @override
+  _i5.Future<void> clearLoginCredentials(String? homeserver) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #clearLoginCredentials,
+          [homeserver],
         ),
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
@@ -8460,7 +8542,7 @@ class MockAuthService extends _i1.Mock implements _i14.AuthService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8469,7 +8551,7 @@ class MockAuthService extends _i1.Mock implements _i14.AuthService {
       );
 
   @override
-  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],

--- a/test/widgets/room_context_menu_test.mocks.dart
+++ b/test/widgets/room_context_menu_test.mocks.dart
@@ -4,13 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -25,14 +26,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i25;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i23;
+import 'package:matrix/src/utils/space_child.dart' as _i24;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -846,8 +847,9 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_75(
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -856,9 +858,19 @@ class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_76 extends _i1.SmartFake
+class _FakeRoomSummary_76 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_76(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_77 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_76(
+  _FakeLatestReceiptState_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,8 +879,8 @@ class _FakeLatestReceiptState_76 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_77(
+class _FakeTimeline_78 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -877,8 +889,8 @@ class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_78(
+class _FakeUser_79 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -905,12 +917,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1030,11 +1042,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1071,11 +1083,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1105,11 +1117,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1118,11 +1130,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1408,34 +1420,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1591,7 +1603,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1880,14 +1892,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2275,8 +2287,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2292,8 +2304,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2334,7 +2346,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2350,7 +2362,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2399,7 +2411,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2420,7 +2432,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2523,7 +2535,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2541,7 +2553,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3060,7 +3072,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3412,7 +3424,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3426,7 +3438,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3577,7 +3589,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4955,7 +4967,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4977,7 +4989,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5471,7 +5483,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5483,7 +5495,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6491,7 +6503,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6502,7 +6514,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6750,7 +6762,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6762,7 +6774,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7022,7 +7034,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7035,7 +7047,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7102,7 +7114,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7115,7 +7127,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7163,7 +7175,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7175,7 +7187,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7423,7 +7435,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7434,7 +7446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7696,7 +7708,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7723,7 +7735,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7753,11 +7765,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7882,6 +7894,19 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7979,6 +8004,15 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -8023,7 +8057,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8048,6 +8082,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8057,6 +8092,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8117,7 +8153,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8126,7 +8162,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8145,7 +8181,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8156,7 +8192,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8204,7 +8240,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8242,7 +8278,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8251,7 +8287,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8260,16 +8296,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8297,11 +8333,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8331,11 +8367,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_75(
+        returnValue: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_75(
+        returnValueForMissingStub: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
@@ -8388,11 +8424,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8428,11 +8464,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8448,11 +8484,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8461,11 +8497,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8508,11 +8544,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8555,11 +8591,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_76(
+        returnValue: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_76(
+        returnValueForMissingStub: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8778,18 +8814,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i23.SpaceParent>[],
-        returnValueForMissingStub: <_i23.SpaceParent>[],
-      ) as List<_i23.SpaceParent>);
+        returnValue: <_i24.SpaceParent>[],
+        returnValueForMissingStub: <_i24.SpaceParent>[],
+      ) as List<_i24.SpaceParent>);
 
   @override
-  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i23.SpaceChild>[],
-        returnValueForMissingStub: <_i23.SpaceChild>[],
-      ) as List<_i23.SpaceChild>);
+        returnValue: <_i24.SpaceChild>[],
+        returnValueForMissingStub: <_i24.SpaceChild>[],
+      ) as List<_i24.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8956,14 +8992,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9011,7 +9047,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9019,7 +9055,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9034,7 +9070,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9042,7 +9078,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9136,7 +9172,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9144,7 +9180,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9386,7 +9422,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9397,7 +9433,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9486,15 +9522,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i25.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i24.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i24.TimelineChunk?>.value(),
-      ) as _i5.Future<_i24.TimelineChunk?>);
+        returnValue: _i5.Future<_i25.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i25.TimelineChunk?>.value(),
+      ) as _i5.Future<_i25.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9535,7 +9571,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9552,7 +9588,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9616,14 +9652,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9639,14 +9675,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9702,7 +9738,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9710,7 +9746,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/room_details_panel_test.mocks.dart
+++ b/test/widgets/room_details_panel_test.mocks.dart
@@ -4,14 +4,15 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/models/join_mode.dart' as _i25;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/models/join_mode.dart' as _i26;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -26,14 +27,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i25;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i23;
+import 'package:matrix/src/utils/space_child.dart' as _i24;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -847,8 +848,9 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_75(
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -857,9 +859,19 @@ class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_76 extends _i1.SmartFake
+class _FakeRoomSummary_76 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_76(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_77 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_76(
+  _FakeLatestReceiptState_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -868,8 +880,8 @@ class _FakeLatestReceiptState_76 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_77(
+class _FakeTimeline_78 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -878,8 +890,8 @@ class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_78(
+class _FakeUser_79 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -888,8 +900,8 @@ class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeStateEvent_79 extends _i1.SmartFake implements _i2.StateEvent {
-  _FakeStateEvent_79(
+class _FakeStateEvent_80 extends _i1.SmartFake implements _i2.StateEvent {
+  _FakeStateEvent_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -916,12 +928,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1041,11 +1053,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1082,11 +1094,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1116,11 +1128,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1129,11 +1141,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1419,34 +1431,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1602,7 +1614,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1891,14 +1903,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2286,8 +2298,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2303,8 +2315,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2345,7 +2357,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2361,7 +2373,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2410,7 +2422,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2431,7 +2443,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2534,7 +2546,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2552,7 +2564,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3071,7 +3083,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3423,7 +3435,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3437,7 +3449,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3588,7 +3600,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4966,7 +4978,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4988,7 +5000,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5482,7 +5494,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5494,7 +5506,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6502,7 +6514,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6513,7 +6525,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6761,7 +6773,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6773,7 +6785,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7033,7 +7045,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7046,7 +7058,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7113,7 +7125,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7126,7 +7138,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7174,7 +7186,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7186,7 +7198,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7434,7 +7446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7445,7 +7457,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7707,7 +7719,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7734,7 +7746,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7764,11 +7776,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7893,6 +7905,19 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7990,6 +8015,15 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -8034,7 +8068,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8059,6 +8093,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8068,6 +8103,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8128,7 +8164,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8137,7 +8173,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8156,7 +8192,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8167,7 +8203,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8215,7 +8251,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8253,7 +8289,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8262,7 +8298,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8271,16 +8307,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8308,11 +8344,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8342,11 +8378,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_75(
+        returnValue: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_75(
+        returnValueForMissingStub: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
@@ -8399,11 +8435,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8439,11 +8475,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8459,11 +8495,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8472,11 +8508,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8519,11 +8555,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8566,11 +8602,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_76(
+        returnValue: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_76(
+        returnValueForMissingStub: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8789,18 +8825,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i23.SpaceParent>[],
-        returnValueForMissingStub: <_i23.SpaceParent>[],
-      ) as List<_i23.SpaceParent>);
+        returnValue: <_i24.SpaceParent>[],
+        returnValueForMissingStub: <_i24.SpaceParent>[],
+      ) as List<_i24.SpaceParent>);
 
   @override
-  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i23.SpaceChild>[],
-        returnValueForMissingStub: <_i23.SpaceChild>[],
-      ) as List<_i23.SpaceChild>);
+        returnValue: <_i24.SpaceChild>[],
+        returnValueForMissingStub: <_i24.SpaceChild>[],
+      ) as List<_i24.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8967,14 +9003,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9022,7 +9058,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9030,7 +9066,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9045,7 +9081,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9053,7 +9089,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9147,7 +9183,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9155,7 +9191,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9397,7 +9433,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9408,7 +9444,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9497,15 +9533,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i25.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i24.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i24.TimelineChunk?>.value(),
-      ) as _i5.Future<_i24.TimelineChunk?>);
+        returnValue: _i5.Future<_i25.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i25.TimelineChunk?>.value(),
+      ) as _i5.Future<_i25.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9546,7 +9582,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9563,7 +9599,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9627,14 +9663,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9650,14 +9686,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9713,7 +9749,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9721,7 +9757,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10032,14 +10068,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
 class MockSpaceAccessService extends _i1.Mock
     implements _i12.SpaceAccessService {
   @override
-  _i25.JoinMode getJoinMode(_i2.Room? room) => (super.noSuchMethod(
+  _i26.JoinMode getJoinMode(_i2.Room? room) => (super.noSuchMethod(
         Invocation.method(
           #getJoinMode,
           [room],
         ),
-        returnValue: _i25.JoinMode.invite,
-        returnValueForMissingStub: _i25.JoinMode.invite,
-      ) as _i25.JoinMode);
+        returnValue: _i26.JoinMode.invite,
+        returnValueForMissingStub: _i26.JoinMode.invite,
+      ) as _i26.JoinMode);
 
   @override
   List<String> allowedSpaceIds(_i2.Room? room) => (super.noSuchMethod(
@@ -10123,7 +10159,7 @@ class MockSpaceAccessService extends _i1.Mock
   @override
   _i5.Future<void> applyJoinMode({
     required String? roomId,
-    required _i25.JoinMode? mode,
+    required _i26.JoinMode? mode,
     List<String>? allowSpaceIds = const [],
   }) =>
       (super.noSuchMethod(
@@ -10142,7 +10178,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   Map<String, Object?> buildJoinRulesPayload(
-    _i25.JoinMode? mode,
+    _i26.JoinMode? mode,
     List<String>? allowSpaceIds, {
     List<Map<String, Object?>>? preserveEntries = const [],
   }) =>
@@ -10161,7 +10197,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   _i2.StateEvent buildJoinRulesStateEvent(
-    _i25.JoinMode? mode,
+    _i26.JoinMode? mode,
     List<String>? allowSpaceIds,
   ) =>
       (super.noSuchMethod(
@@ -10172,7 +10208,7 @@ class MockSpaceAccessService extends _i1.Mock
             allowSpaceIds,
           ],
         ),
-        returnValue: _FakeStateEvent_79(
+        returnValue: _FakeStateEvent_80(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -10182,7 +10218,7 @@ class MockSpaceAccessService extends _i1.Mock
             ],
           ),
         ),
-        returnValueForMissingStub: _FakeStateEvent_79(
+        returnValueForMissingStub: _FakeStateEvent_80(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -10207,7 +10243,7 @@ class MockSpaceAccessService extends _i1.Mock
             newVersion,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,
@@ -10218,7 +10254,7 @@ class MockSpaceAccessService extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,

--- a/test/widgets/room_members_section_test.mocks.dart
+++ b/test/widgets/room_members_section_test.mocks.dart
@@ -4,13 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -25,14 +26,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i25;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i23;
+import 'package:matrix/src/utils/space_child.dart' as _i24;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -846,8 +847,9 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_75(
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -856,9 +858,19 @@ class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_76 extends _i1.SmartFake
+class _FakeRoomSummary_76 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_76(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_77 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_76(
+  _FakeLatestReceiptState_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,8 +879,8 @@ class _FakeLatestReceiptState_76 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_77(
+class _FakeTimeline_78 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -877,8 +889,8 @@ class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_78(
+class _FakeUser_79 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -887,8 +899,8 @@ class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_79 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_79(
+class _FakeRoom_80 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -915,12 +927,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1040,11 +1052,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1081,11 +1093,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1115,11 +1127,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1128,11 +1140,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1418,34 +1430,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1601,7 +1613,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1890,14 +1902,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2285,8 +2297,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2302,8 +2314,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2344,7 +2356,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2360,7 +2372,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2409,7 +2421,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2430,7 +2442,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2533,7 +2545,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2551,7 +2563,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3070,7 +3082,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3422,7 +3434,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3436,7 +3448,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3587,7 +3599,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4965,7 +4977,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4987,7 +4999,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5481,7 +5493,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5493,7 +5505,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6501,7 +6513,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6512,7 +6524,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6760,7 +6772,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6772,7 +6784,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7032,7 +7044,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7045,7 +7057,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7112,7 +7124,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7125,7 +7137,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7173,7 +7185,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7185,7 +7197,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7433,7 +7445,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7444,7 +7456,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7706,7 +7718,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7733,7 +7745,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7763,11 +7775,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7892,6 +7904,19 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7989,6 +8014,15 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -8033,7 +8067,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8058,6 +8092,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8067,6 +8102,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8127,7 +8163,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8136,7 +8172,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8155,7 +8191,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8166,7 +8202,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8214,7 +8250,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8252,7 +8288,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8261,7 +8297,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8270,16 +8306,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8307,11 +8343,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8341,11 +8377,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_75(
+        returnValue: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_75(
+        returnValueForMissingStub: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
@@ -8398,11 +8434,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8438,11 +8474,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8458,11 +8494,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8471,11 +8507,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8518,11 +8554,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8565,11 +8601,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_76(
+        returnValue: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_76(
+        returnValueForMissingStub: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8788,18 +8824,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i23.SpaceParent>[],
-        returnValueForMissingStub: <_i23.SpaceParent>[],
-      ) as List<_i23.SpaceParent>);
+        returnValue: <_i24.SpaceParent>[],
+        returnValueForMissingStub: <_i24.SpaceParent>[],
+      ) as List<_i24.SpaceParent>);
 
   @override
-  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i23.SpaceChild>[],
-        returnValueForMissingStub: <_i23.SpaceChild>[],
-      ) as List<_i23.SpaceChild>);
+        returnValue: <_i24.SpaceChild>[],
+        returnValueForMissingStub: <_i24.SpaceChild>[],
+      ) as List<_i24.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8966,14 +9002,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9021,7 +9057,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9029,7 +9065,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9044,7 +9080,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9052,7 +9088,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9146,7 +9182,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9154,7 +9190,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9396,7 +9432,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9407,7 +9443,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9496,15 +9532,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i25.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i24.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i24.TimelineChunk?>.value(),
-      ) as _i5.Future<_i24.TimelineChunk?>);
+        returnValue: _i5.Future<_i25.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i25.TimelineChunk?>.value(),
+      ) as _i5.Future<_i25.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9545,7 +9581,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9562,7 +9598,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9626,14 +9662,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9649,14 +9685,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9712,7 +9748,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9720,7 +9756,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10032,11 +10068,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_79(
+        returnValue: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_79(
+        returnValueForMissingStub: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
@@ -10045,11 +10081,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -10115,11 +10151,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -10144,11 +10180,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10166,11 +10202,11 @@ class MockUser extends _i1.Mock implements _i2.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10217,7 +10253,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -10229,7 +10265,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -10299,7 +10335,7 @@ class MockUser extends _i1.Mock implements _i2.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -10312,7 +10348,7 @@ class MockUser extends _i1.Mock implements _i2.User {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,

--- a/test/widgets/room_section_header_test.mocks.dart
+++ b/test/widgets/room_section_header_test.mocks.dart
@@ -4,15 +4,16 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i19;
-import 'dart:ui' as _i21;
+import 'dart:typed_data' as _i20;
+import 'dart:ui' as _i22;
 
-import 'package:flutter/material.dart' as _i25;
-import 'package:flutter/services.dart' as _i22;
-import 'package:flutter/widgets.dart' as _i23;
+import 'package:flutter/material.dart' as _i26;
+import 'package:flutter/services.dart' as _i23;
+import 'package:flutter/widgets.dart' as _i24;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i20;
-import 'package:kohera/core/services/preferences_service.dart' as _i24;
+import 'package:kohera/core/services/matrix_service.dart' as _i21;
+import 'package:kohera/core/services/preferences_service.dart' as _i25;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -23,19 +24,19 @@ import 'package:kohera/core/services/sub_services/space_access_service.dart'
     as _i12;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i13;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i9;
-import 'package:kohera/core/theme/custom_theme.dart' as _i16;
+import 'package:kohera/core/theme/custom_theme.dart' as _i17;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i17;
+import 'package:matrix/encryption.dart' as _i18;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i27;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i28;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i26;
+import 'package:matrix/src/utils/space_child.dart' as _i27;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i18;
+import 'package:mockito/src/dummies.dart' as _i19;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -849,8 +850,9 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
-class _FakeCustomTheme_75 extends _i1.SmartFake implements _i16.CustomTheme {
-  _FakeCustomTheme_75(
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -859,8 +861,8 @@ class _FakeCustomTheme_75 extends _i1.SmartFake implements _i16.CustomTheme {
         );
 }
 
-class _FakeRoomSummary_76 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_76(
+class _FakeCustomTheme_76 extends _i1.SmartFake implements _i17.CustomTheme {
+  _FakeCustomTheme_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -869,9 +871,19 @@ class _FakeRoomSummary_76 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_77 extends _i1.SmartFake
+class _FakeRoomSummary_77 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_77(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_78 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_77(
+  _FakeLatestReceiptState_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -880,8 +892,8 @@ class _FakeLatestReceiptState_77 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_78 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_78(
+class _FakeTimeline_79 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -890,8 +902,8 @@ class _FakeTimeline_78 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_79 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_79(
+class _FakeUser_80 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -918,12 +930,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i17.KeyVerificationMethod> get verificationMethods =>
+  Set<_i18.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i17.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
-      ) as Set<_i17.KeyVerificationMethod>);
+        returnValue: <_i18.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i18.KeyVerificationMethod>{},
+      ) as Set<_i18.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1043,11 +1055,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1084,11 +1096,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1118,11 +1130,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1131,11 +1143,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1421,34 +1433,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i18.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i18.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i18.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i17.KeyVerification>
+  _i3.CachedStreamController<_i18.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i18.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i17.KeyVerification>(
+                _FakeCachedStreamController_6<_i18.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i17.KeyVerification>);
+          ) as _i3.CachedStreamController<_i18.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1604,7 +1616,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i18.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1893,14 +1905,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2288,8 +2300,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValue: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2305,8 +2317,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i18.ifNotNull(
-              _i18.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i19.ifNotNull(
+              _i19.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2347,7 +2359,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2363,7 +2375,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2412,7 +2424,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2433,7 +2445,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2536,7 +2548,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2554,7 +2566,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3073,7 +3085,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i19.Uint8List? file, {
+    _i20.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3425,7 +3437,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3439,7 +3451,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3590,7 +3602,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i19.Uint8List? body,
+    _i20.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4968,7 +4980,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4990,7 +5002,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5484,7 +5496,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5496,7 +5508,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6504,7 +6516,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6515,7 +6527,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6763,7 +6775,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6775,7 +6787,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7035,7 +7047,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7048,7 +7060,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7115,7 +7127,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7128,7 +7140,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7176,7 +7188,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7188,7 +7200,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7436,7 +7448,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7447,7 +7459,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7709,7 +7721,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i19.Uint8List? body, {
+    _i20.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7736,7 +7748,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i21.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7766,11 +7778,11 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7895,6 +7907,19 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7992,6 +8017,15 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -8036,7 +8070,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i22.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8061,6 +8095,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8070,6 +8105,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8130,7 +8166,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8139,7 +8175,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8158,7 +8194,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i23.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8169,7 +8205,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i23.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8217,7 +8253,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i23.RouteInformation? routeInformation) =>
+          _i24.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8255,7 +8291,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i22.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8264,7 +8300,7 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i22.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8273,16 +8309,16 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
       );
 
   @override
-  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i22.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
-      ) as _i5.Future<_i21.AppExitResponse>);
+            _i5.Future<_i22.AppExitResponse>.value(_i22.AppExitResponse.exit),
+      ) as _i5.Future<_i22.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8307,60 +8343,60 @@ class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockPreferencesService extends _i1.Mock
-    implements _i24.PreferencesService {
+    implements _i25.PreferencesService {
   @override
-  _i24.MessageDensity get messageDensity => (super.noSuchMethod(
+  _i25.MessageDensity get messageDensity => (super.noSuchMethod(
         Invocation.getter(#messageDensity),
-        returnValue: _i24.MessageDensity.compact,
-        returnValueForMissingStub: _i24.MessageDensity.compact,
-      ) as _i24.MessageDensity);
+        returnValue: _i25.MessageDensity.compact,
+        returnValueForMissingStub: _i25.MessageDensity.compact,
+      ) as _i25.MessageDensity);
 
   @override
-  _i24.MobileTab get lastMobileTab => (super.noSuchMethod(
+  _i25.MobileTab get lastMobileTab => (super.noSuchMethod(
         Invocation.getter(#lastMobileTab),
-        returnValue: _i24.MobileTab.inbox,
-        returnValueForMissingStub: _i24.MobileTab.inbox,
-      ) as _i24.MobileTab);
+        returnValue: _i25.MobileTab.inbox,
+        returnValueForMissingStub: _i25.MobileTab.inbox,
+      ) as _i25.MobileTab);
 
   @override
-  _i25.ThemeMode get themeMode => (super.noSuchMethod(
+  _i26.ThemeMode get themeMode => (super.noSuchMethod(
         Invocation.getter(#themeMode),
-        returnValue: _i25.ThemeMode.system,
-        returnValueForMissingStub: _i25.ThemeMode.system,
-      ) as _i25.ThemeMode);
+        returnValue: _i26.ThemeMode.system,
+        returnValueForMissingStub: _i26.ThemeMode.system,
+      ) as _i26.ThemeMode);
 
   @override
   String get themeModeLabel => (super.noSuchMethod(
         Invocation.getter(#themeModeLabel),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#themeModeLabel),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#themeModeLabel),
         ),
       ) as String);
 
   @override
-  _i16.CustomTheme get customTheme => (super.noSuchMethod(
+  _i17.CustomTheme get customTheme => (super.noSuchMethod(
         Invocation.getter(#customTheme),
-        returnValue: _FakeCustomTheme_75(
+        returnValue: _FakeCustomTheme_76(
           this,
           Invocation.getter(#customTheme),
         ),
-        returnValueForMissingStub: _FakeCustomTheme_75(
+        returnValueForMissingStub: _FakeCustomTheme_76(
           this,
           Invocation.getter(#customTheme),
         ),
-      ) as _i16.CustomTheme);
+      ) as _i17.CustomTheme);
 
   @override
-  _i25.ThemeMode get customThemeMode => (super.noSuchMethod(
+  _i26.ThemeMode get customThemeMode => (super.noSuchMethod(
         Invocation.getter(#customThemeMode),
-        returnValue: _i25.ThemeMode.system,
-        returnValueForMissingStub: _i25.ThemeMode.system,
-      ) as _i25.ThemeMode);
+        returnValue: _i26.ThemeMode.system,
+        returnValueForMissingStub: _i26.ThemeMode.system,
+      ) as _i26.ThemeMode);
 
   @override
   Set<String> get collapsedSpaceSections => (super.noSuchMethod(
@@ -8391,20 +8427,20 @@ class MockPreferencesService extends _i1.Mock
       ) as double);
 
   @override
-  _i24.NotificationLevel get notificationLevel => (super.noSuchMethod(
+  _i25.NotificationLevel get notificationLevel => (super.noSuchMethod(
         Invocation.getter(#notificationLevel),
-        returnValue: _i24.NotificationLevel.all,
-        returnValueForMissingStub: _i24.NotificationLevel.all,
-      ) as _i24.NotificationLevel);
+        returnValue: _i25.NotificationLevel.all,
+        returnValueForMissingStub: _i25.NotificationLevel.all,
+      ) as _i25.NotificationLevel);
 
   @override
   String get notificationLevelLabel => (super.noSuchMethod(
         Invocation.getter(#notificationLevelLabel),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#notificationLevelLabel),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#notificationLevelLabel),
         ),
@@ -8558,11 +8594,11 @@ class MockPreferencesService extends _i1.Mock
       ) as bool);
 
   @override
-  _i24.AudioQuality get audioQuality => (super.noSuchMethod(
+  _i25.AudioQuality get audioQuality => (super.noSuchMethod(
         Invocation.getter(#audioQuality),
-        returnValue: _i24.AudioQuality.speech,
-        returnValueForMissingStub: _i24.AudioQuality.speech,
-      ) as _i24.AudioQuality);
+        returnValue: _i25.AudioQuality.speech,
+        returnValueForMissingStub: _i25.AudioQuality.speech,
+      ) as _i25.AudioQuality);
 
   @override
   bool get highPassFilter => (super.noSuchMethod(
@@ -8613,7 +8649,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setMessageDensity(_i24.MessageDensity? density) =>
+  _i5.Future<void> setMessageDensity(_i25.MessageDensity? density) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMessageDensity,
@@ -8624,7 +8660,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setLastMobileTab(_i24.MobileTab? tab) => (super.noSuchMethod(
+  _i5.Future<void> setLastMobileTab(_i25.MobileTab? tab) => (super.noSuchMethod(
         Invocation.method(
           #setLastMobileTab,
           [tab],
@@ -8634,7 +8670,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setThemeMode(_i25.ThemeMode? mode) => (super.noSuchMethod(
+  _i5.Future<void> setThemeMode(_i26.ThemeMode? mode) => (super.noSuchMethod(
         Invocation.method(
           #setThemeMode,
           [mode],
@@ -8654,7 +8690,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setCustomTheme(_i16.CustomTheme? theme) =>
+  _i5.Future<void> setCustomTheme(_i17.CustomTheme? theme) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCustomTheme,
@@ -8665,7 +8701,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setCustomThemeMode(_i25.ThemeMode? mode) =>
+  _i5.Future<void> setCustomThemeMode(_i26.ThemeMode? mode) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCustomThemeMode,
@@ -8717,7 +8753,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setNotificationLevel(_i24.NotificationLevel? level) =>
+  _i5.Future<void> setNotificationLevel(_i25.NotificationLevel? level) =>
       (super.noSuchMethod(
         Invocation.method(
           #setNotificationLevel,
@@ -8996,7 +9032,7 @@ class MockPreferencesService extends _i1.Mock
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> setAudioQuality(_i24.AudioQuality? quality) =>
+  _i5.Future<void> setAudioQuality(_i25.AudioQuality? quality) =>
       (super.noSuchMethod(
         Invocation.method(
           #setAudioQuality,
@@ -9057,7 +9093,7 @@ class MockPreferencesService extends _i1.Mock
       ) as bool);
 
   @override
-  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -9066,7 +9102,7 @@ class MockPreferencesService extends _i1.Mock
       );
 
   @override
-  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i22.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -9100,11 +9136,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -9134,11 +9170,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_76(
+        returnValue: _FakeRoomSummary_77(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_76(
+        returnValueForMissingStub: _FakeRoomSummary_77(
           this,
           Invocation.getter(#summary),
         ),
@@ -9191,11 +9227,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -9231,11 +9267,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -9251,11 +9287,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -9264,11 +9300,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -9311,11 +9347,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -9358,11 +9394,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_77(
+        returnValue: _FakeLatestReceiptState_78(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_77(
+        returnValueForMissingStub: _FakeLatestReceiptState_78(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -9581,18 +9617,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i26.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i27.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i26.SpaceParent>[],
-        returnValueForMissingStub: <_i26.SpaceParent>[],
-      ) as List<_i26.SpaceParent>);
+        returnValue: <_i27.SpaceParent>[],
+        returnValueForMissingStub: <_i27.SpaceParent>[],
+      ) as List<_i27.SpaceParent>);
 
   @override
-  List<_i26.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i27.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i26.SpaceChild>[],
-        returnValueForMissingStub: <_i26.SpaceChild>[],
-      ) as List<_i26.SpaceChild>);
+        returnValue: <_i27.SpaceChild>[],
+        returnValueForMissingStub: <_i27.SpaceChild>[],
+      ) as List<_i27.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -9759,14 +9795,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i18.dummyValue<String>(
+        returnValue: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i18.dummyValue<String>(
+        returnValueForMissingStub: _i19.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9814,7 +9850,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9822,7 +9858,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9837,7 +9873,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9845,7 +9881,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9939,7 +9975,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9947,7 +9983,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -10189,7 +10225,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -10200,7 +10236,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -10289,15 +10325,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i27.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i28.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i27.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i27.TimelineChunk?>.value(),
-      ) as _i5.Future<_i27.TimelineChunk?>);
+        returnValue: _i5.Future<_i28.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i28.TimelineChunk?>.value(),
+      ) as _i5.Future<_i28.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -10338,7 +10374,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
           this,
           Invocation.method(
             #getTimeline,
@@ -10355,7 +10391,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_79(
           this,
           Invocation.method(
             #getTimeline,
@@ -10419,14 +10455,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_79(
+        returnValue: _FakeUser_80(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_79(
+        returnValueForMissingStub: _FakeUser_80(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -10442,14 +10478,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_79(
+        returnValue: _FakeUser_80(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_79(
+        returnValueForMissingStub: _FakeUser_80(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -10505,7 +10541,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10513,7 +10549,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i18.dummyValue<String>(
+            _i5.Future<String>.value(_i19.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/room_tile_test.mocks.dart
+++ b/test/widgets/room_tile_test.mocks.dart
@@ -3,16 +3,17 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i14;
-import 'dart:typed_data' as _i24;
-import 'dart:ui' as _i18;
+import 'dart:async' as _i15;
+import 'dart:typed_data' as _i25;
+import 'dart:ui' as _i19;
 
-import 'package:flutter/services.dart' as _i19;
-import 'package:flutter/widgets.dart' as _i20;
-import 'package:http/http.dart' as _i13;
-import 'package:kohera/core/services/call_service.dart' as _i25;
-import 'package:kohera/core/services/matrix_service.dart' as _i16;
-import 'package:kohera/core/services/preferences_service.dart' as _i31;
+import 'package:flutter/services.dart' as _i20;
+import 'package:flutter/widgets.dart' as _i21;
+import 'package:http/http.dart' as _i14;
+import 'package:kohera/core/services/call_service.dart' as _i26;
+import 'package:kohera/core/services/matrix_service.dart' as _i17;
+import 'package:kohera/core/services/preferences_service.dart' as _i32;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i12;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i10;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i6;
@@ -23,24 +24,24 @@ import 'package:kohera/core/services/sub_services/space_access_service.dart'
     as _i8;
 import 'package:kohera/core/services/sub_services/sync_service.dart' as _i9;
 import 'package:kohera/core/services/sub_services/uia_service.dart' as _i5;
-import 'package:kohera/features/calling/models/call_participant.dart' as _i28;
-import 'package:kohera/features/calling/models/call_state.dart' as _i30;
-import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i29;
-import 'package:kohera/features/calling/services/livekit_service.dart' as _i26;
-import 'package:kohera/features/calling/services/ringtone_service.dart' as _i32;
+import 'package:kohera/features/calling/models/call_participant.dart' as _i29;
+import 'package:kohera/features/calling/models/call_state.dart' as _i31;
+import 'package:kohera/features/calling/models/incoming_call_info.dart' as _i30;
+import 'package:kohera/features/calling/services/livekit_service.dart' as _i27;
+import 'package:kohera/features/calling/services/ringtone_service.dart' as _i33;
 import 'package:kohera/features/notifications/services/call_push_rule_manager.dart'
     as _i2;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i3;
-import 'package:livekit_client/livekit_client.dart' as _i27;
-import 'package:matrix/encryption.dart' as _i23;
+import 'package:livekit_client/livekit_client.dart' as _i28;
+import 'package:matrix/encryption.dart' as _i24;
 import 'package:matrix/matrix.dart' as _i4;
-import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i15;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i22;
-import 'package:matrix/src/utils/cached_stream_controller.dart' as _i12;
-import 'package:matrix/src/utils/space_child.dart' as _i21;
+import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i16;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i23;
+import 'package:matrix/src/utils/cached_stream_controller.dart' as _i13;
+import 'package:matrix/src/utils/space_child.dart' as _i22;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -162,8 +163,9 @@ class _FakeOutboxService_9 extends _i1.SmartFake implements _i11.OutboxService {
         );
 }
 
-class _FakeRoomSummary_10 extends _i1.SmartFake implements _i4.RoomSummary {
-  _FakeRoomSummary_10(
+class _FakeStickerPackService_10 extends _i1.SmartFake
+    implements _i12.StickerPackService {
+  _FakeStickerPackService_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -172,9 +174,8 @@ class _FakeRoomSummary_10 extends _i1.SmartFake implements _i4.RoomSummary {
         );
 }
 
-class _FakeCachedStreamController_11<T> extends _i1.SmartFake
-    implements _i12.CachedStreamController<T> {
-  _FakeCachedStreamController_11(
+class _FakeRoomSummary_11 extends _i1.SmartFake implements _i4.RoomSummary {
+  _FakeRoomSummary_11(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -183,8 +184,9 @@ class _FakeCachedStreamController_11<T> extends _i1.SmartFake
         );
 }
 
-class _FakeDateTime_12 extends _i1.SmartFake implements DateTime {
-  _FakeDateTime_12(
+class _FakeCachedStreamController_12<T> extends _i1.SmartFake
+    implements _i13.CachedStreamController<T> {
+  _FakeCachedStreamController_12(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -193,9 +195,19 @@ class _FakeDateTime_12 extends _i1.SmartFake implements DateTime {
         );
 }
 
-class _FakeLatestReceiptState_13 extends _i1.SmartFake
+class _FakeDateTime_13 extends _i1.SmartFake implements DateTime {
+  _FakeDateTime_13(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_14 extends _i1.SmartFake
     implements _i4.LatestReceiptState {
-  _FakeLatestReceiptState_13(
+  _FakeLatestReceiptState_14(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -204,8 +216,8 @@ class _FakeLatestReceiptState_13 extends _i1.SmartFake
         );
 }
 
-class _FakeSyncUpdate_14 extends _i1.SmartFake implements _i4.SyncUpdate {
-  _FakeSyncUpdate_14(
+class _FakeSyncUpdate_15 extends _i1.SmartFake implements _i4.SyncUpdate {
+  _FakeSyncUpdate_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -214,8 +226,8 @@ class _FakeSyncUpdate_14 extends _i1.SmartFake implements _i4.SyncUpdate {
         );
 }
 
-class _FakeTimeline_15 extends _i1.SmartFake implements _i4.Timeline {
-  _FakeTimeline_15(
+class _FakeTimeline_16 extends _i1.SmartFake implements _i4.Timeline {
+  _FakeTimeline_16(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -224,8 +236,8 @@ class _FakeTimeline_15 extends _i1.SmartFake implements _i4.Timeline {
         );
 }
 
-class _FakeUser_16 extends _i1.SmartFake implements _i4.User {
-  _FakeUser_16(
+class _FakeUser_17 extends _i1.SmartFake implements _i4.User {
+  _FakeUser_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -234,8 +246,8 @@ class _FakeUser_16 extends _i1.SmartFake implements _i4.User {
         );
 }
 
-class _FakeUri_17 extends _i1.SmartFake implements Uri {
-  _FakeUri_17(
+class _FakeUri_18 extends _i1.SmartFake implements Uri {
+  _FakeUri_18(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -244,8 +256,8 @@ class _FakeUri_17 extends _i1.SmartFake implements Uri {
         );
 }
 
-class _FakeDatabaseApi_18 extends _i1.SmartFake implements _i4.DatabaseApi {
-  _FakeDatabaseApi_18(
+class _FakeDatabaseApi_19 extends _i1.SmartFake implements _i4.DatabaseApi {
+  _FakeDatabaseApi_19(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -254,8 +266,8 @@ class _FakeDatabaseApi_18 extends _i1.SmartFake implements _i4.DatabaseApi {
         );
 }
 
-class _FakeFilter_19 extends _i1.SmartFake implements _i4.Filter {
-  _FakeFilter_19(
+class _FakeFilter_20 extends _i1.SmartFake implements _i4.Filter {
+  _FakeFilter_20(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -264,9 +276,9 @@ class _FakeFilter_19 extends _i1.SmartFake implements _i4.Filter {
         );
 }
 
-class _FakeNativeImplementations_20 extends _i1.SmartFake
+class _FakeNativeImplementations_21 extends _i1.SmartFake
     implements _i4.NativeImplementations {
-  _FakeNativeImplementations_20(
+  _FakeNativeImplementations_21(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -275,8 +287,8 @@ class _FakeNativeImplementations_20 extends _i1.SmartFake
         );
 }
 
-class _FakeDuration_21 extends _i1.SmartFake implements Duration {
-  _FakeDuration_21(
+class _FakeDuration_22 extends _i1.SmartFake implements Duration {
+  _FakeDuration_22(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -285,9 +297,9 @@ class _FakeDuration_21 extends _i1.SmartFake implements Duration {
         );
 }
 
-class _FakePushruleEvaluator_22 extends _i1.SmartFake
+class _FakePushruleEvaluator_23 extends _i1.SmartFake
     implements _i4.PushruleEvaluator {
-  _FakePushruleEvaluator_22(
+  _FakePushruleEvaluator_23(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -296,8 +308,8 @@ class _FakePushruleEvaluator_22 extends _i1.SmartFake
         );
 }
 
-class _FakeProfile_23 extends _i1.SmartFake implements _i4.Profile {
-  _FakeProfile_23(
+class _FakeProfile_24 extends _i1.SmartFake implements _i4.Profile {
+  _FakeProfile_24(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -306,8 +318,8 @@ class _FakeProfile_23 extends _i1.SmartFake implements _i4.Profile {
         );
 }
 
-class _FakeClient_24 extends _i1.SmartFake implements _i13.Client {
-  _FakeClient_24(
+class _FakeClient_25 extends _i1.SmartFake implements _i14.Client {
+  _FakeClient_25(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -316,9 +328,9 @@ class _FakeClient_24 extends _i1.SmartFake implements _i13.Client {
         );
 }
 
-class _FakeDiscoveryInformation_25 extends _i1.SmartFake
+class _FakeDiscoveryInformation_26 extends _i1.SmartFake
     implements _i4.DiscoveryInformation {
-  _FakeDiscoveryInformation_25(
+  _FakeDiscoveryInformation_26(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -327,9 +339,9 @@ class _FakeDiscoveryInformation_25 extends _i1.SmartFake
         );
 }
 
-class _FakeGetVersionsResponse_26 extends _i1.SmartFake
+class _FakeGetVersionsResponse_27 extends _i1.SmartFake
     implements _i4.GetVersionsResponse {
-  _FakeGetVersionsResponse_26(
+  _FakeGetVersionsResponse_27(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -338,9 +350,9 @@ class _FakeGetVersionsResponse_26 extends _i1.SmartFake
         );
 }
 
-class _FakeRegisterResponse_27 extends _i1.SmartFake
+class _FakeRegisterResponse_28 extends _i1.SmartFake
     implements _i4.RegisterResponse {
-  _FakeRegisterResponse_27(
+  _FakeRegisterResponse_28(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -349,8 +361,8 @@ class _FakeRegisterResponse_27 extends _i1.SmartFake
         );
 }
 
-class _FakeLoginResponse_28 extends _i1.SmartFake implements _i4.LoginResponse {
-  _FakeLoginResponse_28(
+class _FakeLoginResponse_29 extends _i1.SmartFake implements _i4.LoginResponse {
+  _FakeLoginResponse_29(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -359,9 +371,9 @@ class _FakeLoginResponse_28 extends _i1.SmartFake implements _i4.LoginResponse {
         );
 }
 
-class _FakeGetAuthMetadataResponse_29 extends _i1.SmartFake
+class _FakeGetAuthMetadataResponse_30 extends _i1.SmartFake
     implements _i4.GetAuthMetadataResponse {
-  _FakeGetAuthMetadataResponse_29(
+  _FakeGetAuthMetadataResponse_30(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -370,8 +382,8 @@ class _FakeGetAuthMetadataResponse_29 extends _i1.SmartFake
         );
 }
 
-class _FakeFuture_30<T1> extends _i1.SmartFake implements _i14.Future<T1> {
-  _FakeFuture_30(
+class _FakeFuture_31<T1> extends _i1.SmartFake implements _i15.Future<T1> {
+  _FakeFuture_31(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -380,9 +392,9 @@ class _FakeFuture_30<T1> extends _i1.SmartFake implements _i14.Future<T1> {
         );
 }
 
-class _FakeCachedProfileInformation_31 extends _i1.SmartFake
+class _FakeCachedProfileInformation_32 extends _i1.SmartFake
     implements _i4.CachedProfileInformation {
-  _FakeCachedProfileInformation_31(
+  _FakeCachedProfileInformation_32(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -391,8 +403,8 @@ class _FakeCachedProfileInformation_31 extends _i1.SmartFake
         );
 }
 
-class _FakeMediaConfig_32 extends _i1.SmartFake implements _i4.MediaConfig {
-  _FakeMediaConfig_32(
+class _FakeMediaConfig_33 extends _i1.SmartFake implements _i4.MediaConfig {
+  _FakeMediaConfig_33(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -401,8 +413,8 @@ class _FakeMediaConfig_32 extends _i1.SmartFake implements _i4.MediaConfig {
         );
 }
 
-class _FakeFileResponse_33 extends _i1.SmartFake implements _i15.FileResponse {
-  _FakeFileResponse_33(
+class _FakeFileResponse_34 extends _i1.SmartFake implements _i16.FileResponse {
+  _FakeFileResponse_34(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -411,8 +423,8 @@ class _FakeFileResponse_33 extends _i1.SmartFake implements _i15.FileResponse {
         );
 }
 
-class _FakePreviewForUrl_34 extends _i1.SmartFake implements _i4.PreviewForUrl {
-  _FakePreviewForUrl_34(
+class _FakePreviewForUrl_35 extends _i1.SmartFake implements _i4.PreviewForUrl {
+  _FakePreviewForUrl_35(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -421,9 +433,9 @@ class _FakePreviewForUrl_34 extends _i1.SmartFake implements _i4.PreviewForUrl {
         );
 }
 
-class _FakeCachedPresence_35 extends _i1.SmartFake
+class _FakeCachedPresence_36 extends _i1.SmartFake
     implements _i4.CachedPresence {
-  _FakeCachedPresence_35(
+  _FakeCachedPresence_36(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -432,9 +444,9 @@ class _FakeCachedPresence_35 extends _i1.SmartFake
         );
 }
 
-class _FakeTurnServerCredentials_36 extends _i1.SmartFake
+class _FakeTurnServerCredentials_37 extends _i1.SmartFake
     implements _i4.TurnServerCredentials {
-  _FakeTurnServerCredentials_36(
+  _FakeTurnServerCredentials_37(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -443,9 +455,9 @@ class _FakeTurnServerCredentials_36 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeysUpdateResponse_37 extends _i1.SmartFake
+class _FakeRoomKeysUpdateResponse_38 extends _i1.SmartFake
     implements _i4.RoomKeysUpdateResponse {
-  _FakeRoomKeysUpdateResponse_37(
+  _FakeRoomKeysUpdateResponse_38(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -454,8 +466,8 @@ class _FakeRoomKeysUpdateResponse_37 extends _i1.SmartFake
         );
 }
 
-class _FakeKeyBackupData_38 extends _i1.SmartFake implements _i4.KeyBackupData {
-  _FakeKeyBackupData_38(
+class _FakeKeyBackupData_39 extends _i1.SmartFake implements _i4.KeyBackupData {
+  _FakeKeyBackupData_39(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -464,9 +476,9 @@ class _FakeKeyBackupData_38 extends _i1.SmartFake implements _i4.KeyBackupData {
         );
 }
 
-class _FakeGetWellknownSupportResponse_39 extends _i1.SmartFake
+class _FakeGetWellknownSupportResponse_40 extends _i1.SmartFake
     implements _i4.GetWellknownSupportResponse {
-  _FakeGetWellknownSupportResponse_39(
+  _FakeGetWellknownSupportResponse_40(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -475,9 +487,9 @@ class _FakeGetWellknownSupportResponse_39 extends _i1.SmartFake
         );
 }
 
-class _FakeGenerateLoginTokenResponse_40 extends _i1.SmartFake
+class _FakeGenerateLoginTokenResponse_41 extends _i1.SmartFake
     implements _i4.GenerateLoginTokenResponse {
-  _FakeGenerateLoginTokenResponse_40(
+  _FakeGenerateLoginTokenResponse_41(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -486,9 +498,9 @@ class _FakeGenerateLoginTokenResponse_40 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomSummaryResponse$3_41 extends _i1.SmartFake
+class _FakeGetRoomSummaryResponse$3_42 extends _i1.SmartFake
     implements _i4.GetRoomSummaryResponse$3 {
-  _FakeGetRoomSummaryResponse$3_41(
+  _FakeGetRoomSummaryResponse$3_42(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -497,9 +509,9 @@ class _FakeGetRoomSummaryResponse$3_41 extends _i1.SmartFake
         );
 }
 
-class _FakeGetSpaceHierarchyResponse_42 extends _i1.SmartFake
+class _FakeGetSpaceHierarchyResponse_43 extends _i1.SmartFake
     implements _i4.GetSpaceHierarchyResponse {
-  _FakeGetSpaceHierarchyResponse_42(
+  _FakeGetSpaceHierarchyResponse_43(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -508,9 +520,9 @@ class _FakeGetSpaceHierarchyResponse_42 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsResponse_43 extends _i1.SmartFake
+class _FakeGetRelatingEventsResponse_44 extends _i1.SmartFake
     implements _i4.GetRelatingEventsResponse {
-  _FakeGetRelatingEventsResponse_43(
+  _FakeGetRelatingEventsResponse_44(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -519,9 +531,9 @@ class _FakeGetRelatingEventsResponse_43 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeResponse_44 extends _i1.SmartFake
+class _FakeGetRelatingEventsWithRelTypeResponse_45 extends _i1.SmartFake
     implements _i4.GetRelatingEventsWithRelTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeResponse_44(
+  _FakeGetRelatingEventsWithRelTypeResponse_45(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -530,9 +542,9 @@ class _FakeGetRelatingEventsWithRelTypeResponse_44 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45 extends _i1
+class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46 extends _i1
     .SmartFake implements _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse {
-  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
+  _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -541,9 +553,9 @@ class _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45 extends _i1
         );
 }
 
-class _FakeGetThreadRootsResponse_46 extends _i1.SmartFake
+class _FakeGetThreadRootsResponse_47 extends _i1.SmartFake
     implements _i4.GetThreadRootsResponse {
-  _FakeGetThreadRootsResponse_46(
+  _FakeGetThreadRootsResponse_47(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -552,9 +564,9 @@ class _FakeGetThreadRootsResponse_46 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventByTimestampResponse_47 extends _i1.SmartFake
+class _FakeGetEventByTimestampResponse_48 extends _i1.SmartFake
     implements _i4.GetEventByTimestampResponse {
-  _FakeGetEventByTimestampResponse_47(
+  _FakeGetEventByTimestampResponse_48(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -563,9 +575,9 @@ class _FakeGetEventByTimestampResponse_47 extends _i1.SmartFake
         );
 }
 
-class _FakeRequestTokenResponse_48 extends _i1.SmartFake
+class _FakeRequestTokenResponse_49 extends _i1.SmartFake
     implements _i4.RequestTokenResponse {
-  _FakeRequestTokenResponse_48(
+  _FakeRequestTokenResponse_49(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -574,9 +586,9 @@ class _FakeRequestTokenResponse_48 extends _i1.SmartFake
         );
 }
 
-class _FakeTokenOwnerInfo_49 extends _i1.SmartFake
+class _FakeTokenOwnerInfo_50 extends _i1.SmartFake
     implements _i4.TokenOwnerInfo {
-  _FakeTokenOwnerInfo_49(
+  _FakeTokenOwnerInfo_50(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -585,8 +597,8 @@ class _FakeTokenOwnerInfo_49 extends _i1.SmartFake
         );
 }
 
-class _FakeWhoIsInfo_50 extends _i1.SmartFake implements _i4.WhoIsInfo {
-  _FakeWhoIsInfo_50(
+class _FakeWhoIsInfo_51 extends _i1.SmartFake implements _i4.WhoIsInfo {
+  _FakeWhoIsInfo_51(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -595,8 +607,8 @@ class _FakeWhoIsInfo_50 extends _i1.SmartFake implements _i4.WhoIsInfo {
         );
 }
 
-class _FakeCapabilities_51 extends _i1.SmartFake implements _i4.Capabilities {
-  _FakeCapabilities_51(
+class _FakeCapabilities_52 extends _i1.SmartFake implements _i4.Capabilities {
+  _FakeCapabilities_52(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -605,8 +617,8 @@ class _FakeCapabilities_51 extends _i1.SmartFake implements _i4.Capabilities {
         );
 }
 
-class _FakeDevice_52 extends _i1.SmartFake implements _i4.Device {
-  _FakeDevice_52(
+class _FakeDevice_53 extends _i1.SmartFake implements _i4.Device {
+  _FakeDevice_53(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -615,9 +627,9 @@ class _FakeDevice_52 extends _i1.SmartFake implements _i4.Device {
         );
 }
 
-class _FakeGetRoomIdByAliasResponse_53 extends _i1.SmartFake
+class _FakeGetRoomIdByAliasResponse_54 extends _i1.SmartFake
     implements _i4.GetRoomIdByAliasResponse {
-  _FakeGetRoomIdByAliasResponse_53(
+  _FakeGetRoomIdByAliasResponse_54(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -626,9 +638,9 @@ class _FakeGetRoomIdByAliasResponse_53 extends _i1.SmartFake
         );
 }
 
-class _FakeGetEventsResponse_54 extends _i1.SmartFake
+class _FakeGetEventsResponse_55 extends _i1.SmartFake
     implements _i4.GetEventsResponse {
-  _FakeGetEventsResponse_54(
+  _FakeGetEventsResponse_55(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -637,9 +649,9 @@ class _FakeGetEventsResponse_54 extends _i1.SmartFake
         );
 }
 
-class _FakePeekEventsResponse_55 extends _i1.SmartFake
+class _FakePeekEventsResponse_56 extends _i1.SmartFake
     implements _i4.PeekEventsResponse {
-  _FakePeekEventsResponse_55(
+  _FakePeekEventsResponse_56(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -648,8 +660,8 @@ class _FakePeekEventsResponse_55 extends _i1.SmartFake
         );
 }
 
-class _FakeMatrixEvent_56 extends _i1.SmartFake implements _i4.MatrixEvent {
-  _FakeMatrixEvent_56(
+class _FakeMatrixEvent_57 extends _i1.SmartFake implements _i4.MatrixEvent {
+  _FakeMatrixEvent_57(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -658,9 +670,9 @@ class _FakeMatrixEvent_56 extends _i1.SmartFake implements _i4.MatrixEvent {
         );
 }
 
-class _FakeGetKeysChangesResponse_57 extends _i1.SmartFake
+class _FakeGetKeysChangesResponse_58 extends _i1.SmartFake
     implements _i4.GetKeysChangesResponse {
-  _FakeGetKeysChangesResponse_57(
+  _FakeGetKeysChangesResponse_58(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -669,9 +681,9 @@ class _FakeGetKeysChangesResponse_57 extends _i1.SmartFake
         );
 }
 
-class _FakeClaimKeysResponse_58 extends _i1.SmartFake
+class _FakeClaimKeysResponse_59 extends _i1.SmartFake
     implements _i4.ClaimKeysResponse {
-  _FakeClaimKeysResponse_58(
+  _FakeClaimKeysResponse_59(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -680,9 +692,9 @@ class _FakeClaimKeysResponse_58 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryKeysResponse_59 extends _i1.SmartFake
+class _FakeQueryKeysResponse_60 extends _i1.SmartFake
     implements _i4.QueryKeysResponse {
-  _FakeQueryKeysResponse_59(
+  _FakeQueryKeysResponse_60(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -691,9 +703,9 @@ class _FakeQueryKeysResponse_59 extends _i1.SmartFake
         );
 }
 
-class _FakeGetNotificationsResponse_60 extends _i1.SmartFake
+class _FakeGetNotificationsResponse_61 extends _i1.SmartFake
     implements _i4.GetNotificationsResponse {
-  _FakeGetNotificationsResponse_60(
+  _FakeGetNotificationsResponse_61(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -702,9 +714,9 @@ class _FakeGetNotificationsResponse_60 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPresenceResponse_61 extends _i1.SmartFake
+class _FakeGetPresenceResponse_62 extends _i1.SmartFake
     implements _i4.GetPresenceResponse {
-  _FakeGetPresenceResponse_61(
+  _FakeGetPresenceResponse_62(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -713,9 +725,9 @@ class _FakeGetPresenceResponse_61 extends _i1.SmartFake
         );
 }
 
-class _FakeGetPublicRoomsResponse_62 extends _i1.SmartFake
+class _FakeGetPublicRoomsResponse_63 extends _i1.SmartFake
     implements _i4.GetPublicRoomsResponse {
-  _FakeGetPublicRoomsResponse_62(
+  _FakeGetPublicRoomsResponse_63(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -724,9 +736,9 @@ class _FakeGetPublicRoomsResponse_62 extends _i1.SmartFake
         );
 }
 
-class _FakeQueryPublicRoomsResponse_63 extends _i1.SmartFake
+class _FakeQueryPublicRoomsResponse_64 extends _i1.SmartFake
     implements _i4.QueryPublicRoomsResponse {
-  _FakeQueryPublicRoomsResponse_63(
+  _FakeQueryPublicRoomsResponse_64(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -735,8 +747,8 @@ class _FakeQueryPublicRoomsResponse_63 extends _i1.SmartFake
         );
 }
 
-class _FakePushRuleSet_64 extends _i1.SmartFake implements _i4.PushRuleSet {
-  _FakePushRuleSet_64(
+class _FakePushRuleSet_65 extends _i1.SmartFake implements _i4.PushRuleSet {
+  _FakePushRuleSet_65(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -745,9 +757,9 @@ class _FakePushRuleSet_64 extends _i1.SmartFake implements _i4.PushRuleSet {
         );
 }
 
-class _FakeGetPushRulesGlobalResponse_65 extends _i1.SmartFake
+class _FakeGetPushRulesGlobalResponse_66 extends _i1.SmartFake
     implements _i4.GetPushRulesGlobalResponse {
-  _FakeGetPushRulesGlobalResponse_65(
+  _FakeGetPushRulesGlobalResponse_66(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -756,8 +768,8 @@ class _FakeGetPushRulesGlobalResponse_65 extends _i1.SmartFake
         );
 }
 
-class _FakePushRule_66 extends _i1.SmartFake implements _i4.PushRule {
-  _FakePushRule_66(
+class _FakePushRule_67 extends _i1.SmartFake implements _i4.PushRule {
+  _FakePushRule_67(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -766,9 +778,9 @@ class _FakePushRule_66 extends _i1.SmartFake implements _i4.PushRule {
         );
 }
 
-class _FakeRefreshResponse_67 extends _i1.SmartFake
+class _FakeRefreshResponse_68 extends _i1.SmartFake
     implements _i4.RefreshResponse {
-  _FakeRefreshResponse_67(
+  _FakeRefreshResponse_68(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -777,8 +789,8 @@ class _FakeRefreshResponse_67 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomKeys_68 extends _i1.SmartFake implements _i4.RoomKeys {
-  _FakeRoomKeys_68(
+class _FakeRoomKeys_69 extends _i1.SmartFake implements _i4.RoomKeys {
+  _FakeRoomKeys_69(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -787,8 +799,8 @@ class _FakeRoomKeys_68 extends _i1.SmartFake implements _i4.RoomKeys {
         );
 }
 
-class _FakeRoomKeyBackup_69 extends _i1.SmartFake implements _i4.RoomKeyBackup {
-  _FakeRoomKeyBackup_69(
+class _FakeRoomKeyBackup_70 extends _i1.SmartFake implements _i4.RoomKeyBackup {
+  _FakeRoomKeyBackup_70(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -797,9 +809,9 @@ class _FakeRoomKeyBackup_69 extends _i1.SmartFake implements _i4.RoomKeyBackup {
         );
 }
 
-class _FakeGetRoomKeysVersionCurrentResponse_70 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionCurrentResponse_71 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionCurrentResponse {
-  _FakeGetRoomKeysVersionCurrentResponse_70(
+  _FakeGetRoomKeysVersionCurrentResponse_71(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -808,9 +820,9 @@ class _FakeGetRoomKeysVersionCurrentResponse_70 extends _i1.SmartFake
         );
 }
 
-class _FakeGetRoomKeysVersionResponse_71 extends _i1.SmartFake
+class _FakeGetRoomKeysVersionResponse_72 extends _i1.SmartFake
     implements _i4.GetRoomKeysVersionResponse {
-  _FakeGetRoomKeysVersionResponse_71(
+  _FakeGetRoomKeysVersionResponse_72(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -819,8 +831,8 @@ class _FakeGetRoomKeysVersionResponse_71 extends _i1.SmartFake
         );
 }
 
-class _FakeEventContext_72 extends _i1.SmartFake implements _i4.EventContext {
-  _FakeEventContext_72(
+class _FakeEventContext_73 extends _i1.SmartFake implements _i4.EventContext {
+  _FakeEventContext_73(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -829,9 +841,9 @@ class _FakeEventContext_72 extends _i1.SmartFake implements _i4.EventContext {
         );
 }
 
-class _FakeGetRoomEventsResponse_73 extends _i1.SmartFake
+class _FakeGetRoomEventsResponse_74 extends _i1.SmartFake
     implements _i4.GetRoomEventsResponse {
-  _FakeGetRoomEventsResponse_73(
+  _FakeGetRoomEventsResponse_74(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -840,8 +852,8 @@ class _FakeGetRoomEventsResponse_73 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchResults_74 extends _i1.SmartFake implements _i4.SearchResults {
-  _FakeSearchResults_74(
+class _FakeSearchResults_75 extends _i1.SmartFake implements _i4.SearchResults {
+  _FakeSearchResults_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -850,9 +862,9 @@ class _FakeSearchResults_74 extends _i1.SmartFake implements _i4.SearchResults {
         );
 }
 
-class _FakeGetProtocolMetadataResponse$2_75 extends _i1.SmartFake
+class _FakeGetProtocolMetadataResponse$2_76 extends _i1.SmartFake
     implements _i4.GetProtocolMetadataResponse$2 {
-  _FakeGetProtocolMetadataResponse$2_75(
+  _FakeGetProtocolMetadataResponse$2_76(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -861,9 +873,9 @@ class _FakeGetProtocolMetadataResponse$2_75 extends _i1.SmartFake
         );
 }
 
-class _FakeOpenIdCredentials_76 extends _i1.SmartFake
+class _FakeOpenIdCredentials_77 extends _i1.SmartFake
     implements _i4.OpenIdCredentials {
-  _FakeOpenIdCredentials_76(
+  _FakeOpenIdCredentials_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -872,9 +884,9 @@ class _FakeOpenIdCredentials_76 extends _i1.SmartFake
         );
 }
 
-class _FakeSearchUserDirectoryResponse_77 extends _i1.SmartFake
+class _FakeSearchUserDirectoryResponse_78 extends _i1.SmartFake
     implements _i4.SearchUserDirectoryResponse {
-  _FakeSearchUserDirectoryResponse_77(
+  _FakeSearchUserDirectoryResponse_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -883,9 +895,9 @@ class _FakeSearchUserDirectoryResponse_77 extends _i1.SmartFake
         );
 }
 
-class _FakeCreateContentResponse_78 extends _i1.SmartFake
+class _FakeCreateContentResponse_79 extends _i1.SmartFake
     implements _i4.CreateContentResponse {
-  _FakeCreateContentResponse_78(
+  _FakeCreateContentResponse_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -894,8 +906,8 @@ class _FakeCreateContentResponse_78 extends _i1.SmartFake
         );
 }
 
-class _FakeRoom_79 extends _i1.SmartFake implements _i4.Room {
-  _FakeRoom_79(
+class _FakeRoom_80 extends _i1.SmartFake implements _i4.Room {
+  _FakeRoom_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -904,8 +916,8 @@ class _FakeRoom_79 extends _i1.SmartFake implements _i4.Room {
         );
 }
 
-class _FakeMatrixFile_80 extends _i1.SmartFake implements _i4.MatrixFile {
-  _FakeMatrixFile_80(
+class _FakeMatrixFile_81 extends _i1.SmartFake implements _i4.MatrixFile {
+  _FakeMatrixFile_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -914,8 +926,8 @@ class _FakeMatrixFile_80 extends _i1.SmartFake implements _i4.MatrixFile {
         );
 }
 
-class _FakeEvent_81 extends _i1.SmartFake implements _i4.Event {
-  _FakeEvent_81(
+class _FakeEvent_82 extends _i1.SmartFake implements _i4.Event {
+  _FakeEvent_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -924,8 +936,8 @@ class _FakeEvent_81 extends _i1.SmartFake implements _i4.Event {
         );
 }
 
-class _FakeResponse_82 extends _i1.SmartFake implements _i13.Response {
-  _FakeResponse_82(
+class _FakeResponse_83 extends _i1.SmartFake implements _i14.Response {
+  _FakeResponse_83(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -937,7 +949,7 @@ class _FakeResponse_82 extends _i1.SmartFake implements _i13.Response {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i17.MatrixService {
   @override
   _i2.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -967,11 +979,11 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1096,6 +1108,19 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as _i11.OutboxService);
 
   @override
+  _i12.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_10(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i12.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -1193,6 +1218,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
+  set stickerPacks(_i12.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -1200,14 +1234,14 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  _i14.Future<void> activateSessionForTest() => (super.noSuchMethod(
+  _i15.Future<void> activateSessionForTest() => (super.noSuchMethod(
         Invocation.method(
           #activateSessionForTest,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void notifyListeners() => super.noSuchMethod(
@@ -1237,7 +1271,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -1247,21 +1281,22 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
+  _i15.Future<void> init({bool? restoreSession = true}) => (super.noSuchMethod(
         Invocation.method(
           #init,
           [],
           {#restoreSession: restoreSession},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> login({
+  _i15.Future<bool> login({
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -1271,14 +1306,15 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> completeSsoLogin({
+  _i15.Future<bool> completeSsoLogin({
     required String? homeserver,
     required String? loginToken,
   }) =>
@@ -1291,12 +1327,12 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
             #loginToken: loginToken,
           },
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> completeRegistration(
+  _i15.Future<void> completeRegistration(
     _i4.RegisterResponse? response, {
     String? password,
   }) =>
@@ -1306,32 +1342,32 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
           [response],
           {#password: password},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSoftLogout() => (super.noSuchMethod(
+  _i15.Future<void> handleSoftLogout() => (super.noSuchMethod(
         Invocation.method(
           #handleSoftLogout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -1340,7 +1376,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -1349,17 +1385,17 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i15.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -1370,7 +1406,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -1407,26 +1443,26 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i15.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+  _i15.Future<bool> didPushRouteInformation(
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -1456,7 +1492,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -1465,7 +1501,7 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -1474,16 +1510,16 @@ class MockMatrixService extends _i1.Mock implements _i16.MatrixService {
       );
 
   @override
-  _i14.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i15.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i15.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i14.Future<_i18.AppExitResponse>);
+            _i15.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i15.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -1511,11 +1547,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -1545,11 +1581,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_10(
+        returnValue: _FakeRoomSummary_11(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_10(
+        returnValueForMissingStub: _FakeRoomSummary_11(
           this,
           Invocation.getter(#summary),
         ),
@@ -1579,11 +1615,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, _i4.BasicEvent>);
 
   @override
-  List<_i14.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
+  List<_i15.Completer<dynamic>> get sendingQueue => (super.noSuchMethod(
         Invocation.getter(#sendingQueue),
-        returnValue: <_i14.Completer<dynamic>>[],
-        returnValueForMissingStub: <_i14.Completer<dynamic>>[],
-      ) as List<_i14.Completer<dynamic>>);
+        returnValue: <_i15.Completer<dynamic>>[],
+        returnValueForMissingStub: <_i15.Completer<dynamic>>[],
+      ) as List<_i15.Completer<dynamic>>);
 
   @override
   List<String> get sendingQueueEventsByTxId => (super.noSuchMethod(
@@ -1602,51 +1638,51 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
       ) as String);
 
   @override
-  _i12.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
+  _i13.CachedStreamController<String> get onUpdate => (super.noSuchMethod(
         Invocation.getter(#onUpdate),
-        returnValue: _FakeCachedStreamController_11<String>(
+        returnValue: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onUpdate),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i12.CachedStreamController<String> get onSessionKeyReceived =>
+  _i13.CachedStreamController<String> get onSessionKeyReceived =>
       (super.noSuchMethod(
         Invocation.getter(#onSessionKeyReceived),
-        returnValue: _FakeCachedStreamController_11<String>(
+        returnValue: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onSessionKeyReceived),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -1662,11 +1698,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -1675,11 +1711,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -1722,11 +1758,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -1735,11 +1771,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   DateTime get latestEventReceivedTime => (super.noSuchMethod(
         Invocation.getter(#latestEventReceivedTime),
-        returnValue: _FakeDateTime_12(
+        returnValue: _FakeDateTime_13(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
-        returnValueForMissingStub: _FakeDateTime_12(
+        returnValueForMissingStub: _FakeDateTime_13(
           this,
           Invocation.getter(#latestEventReceivedTime),
         ),
@@ -1769,11 +1805,11 @@ class MockRoom extends _i1.Mock implements _i4.Room {
   @override
   _i4.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_13(
+        returnValue: _FakeLatestReceiptState_14(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_13(
+        returnValueForMissingStub: _FakeLatestReceiptState_14(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -1794,18 +1830,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i14.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
+  _i15.Future<_i4.SyncUpdate> get waitForSync => (super.noSuchMethod(
         Invocation.getter(#waitForSync),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.getter(#waitForSync),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.getter(#waitForSync),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
   bool get isFavourite => (super.noSuchMethod(
@@ -1992,18 +2028,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  List<_i21.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i22.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i21.SpaceParent>[],
-        returnValueForMissingStub: <_i21.SpaceParent>[],
-      ) as List<_i21.SpaceParent>);
+        returnValue: <_i22.SpaceParent>[],
+        returnValueForMissingStub: <_i22.SpaceParent>[],
+      ) as List<_i22.SpaceParent>);
 
   @override
-  List<_i21.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i22.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i21.SpaceChild>[],
-        returnValueForMissingStub: <_i21.SpaceChild>[],
-      ) as List<_i21.SpaceChild>);
+        returnValue: <_i22.SpaceChild>[],
+        returnValueForMissingStub: <_i22.SpaceChild>[],
+      ) as List<_i22.SpaceChild>);
 
   @override
   set membership(_i4.Membership? value) => super.noSuchMethod(
@@ -2116,14 +2152,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as Map<String, dynamic>);
 
   @override
-  _i14.Future<void> postLoad() => (super.noSuchMethod(
+  _i15.Future<void> postLoad() => (super.noSuchMethod(
         Invocation.method(
           #postLoad,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   _i4.StrippedStateEvent? getState(
@@ -2151,15 +2187,15 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i14.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
+  _i15.Future<List<_i4.User>> loadHeroUsers() => (super.noSuchMethod(
         Invocation.method(
           #loadHeroUsers,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i14.Future<List<_i4.User>>);
+            _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i15.Future<List<_i4.User>>);
 
   @override
   String getLocalizedDisplayname(
@@ -2170,14 +2206,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -2187,18 +2223,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String);
 
   @override
-  _i14.Future<void> setCanonicalAlias(String? canonicalAlias) =>
+  _i15.Future<void> setCanonicalAlias(String? canonicalAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #setCanonicalAlias,
           [canonicalAlias],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Event?> refreshLastEvent(
+  _i15.Future<_i4.Event?> refreshLastEvent(
           {Duration? timeout = const Duration(seconds: 30)}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -2206,9 +2242,9 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
   void setEphemeral(_i4.BasicEvent? ephemeral) => super.noSuchMethod(
@@ -2220,12 +2256,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       );
 
   @override
-  _i14.Future<String> setName(String? newName) => (super.noSuchMethod(
+  _i15.Future<String> setName(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setName,
           [newName],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -2233,22 +2269,22 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
             [newName],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> setDescription(String? newName) => (super.noSuchMethod(
+  _i15.Future<String> setDescription(String? newName) => (super.noSuchMethod(
         Invocation.method(
           #setDescription,
           [newName],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -2256,17 +2292,17 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
             [newName],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> addTag(
+  _i15.Future<void> addTag(
     String? tag, {
     double? order,
   }) =>
@@ -2276,27 +2312,27 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [tag],
           {#order: order},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> removeTag(String? tag) => (super.noSuchMethod(
+  _i15.Future<void> removeTag(String? tag) => (super.noSuchMethod(
         Invocation.method(
           #removeTag,
           [tag],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
+  _i15.Future<_i4.SyncUpdate> waitForRoomInSync() => (super.noSuchMethod(
         Invocation.method(
           #waitForRoomInSync,
           [],
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -2304,53 +2340,53 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
+  _i15.Future<void> markUnread(bool? unread) => (super.noSuchMethod(
         Invocation.method(
           #markUnread,
           [unread],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
+  _i15.Future<void> setFavourite(bool? favourite) => (super.noSuchMethod(
         Invocation.method(
           #setFavourite,
           [favourite],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
+  _i15.Future<void> setLowPriority(bool? lowPriority) => (super.noSuchMethod(
         Invocation.method(
           #setLowPriority,
           [lowPriority],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
+  _i15.Future<String> setPinnedEvents(List<String>? pinnedEventIds) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -2358,14 +2394,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
             [pinnedEventIds],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
   String? getMention(String? mention) => (super.noSuchMethod(
@@ -2377,7 +2413,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as String?);
 
   @override
-  _i14.Future<String?> sendTextEvent(
+  _i15.Future<String?> sendTextEvent(
     String? message, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2409,12 +2445,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendReaction(
+  _i15.Future<String?> sendReaction(
     String? eventId,
     String? key, {
     String? txid,
@@ -2428,12 +2464,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendLocation(
+  _i15.Future<String?> sendLocation(
     String? body,
     String? geoUri, {
     String? txid,
@@ -2447,12 +2483,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ],
           {#txid: txid},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> sendFileEvent(
+  _i15.Future<String?> sendFileEvent(
     _i4.MatrixFile? file, {
     String? txid,
     _i4.Event? inReplyTo,
@@ -2480,25 +2516,25 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
+  _i15.Future<_i4.EncryptionHealthState> calcEncryptionHealthState() =>
       (super.noSuchMethod(
         Invocation.method(
           #calcEncryptionHealthState,
           [],
         ),
-        returnValue: _i14.Future<_i4.EncryptionHealthState>.value(
+        returnValue: _i15.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-        returnValueForMissingStub: _i14.Future<_i4.EncryptionHealthState>.value(
+        returnValueForMissingStub: _i15.Future<_i4.EncryptionHealthState>.value(
             _i4.EncryptionHealthState.allVerified),
-      ) as _i14.Future<_i4.EncryptionHealthState>);
+      ) as _i15.Future<_i4.EncryptionHealthState>);
 
   @override
-  _i14.Future<String?> sendEvent(
+  _i15.Future<String?> sendEvent(
     Map<String, dynamic>? content, {
     String? type = 'm.room.message',
     String? txid,
@@ -2522,73 +2558,73 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #displayPendingEvent: displayPendingEvent,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
+  _i15.Future<void> join({bool? leaveIfNotFound = true}) => (super.noSuchMethod(
         Invocation.method(
           #join,
           [],
           {#leaveIfNotFound: leaveIfNotFound},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> leave() => (super.noSuchMethod(
+  _i15.Future<void> leave() => (super.noSuchMethod(
         Invocation.method(
           #leave,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> forget() => (super.noSuchMethod(
+  _i15.Future<void> forget() => (super.noSuchMethod(
         Invocation.method(
           #forget,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> kick(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> kick(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ban(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> ban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> unban(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> unban(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> setPower(
+  _i15.Future<String> setPower(
     String? userId,
     int? power,
   ) =>
@@ -2600,7 +2636,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             power,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2611,7 +2647,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -2621,10 +2657,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> invite(
+  _i15.Future<void> invite(
     String? userID, {
     String? reason,
   }) =>
@@ -2634,12 +2670,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [userID],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<int> requestHistory({
+  _i15.Future<int> requestHistory({
     int? historyCount = 30,
     void Function()? onHistoryReceived,
     dynamic direction = _i4.Direction.b,
@@ -2656,32 +2692,32 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<int>.value(0),
-        returnValueForMissingStub: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+        returnValueForMissingStub: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
-  _i14.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
+  _i15.Future<void> addToDirectChat(String? userID) => (super.noSuchMethod(
         Invocation.method(
           #addToDirectChat,
           [userID],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> removeFromDirectChat() => (super.noSuchMethod(
+  _i15.Future<void> removeFromDirectChat() => (super.noSuchMethod(
         Invocation.method(
           #removeFromDirectChat,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setReadMarker(
+  _i15.Future<void> setReadMarker(
     String? eventId, {
     String? mRead,
     bool? public,
@@ -2695,23 +2731,23 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #public: public,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i22.TimelineChunk?> getEventContext(String? eventId) =>
+  _i15.Future<_i23.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i14.Future<_i22.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i14.Future<_i22.TimelineChunk?>.value(),
-      ) as _i14.Future<_i22.TimelineChunk?>);
+        returnValue: _i15.Future<_i23.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i15.Future<_i23.TimelineChunk?>.value(),
+      ) as _i15.Future<_i23.TimelineChunk?>);
 
   @override
-  _i14.Future<void> postReceipt(
+  _i15.Future<void> postReceipt(
     String? eventId, {
     _i4.ReceiptType? type = _i4.ReceiptType.mRead,
   }) =>
@@ -2721,12 +2757,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [eventId],
           {#type: type},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Timeline> getTimeline({
+  _i15.Future<_i4.Timeline> getTimeline({
     void Function(int)? onChange,
     void Function(int)? onRemove,
     void Function(int)? onInsert,
@@ -2749,7 +2785,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i14.Future<_i4.Timeline>.value(_FakeTimeline_15(
+        returnValue: _i15.Future<_i4.Timeline>.value(_FakeTimeline_16(
           this,
           Invocation.method(
             #getTimeline,
@@ -2766,7 +2802,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Timeline>.value(_FakeTimeline_15(
+            _i15.Future<_i4.Timeline>.value(_FakeTimeline_16(
           this,
           Invocation.method(
             #getTimeline,
@@ -2782,7 +2818,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Timeline>);
+      ) as _i15.Future<_i4.Timeline>);
 
   @override
   List<_i4.User> getParticipants(
@@ -2801,7 +2837,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as List<_i4.User>);
 
   @override
-  _i14.Future<List<_i4.User>> requestParticipants([
+  _i15.Future<List<_i4.User>> requestParticipants([
     List<_i4.Membership>? membershipFilter = const [
       _i4.Membership.join,
       _i4.Membership.invite,
@@ -2819,10 +2855,10 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             cache,
           ],
         ),
-        returnValue: _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
+        returnValue: _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.User>>.value(<_i4.User>[]),
-      ) as _i14.Future<List<_i4.User>>);
+            _i15.Future<List<_i4.User>>.value(<_i4.User>[]),
+      ) as _i15.Future<List<_i4.User>>);
 
   @override
   _i4.User getUserByMXIDSync(String? mxID) => (super.noSuchMethod(
@@ -2830,14 +2866,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_16(
+        returnValue: _FakeUser_17(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_16(
+        returnValueForMissingStub: _FakeUser_17(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -2853,14 +2889,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_16(
+        returnValue: _FakeUser_17(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_16(
+        returnValueForMissingStub: _FakeUser_17(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -2870,7 +2906,7 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as _i4.User);
 
   @override
-  _i14.Future<_i4.User?> requestUser(
+  _i15.Future<_i4.User?> requestUser(
     String? mxID, {
     bool? ignoreErrors = false,
     bool? requestState = true,
@@ -2886,19 +2922,19 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #requestProfile: requestProfile,
           },
         ),
-        returnValue: _i14.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.User?>.value(),
-      ) as _i14.Future<_i4.User?>);
+        returnValue: _i15.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.User?>.value(),
+      ) as _i15.Future<_i4.User?>);
 
   @override
-  _i14.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
+  _i15.Future<_i4.Event?> getEventById(String? eventID) => (super.noSuchMethod(
         Invocation.method(
           #getEventById,
           [eventID],
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
   int getPowerLevelByUserId(String? userId) => (super.noSuchMethod(
@@ -2911,12 +2947,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i14.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i15.Future<String> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -2924,14 +2960,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
             [file],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
   bool canChangeStateEvent(String? action) => (super.noSuchMethod(
@@ -2954,14 +2990,14 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as int);
 
   @override
-  _i14.Future<void> enableGroupCalls() => (super.noSuchMethod(
+  _i15.Future<void> enableGroupCalls() => (super.noSuchMethod(
         Invocation.method(
           #enableGroupCalls,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   int getDefaultPowerLevel(Map<String, dynamic>? powerLevelMap) =>
@@ -3000,18 +3036,18 @@ class MockRoom extends _i1.Mock implements _i4.Room {
       ) as bool);
 
   @override
-  _i14.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
+  _i15.Future<void> setPushRuleState(_i4.PushRuleState? newState) =>
       (super.noSuchMethod(
         Invocation.method(
           #setPushRuleState,
           [newState],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEvent(
+  _i15.Future<String?> redactEvent(
     String? eventId, {
     String? reason,
     String? txid,
@@ -3025,12 +3061,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #txid: txid,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> setTyping(
+  _i15.Future<void> setTyping(
     bool? isTyping, {
     int? timeout,
   }) =>
@@ -3040,12 +3076,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
           [isTyping],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setJoinRules(
+  _i15.Future<void> setJoinRules(
     _i4.JoinRules? joinRules, {
     List<String>? allowConditionRoomIds,
     String? allowConditionRoomId,
@@ -3059,59 +3095,59 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #allowConditionRoomId: allowConditionRoomId,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
+  _i15.Future<void> setGuestAccess(_i4.GuestAccess? guestAccess) =>
       (super.noSuchMethod(
         Invocation.method(
           #setGuestAccess,
           [guestAccess],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setHistoryVisibility(
+  _i15.Future<void> setHistoryVisibility(
           _i4.HistoryVisibility? historyVisibility) =>
       (super.noSuchMethod(
         Invocation.method(
           #setHistoryVisibility,
           [historyVisibility],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
+  _i15.Future<void> enableEncryption({int? algorithmIndex = 0}) =>
       (super.noSuchMethod(
         Invocation.method(
           #enableEncryption,
           [],
           {#algorithmIndex: algorithmIndex},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
+  _i15.Future<List<_i4.DeviceKeys>> getUserDeviceKeys() => (super.noSuchMethod(
         Invocation.method(
           #getUserDeviceKeys,
           [],
         ),
         returnValue:
-            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+            _i15.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
-      ) as _i14.Future<List<_i4.DeviceKeys>>);
+            _i15.Future<List<_i4.DeviceKeys>>.value(<_i4.DeviceKeys>[]),
+      ) as _i15.Future<List<_i4.DeviceKeys>>);
 
   @override
-  _i14.Future<void> requestSessionKey(
+  _i15.Future<void> requestSessionKey(
     String? sessionId,
     String? senderKey,
   ) =>
@@ -3123,12 +3159,12 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             senderKey,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setSpaceChild(
+  _i15.Future<void> setSpaceChild(
     String? roomId, {
     List<String>? via,
     String? order,
@@ -3144,44 +3180,44 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #suggested: suggested,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
+  _i15.Future<Uri> matrixToInviteLink() => (super.noSuchMethod(
         Invocation.method(
           #matrixToInviteLink,
           [],
         ),
-        returnValue: _i14.Future<Uri>.value(_FakeUri_17(
+        returnValue: _i15.Future<Uri>.value(_FakeUri_18(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_17(
+        returnValueForMissingStub: _i15.Future<Uri>.value(_FakeUri_18(
           this,
           Invocation.method(
             #matrixToInviteLink,
             [],
           ),
         )),
-      ) as _i14.Future<Uri>);
+      ) as _i15.Future<Uri>);
 
   @override
-  _i14.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> removeSpaceChild(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #removeSpaceChild,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<
+  _i15.Future<
       ({
         List<_i4.Event> events,
         String? nextBatch,
@@ -3208,21 +3244,21 @@ class MockRoom extends _i1.Mock implements _i4.Room {
             #includeEventTypes: includeEventTypes,
           },
         ),
-        returnValue: _i14.Future<
+        returnValue: _i15.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-        returnValueForMissingStub: _i14.Future<
+        returnValueForMissingStub: _i15.Future<
                 ({
                   List<_i4.Event> events,
                   String? nextBatch,
                   DateTime? searchedUntil
                 })>.value(
             (events: <_i4.Event>[], nextBatch: null, searchedUntil: null)),
-      ) as _i14.Future<
+      ) as _i15.Future<
           ({
             List<_i4.Event> events,
             String? nextBatch,
@@ -3237,23 +3273,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.DatabaseApi get database => (super.noSuchMethod(
         Invocation.getter(#database),
-        returnValue: _FakeDatabaseApi_18(
+        returnValue: _FakeDatabaseApi_19(
           this,
           Invocation.getter(#database),
         ),
-        returnValueForMissingStub: _FakeDatabaseApi_18(
+        returnValueForMissingStub: _FakeDatabaseApi_19(
           this,
           Invocation.getter(#database),
         ),
       ) as _i4.DatabaseApi);
 
   @override
-  Set<_i23.KeyVerificationMethod> get verificationMethods =>
+  Set<_i24.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i23.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i23.KeyVerificationMethod>{},
-      ) as Set<_i23.KeyVerificationMethod>);
+        returnValue: <_i24.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i24.KeyVerificationMethod>{},
+      ) as Set<_i24.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -3314,11 +3350,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.Filter get syncFilter => (super.noSuchMethod(
         Invocation.getter(#syncFilter),
-        returnValue: _FakeFilter_19(
+        returnValue: _FakeFilter_20(
           this,
           Invocation.getter(#syncFilter),
         ),
-        returnValueForMissingStub: _FakeFilter_19(
+        returnValueForMissingStub: _FakeFilter_20(
           this,
           Invocation.getter(#syncFilter),
         ),
@@ -3327,11 +3363,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.NativeImplementations get nativeImplementations => (super.noSuchMethod(
         Invocation.getter(#nativeImplementations),
-        returnValue: _FakeNativeImplementations_20(
+        returnValue: _FakeNativeImplementations_21(
           this,
           Invocation.getter(#nativeImplementations),
         ),
-        returnValueForMissingStub: _FakeNativeImplementations_20(
+        returnValueForMissingStub: _FakeNativeImplementations_21(
           this,
           Invocation.getter(#nativeImplementations),
         ),
@@ -3347,11 +3383,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get sendTimelineEventTimeout => (super.noSuchMethod(
         Invocation.getter(#sendTimelineEventTimeout),
-        returnValue: _FakeDuration_21(
+        returnValue: _FakeDuration_22(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_21(
+        returnValueForMissingStub: _FakeDuration_22(
           this,
           Invocation.getter(#sendTimelineEventTimeout),
         ),
@@ -3360,11 +3396,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   Duration get typingIndicatorTimeout => (super.noSuchMethod(
         Invocation.getter(#typingIndicatorTimeout),
-        returnValue: _FakeDuration_21(
+        returnValue: _FakeDuration_22(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
-        returnValueForMissingStub: _FakeDuration_21(
+        returnValueForMissingStub: _FakeDuration_22(
           this,
           Invocation.getter(#typingIndicatorTimeout),
         ),
@@ -3373,11 +3409,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -3414,11 +3450,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -3448,11 +3484,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -3461,11 +3497,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -3488,11 +3524,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   _i4.PushruleEvaluator get pushruleEvaluator => (super.noSuchMethod(
         Invocation.getter(#pushruleEvaluator),
-        returnValue: _FakePushruleEvaluator_22(
+        returnValue: _FakePushruleEvaluator_23(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
-        returnValueForMissingStub: _FakePushruleEvaluator_22(
+        returnValueForMissingStub: _FakePushruleEvaluator_23(
           this,
           Invocation.getter(#pushruleEvaluator),
         ),
@@ -3513,332 +3549,332 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Map<String, List<String>>);
 
   @override
-  _i14.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
+  _i15.Future<_i4.Profile> get ownProfile => (super.noSuchMethod(
         Invocation.getter(#ownProfile),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.getter(#ownProfile),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.getter(#ownProfile),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i12.CachedStreamController<String> get onUserProfileUpdate =>
+  _i13.CachedStreamController<String> get onUserProfileUpdate =>
       (super.noSuchMethod(
         Invocation.getter(#onUserProfileUpdate),
-        returnValue: _FakeCachedStreamController_11<String>(
+        returnValue: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onUserProfileUpdate),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i14.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
+  _i15.Future<List<_i4.Room>> get archive => (super.noSuchMethod(
         Invocation.getter(#archive),
-        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i14.Future<List<_i4.Room>>);
+            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i15.Future<List<_i4.Room>>);
 
   @override
-  _i12.CachedStreamController<_i4.EventUpdate> get onEvent =>
+  _i13.CachedStreamController<_i4.EventUpdate> get onEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onEvent),
-        returnValue: _FakeCachedStreamController_11<_i4.EventUpdate>(
+        returnValue: _FakeCachedStreamController_12<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.EventUpdate>(
+            _FakeCachedStreamController_12<_i4.EventUpdate>(
           this,
           Invocation.getter(#onEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.EventUpdate>);
+      ) as _i13.CachedStreamController<_i4.EventUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onTimelineEvent =>
+  _i13.CachedStreamController<_i4.Event> get onTimelineEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onTimelineEvent),
-        returnValue: _FakeCachedStreamController_11<_i4.Event>(
+        returnValue: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onTimelineEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onHistoryEvent =>
+  _i13.CachedStreamController<_i4.Event> get onHistoryEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onHistoryEvent),
-        returnValue: _FakeCachedStreamController_11<_i4.Event>(
+        returnValue: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onHistoryEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onNotification =>
+  _i13.CachedStreamController<_i4.Event> get onNotification =>
       (super.noSuchMethod(
         Invocation.getter(#onNotification),
-        returnValue: _FakeCachedStreamController_11<_i4.Event>(
+        returnValue: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onNotification),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
+  _i13.CachedStreamController<_i4.ToDeviceEvent> get onToDeviceEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onToDeviceEvent),
-        returnValue: _FakeCachedStreamController_11<_i4.ToDeviceEvent>(
+        returnValue: _FakeCachedStreamController_12<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.ToDeviceEvent>(
+            _FakeCachedStreamController_12<_i4.ToDeviceEvent>(
           this,
           Invocation.getter(#onToDeviceEvent),
         ),
-      ) as _i12.CachedStreamController<_i4.ToDeviceEvent>);
+      ) as _i13.CachedStreamController<_i4.ToDeviceEvent>);
 
   @override
-  _i12.CachedStreamController<List<_i4.BasicEventWithSender>>
+  _i13.CachedStreamController<List<_i4.BasicEventWithSender>>
       get onCallEvents => (super.noSuchMethod(
             Invocation.getter(#onCallEvents),
             returnValue:
-                _FakeCachedStreamController_11<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_12<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_11<List<_i4.BasicEventWithSender>>(
+                _FakeCachedStreamController_12<List<_i4.BasicEventWithSender>>(
               this,
               Invocation.getter(#onCallEvents),
             ),
-          ) as _i12.CachedStreamController<List<_i4.BasicEventWithSender>>);
+          ) as _i13.CachedStreamController<List<_i4.BasicEventWithSender>>);
 
   @override
-  _i12.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
+  _i13.CachedStreamController<_i4.LoginState> get onLoginStateChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onLoginStateChanged),
-        returnValue: _FakeCachedStreamController_11<_i4.LoginState>(
+        returnValue: _FakeCachedStreamController_12<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.LoginState>(
+            _FakeCachedStreamController_12<_i4.LoginState>(
           this,
           Invocation.getter(#onLoginStateChanged),
         ),
-      ) as _i12.CachedStreamController<_i4.LoginState>);
+      ) as _i13.CachedStreamController<_i4.LoginState>);
 
   @override
-  _i12.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
+  _i13.CachedStreamController<bool> get onCacheCleared => (super.noSuchMethod(
         Invocation.getter(#onCacheCleared),
-        returnValue: _FakeCachedStreamController_11<bool>(
+        returnValue: _FakeCachedStreamController_12<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<bool>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<bool>(
           this,
           Invocation.getter(#onCacheCleared),
         ),
-      ) as _i12.CachedStreamController<bool>);
+      ) as _i13.CachedStreamController<bool>);
 
   @override
-  _i12.CachedStreamController<_i4.SdkError> get onEncryptionError =>
+  _i13.CachedStreamController<_i4.SdkError> get onEncryptionError =>
       (super.noSuchMethod(
         Invocation.getter(#onEncryptionError),
-        returnValue: _FakeCachedStreamController_11<_i4.SdkError>(
+        returnValue: _FakeCachedStreamController_12<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.SdkError>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.SdkError>(
           this,
           Invocation.getter(#onEncryptionError),
         ),
-      ) as _i12.CachedStreamController<_i4.SdkError>);
+      ) as _i13.CachedStreamController<_i4.SdkError>);
 
   @override
-  _i12.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
+  _i13.CachedStreamController<_i4.SyncUpdate> get onSync => (super.noSuchMethod(
         Invocation.getter(#onSync),
-        returnValue: _FakeCachedStreamController_11<_i4.SyncUpdate>(
+        returnValue: _FakeCachedStreamController_12<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.SyncUpdate>(
+            _FakeCachedStreamController_12<_i4.SyncUpdate>(
           this,
           Invocation.getter(#onSync),
         ),
-      ) as _i12.CachedStreamController<_i4.SyncUpdate>);
+      ) as _i13.CachedStreamController<_i4.SyncUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
+  _i13.CachedStreamController<_i4.SyncStatusUpdate> get onSyncStatus =>
       (super.noSuchMethod(
         Invocation.getter(#onSyncStatus),
-        returnValue: _FakeCachedStreamController_11<_i4.SyncStatusUpdate>(
+        returnValue: _FakeCachedStreamController_12<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.SyncStatusUpdate>(
+            _FakeCachedStreamController_12<_i4.SyncStatusUpdate>(
           this,
           Invocation.getter(#onSyncStatus),
         ),
-      ) as _i12.CachedStreamController<_i4.SyncStatusUpdate>);
+      ) as _i13.CachedStreamController<_i4.SyncStatusUpdate>);
 
   @override
-  _i12.CachedStreamController<_i4.Presence> get onPresence =>
+  _i13.CachedStreamController<_i4.Presence> get onPresence =>
       (super.noSuchMethod(
         Invocation.getter(#onPresence),
-        returnValue: _FakeCachedStreamController_11<_i4.Presence>(
+        returnValue: _FakeCachedStreamController_12<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Presence>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Presence>(
           this,
           Invocation.getter(#onPresence),
         ),
-      ) as _i12.CachedStreamController<_i4.Presence>);
+      ) as _i13.CachedStreamController<_i4.Presence>);
 
   @override
-  _i12.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
+  _i13.CachedStreamController<_i4.CachedPresence> get onPresenceChanged =>
       (super.noSuchMethod(
         Invocation.getter(#onPresenceChanged),
-        returnValue: _FakeCachedStreamController_11<_i4.CachedPresence>(
+        returnValue: _FakeCachedStreamController_12<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.CachedPresence>(
+            _FakeCachedStreamController_12<_i4.CachedPresence>(
           this,
           Invocation.getter(#onPresenceChanged),
         ),
-      ) as _i12.CachedStreamController<_i4.CachedPresence>);
+      ) as _i13.CachedStreamController<_i4.CachedPresence>);
 
   @override
-  _i12.CachedStreamController<_i4.BasicEvent> get onAccountData =>
+  _i13.CachedStreamController<_i4.BasicEvent> get onAccountData =>
       (super.noSuchMethod(
         Invocation.getter(#onAccountData),
-        returnValue: _FakeCachedStreamController_11<_i4.BasicEvent>(
+        returnValue: _FakeCachedStreamController_12<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.BasicEvent>(
+            _FakeCachedStreamController_12<_i4.BasicEvent>(
           this,
           Invocation.getter(#onAccountData),
         ),
-      ) as _i12.CachedStreamController<_i4.BasicEvent>);
+      ) as _i13.CachedStreamController<_i4.BasicEvent>);
 
   @override
-  _i12.CachedStreamController<_i23.RoomKeyRequest> get onRoomKeyRequest =>
+  _i13.CachedStreamController<_i24.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_11<_i23.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_12<_i24.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i23.RoomKeyRequest>(
+            _FakeCachedStreamController_12<_i24.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i12.CachedStreamController<_i23.RoomKeyRequest>);
+      ) as _i13.CachedStreamController<_i24.RoomKeyRequest>);
 
   @override
-  _i12.CachedStreamController<_i23.KeyVerification>
+  _i13.CachedStreamController<_i24.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_11<_i23.KeyVerification>(
+            returnValue: _FakeCachedStreamController_12<_i24.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_11<_i23.KeyVerification>(
+                _FakeCachedStreamController_12<_i24.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i12.CachedStreamController<_i23.KeyVerification>);
+          ) as _i13.CachedStreamController<_i24.KeyVerification>);
 
   @override
-  _i12.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
+  _i13.CachedStreamController<_i4.UiaRequest<dynamic>> get onUiaRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onUiaRequest),
-        returnValue: _FakeCachedStreamController_11<_i4.UiaRequest<dynamic>>(
+        returnValue: _FakeCachedStreamController_12<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_11<_i4.UiaRequest<dynamic>>(
+            _FakeCachedStreamController_12<_i4.UiaRequest<dynamic>>(
           this,
           Invocation.getter(#onUiaRequest),
         ),
-      ) as _i12.CachedStreamController<_i4.UiaRequest<dynamic>>);
+      ) as _i13.CachedStreamController<_i4.UiaRequest<dynamic>>);
 
   @override
-  _i12.CachedStreamController<_i4.Event> get onGroupMember =>
+  _i13.CachedStreamController<_i4.Event> get onGroupMember =>
       (super.noSuchMethod(
         Invocation.getter(#onGroupMember),
-        returnValue: _FakeCachedStreamController_11<_i4.Event>(
+        returnValue: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<_i4.Event>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<_i4.Event>(
           this,
           Invocation.getter(#onGroupMember),
         ),
-      ) as _i12.CachedStreamController<_i4.Event>);
+      ) as _i13.CachedStreamController<_i4.Event>);
 
   @override
-  _i12.CachedStreamController<String> get onCancelSendEvent =>
+  _i13.CachedStreamController<String> get onCancelSendEvent =>
       (super.noSuchMethod(
         Invocation.getter(#onCancelSendEvent),
-        returnValue: _FakeCachedStreamController_11<String>(
+        returnValue: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-        returnValueForMissingStub: _FakeCachedStreamController_11<String>(
+        returnValueForMissingStub: _FakeCachedStreamController_12<String>(
           this,
           Invocation.getter(#onCancelSendEvent),
         ),
-      ) as _i12.CachedStreamController<String>);
+      ) as _i13.CachedStreamController<String>);
 
   @override
-  _i12.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
+  _i13.CachedStreamController<({String roomId, _i4.StrippedStateEvent state})>
       get onRoomState => (super.noSuchMethod(
             Invocation.getter(#onRoomState),
-            returnValue: _FakeCachedStreamController_11<
+            returnValue: _FakeCachedStreamController_12<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-            returnValueForMissingStub: _FakeCachedStreamController_11<
+            returnValueForMissingStub: _FakeCachedStreamController_12<
                 ({String roomId, _i4.StrippedStateEvent state})>(
               this,
               Invocation.getter(#onRoomState),
             ),
-          ) as _i12.CachedStreamController<
+          ) as _i13.CachedStreamController<
               ({String roomId, _i4.StrippedStateEvent state})>);
 
   @override
@@ -3858,11 +3894,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
   @override
   DateTime get lastStaleCallRun => (super.noSuchMethod(
         Invocation.getter(#lastStaleCallRun),
-        returnValue: _FakeDateTime_12(
+        returnValue: _FakeDateTime_13(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
-        returnValueForMissingStub: _FakeDateTime_12(
+        returnValueForMissingStub: _FakeDateTime_13(
           this,
           Invocation.getter(#lastStaleCallRun),
         ),
@@ -3935,7 +3971,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set verificationMethods(Set<_i23.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i24.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -3990,7 +4026,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set onSoftLogout(_i14.Future<void> Function(_i4.Client)? value) =>
+  set onSoftLogout(_i15.Future<void> Function(_i4.Client)? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #onSoftLogout,
@@ -4001,7 +4037,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
 
   @override
   set customImageResizer(
-          _i14.Future<_i4.MatrixImageFileResizedResponse?> Function(
+          _i15.Future<_i4.MatrixImageFileResizedResponse?> Function(
                   _i4.MatrixImageFileResizeArguments)?
               value) =>
       super.noSuchMethod(
@@ -4112,7 +4148,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set userDeviceKeysLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set userDeviceKeysLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #userDeviceKeysLoading,
           value,
@@ -4121,7 +4157,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set roomsLoading(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set roomsLoading(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #roomsLoading,
           value,
@@ -4130,7 +4166,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  set firstSyncReceived(_i14.Future<dynamic>? value) => super.noSuchMethod(
+  set firstSyncReceived(_i15.Future<dynamic>? value) => super.noSuchMethod(
         Invocation.setter(
           #firstSyncReceived,
           value,
@@ -4157,20 +4193,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i13.Client get httpClient => (super.noSuchMethod(
+  _i14.Client get httpClient => (super.noSuchMethod(
         Invocation.getter(#httpClient),
-        returnValue: _FakeClient_24(
+        returnValue: _FakeClient_25(
           this,
           Invocation.getter(#httpClient),
         ),
-        returnValueForMissingStub: _FakeClient_24(
+        returnValueForMissingStub: _FakeClient_25(
           this,
           Invocation.getter(#httpClient),
         ),
-      ) as _i13.Client);
+      ) as _i14.Client);
 
   @override
-  set httpClient(_i13.Client? value) => super.noSuchMethod(
+  set httpClient(_i14.Client? value) => super.noSuchMethod(
         Invocation.setter(
           #httpClient,
           value,
@@ -4197,7 +4233,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<void> refreshAccessToken(
+  _i15.Future<void> refreshAccessToken(
           {Duration? customRefreshTokenLifetime}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4205,9 +4241,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#customRefreshTokenLifetime: customRefreshTokenLifetime},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   bool isLogged() => (super.noSuchMethod(
@@ -4225,14 +4261,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -4269,33 +4305,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as String?);
 
   @override
-  _i14.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
+  _i15.Future<_i4.DiscoveryInformation> getDiscoveryInformationsByUserId(
           String? MatrixIdOrDomain) =>
       (super.noSuchMethod(
         Invocation.method(
           #getDiscoveryInformationsByUserId,
           [MatrixIdOrDomain],
         ),
-        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_25(
+        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_26(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_25(
+        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_26(
           this,
           Invocation.method(
             #getDiscoveryInformationsByUserId,
             [MatrixIdOrDomain],
           ),
         )),
-      ) as _i14.Future<_i4.DiscoveryInformation>);
+      ) as _i15.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i14.Future<
+  _i15.Future<
       (
         _i4.DiscoveryInformation?,
         _i4.GetVersionsResponse,
@@ -4317,7 +4353,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #overrideSupportedVersions: overrideSupportedVersions,
           },
         ),
-        returnValue: _i14.Future<
+        returnValue: _i15.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4325,7 +4361,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_26(
+          _FakeGetVersionsResponse_27(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4340,7 +4376,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-        returnValueForMissingStub: _i14.Future<
+        returnValueForMissingStub: _i15.Future<
             (
               _i4.DiscoveryInformation?,
               _i4.GetVersionsResponse,
@@ -4348,7 +4384,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
               _i4.GetAuthMetadataResponse?
             )>.value((
           null,
-          _FakeGetVersionsResponse_26(
+          _FakeGetVersionsResponse_27(
             this,
             Invocation.method(
               #checkHomeserver,
@@ -4363,7 +4399,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           <_i4.LoginFlow>[],
           null
         )),
-      ) as _i14.Future<
+      ) as _i15.Future<
           (
             _i4.DiscoveryInformation?,
             _i4.GetVersionsResponse,
@@ -4372,7 +4408,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           )>);
 
   @override
-  _i14.Future<_i4.DiscoveryInformation> getWellknown({
+  _i15.Future<_i4.DiscoveryInformation> getWellknown({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4385,8 +4421,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_25(
+        returnValue: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_26(
           this,
           Invocation.method(
             #getWellknown,
@@ -4397,8 +4433,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.DiscoveryInformation>.value(
-            _FakeDiscoveryInformation_25(
+        returnValueForMissingStub: _i15.Future<_i4.DiscoveryInformation>.value(
+            _FakeDiscoveryInformation_26(
           this,
           Invocation.method(
             #getWellknown,
@@ -4409,10 +4445,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.DiscoveryInformation>);
+      ) as _i15.Future<_i4.DiscoveryInformation>);
 
   @override
-  _i14.Future<_i4.RegisterResponse> register({
+  _i15.Future<_i4.RegisterResponse> register({
     String? username,
     String? password,
     String? deviceId,
@@ -4440,7 +4476,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
+            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_28(
           this,
           Invocation.method(
             #register,
@@ -4459,7 +4495,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_27(
+            _i15.Future<_i4.RegisterResponse>.value(_FakeRegisterResponse_28(
           this,
           Invocation.method(
             #register,
@@ -4477,10 +4513,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RegisterResponse>);
+      ) as _i15.Future<_i4.RegisterResponse>);
 
   @override
-  _i14.Future<_i4.LoginResponse> login(
+  _i15.Future<_i4.LoginResponse> login(
     String? type, {
     _i4.AuthenticationIdentifier? identifier,
     String? password,
@@ -4510,7 +4546,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
+        returnValue: _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_29(
           this,
           Invocation.method(
             #login,
@@ -4530,7 +4566,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.LoginResponse>.value(_FakeLoginResponse_28(
+            _i15.Future<_i4.LoginResponse>.value(_FakeLoginResponse_29(
           this,
           Invocation.method(
             #login,
@@ -4549,10 +4585,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.LoginResponse>);
+      ) as _i15.Future<_i4.LoginResponse>);
 
   @override
-  _i14.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
+  _i15.Future<_i4.GetAuthMetadataResponse> getAuthMetadata({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -4565,8 +4601,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.GetAuthMetadataResponse>.value(
-            _FakeGetAuthMetadataResponse_29(
+        returnValue: _i15.Future<_i4.GetAuthMetadataResponse>.value(
+            _FakeGetAuthMetadataResponse_30(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4578,8 +4614,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetAuthMetadataResponse>.value(
-                _FakeGetAuthMetadataResponse_29(
+            _i15.Future<_i4.GetAuthMetadataResponse>.value(
+                _FakeGetAuthMetadataResponse_30(
           this,
           Invocation.method(
             #getAuthMetadata,
@@ -4590,74 +4626,74 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetAuthMetadataResponse>);
+      ) as _i15.Future<_i4.GetAuthMetadataResponse>);
 
   @override
-  _i14.Future<void> logout() => (super.noSuchMethod(
+  _i15.Future<void> logout() => (super.noSuchMethod(
         Invocation.method(
           #logout,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> logoutAll() => (super.noSuchMethod(
+  _i15.Future<void> logoutAll() => (super.noSuchMethod(
         Invocation.method(
           #logoutAll,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<T> uiaRequestBackground<T>(
-          _i14.Future<T> Function(_i4.AuthenticationData?)? request) =>
+  _i15.Future<T> uiaRequestBackground<T>(
+          _i15.Future<T> Function(_i4.AuthenticationData?)? request) =>
       (super.noSuchMethod(
         Invocation.method(
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i14.Future<T>.value(v),
+              (T v) => _i15.Future<T>.value(v),
             ) ??
-            _FakeFuture_30<T>(
+            _FakeFuture_31<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
                   [request],
                 ),
               ),
-              (T v) => _i14.Future<T>.value(v),
+              (T v) => _i15.Future<T>.value(v),
             ) ??
-            _FakeFuture_30<T>(
+            _FakeFuture_31<T>(
               this,
               Invocation.method(
                 #uiaRequestBackground,
                 [request],
               ),
             ),
-      ) as _i14.Future<T>);
+      ) as _i15.Future<T>);
 
   @override
-  _i14.Future<String> startDirectChat(
+  _i15.Future<String> startDirectChat(
     String? mxid, {
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
@@ -4679,7 +4715,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4695,7 +4731,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -4710,10 +4746,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<String> createGroupChat({
+  _i15.Future<String> createGroupChat({
     String? groupName,
     bool? enableEncryption,
     List<String>? invite,
@@ -4744,7 +4780,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4765,7 +4801,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -4785,10 +4821,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> waitForRoomInSync(
+  _i15.Future<_i4.SyncUpdate> waitForRoomInSync(
     String? roomId, {
     bool? join = false,
     bool? invite = false,
@@ -4804,7 +4840,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #leave: leave,
           },
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4817,7 +4853,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #waitForRoomInSync,
@@ -4829,21 +4865,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<bool> userOwnsEncryptionKeys(String? userId) =>
+  _i15.Future<bool> userOwnsEncryptionKeys(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #userOwnsEncryptionKeys,
           [userId],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<String> createSpace({
+  _i15.Future<String> createSpace({
     String? name,
     String? topic,
     _i4.Visibility? visibility = _i4.Visibility.public,
@@ -4868,7 +4904,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4886,7 +4922,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -4903,10 +4939,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.Profile> fetchOwnProfileFromServer(
+  _i15.Future<_i4.Profile> fetchOwnProfileFromServer(
           {bool? useServerCache = false}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4914,7 +4950,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#useServerCache: useServerCache},
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4923,7 +4959,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #fetchOwnProfileFromServer,
@@ -4931,10 +4967,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#useServerCache: useServerCache},
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i14.Future<_i4.Profile> fetchOwnProfile({
+  _i15.Future<_i4.Profile> fetchOwnProfile({
     bool? getFromRooms = true,
     bool? cache = true,
   }) =>
@@ -4947,7 +4983,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #cache: cache,
           },
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4959,7 +4995,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #fetchOwnProfile,
@@ -4970,10 +5006,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
-  _i14.Future<_i4.CachedProfileInformation> getUserProfile(
+  _i15.Future<_i4.CachedProfileInformation> getUserProfile(
     String? userId, {
     Duration? timeout = const Duration(seconds: 30),
     Duration? maxCacheAge = const Duration(days: 1),
@@ -4987,8 +5023,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i14.Future<_i4.CachedProfileInformation>.value(
-            _FakeCachedProfileInformation_31(
+        returnValue: _i15.Future<_i4.CachedProfileInformation>.value(
+            _FakeCachedProfileInformation_32(
           this,
           Invocation.method(
             #getUserProfile,
@@ -5000,8 +5036,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedProfileInformation>.value(
-                _FakeCachedProfileInformation_31(
+            _i15.Future<_i4.CachedProfileInformation>.value(
+                _FakeCachedProfileInformation_32(
           this,
           Invocation.method(
             #getUserProfile,
@@ -5012,10 +5048,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.CachedProfileInformation>);
+      ) as _i15.Future<_i4.CachedProfileInformation>);
 
   @override
-  _i14.Future<_i4.Profile> getProfileFromUserId(
+  _i15.Future<_i4.Profile> getProfileFromUserId(
     String? userId, {
     bool? getFromRooms,
     bool? cache,
@@ -5033,7 +5069,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #maxCacheAge: maxCacheAge,
           },
         ),
-        returnValue: _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+        returnValue: _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -5047,7 +5083,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Profile>.value(_FakeProfile_23(
+            _i15.Future<_i4.Profile>.value(_FakeProfile_24(
           this,
           Invocation.method(
             #getProfileFromUserId,
@@ -5060,7 +5096,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.Profile>);
+      ) as _i15.Future<_i4.Profile>);
 
   @override
   _i4.ArchivedRoom? getArchiveRoomFromCache(String? roomId) =>
@@ -5082,31 +5118,31 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Room>> loadArchive() => (super.noSuchMethod(
         Invocation.method(
           #loadArchive,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+        returnValue: _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Room>>.value(<_i4.Room>[]),
-      ) as _i14.Future<List<_i4.Room>>);
+            _i15.Future<List<_i4.Room>>.value(<_i4.Room>[]),
+      ) as _i15.Future<List<_i4.Room>>);
 
   @override
-  _i14.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
+  _i15.Future<List<_i4.ArchivedRoom>> loadArchiveWithTimeline() =>
       (super.noSuchMethod(
         Invocation.method(
           #loadArchiveWithTimeline,
           [],
         ),
         returnValue:
-            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
-      ) as _i14.Future<List<_i4.ArchivedRoom>>);
+            _i15.Future<List<_i4.ArchivedRoom>>.value(<_i4.ArchivedRoom>[]),
+      ) as _i15.Future<List<_i4.ArchivedRoom>>);
 
   @override
-  _i14.Future<_i4.GetVersionsResponse> getVersions({
+  _i15.Future<_i4.GetVersionsResponse> getVersions({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5119,8 +5155,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_26(
+        returnValue: _i15.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_27(
           this,
           Invocation.method(
             #getVersions,
@@ -5131,8 +5167,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetVersionsResponse>.value(
-            _FakeGetVersionsResponse_26(
+        returnValueForMissingStub: _i15.Future<_i4.GetVersionsResponse>.value(
+            _FakeGetVersionsResponse_27(
           this,
           Invocation.method(
             #getVersions,
@@ -5143,20 +5179,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetVersionsResponse>);
+      ) as _i15.Future<_i4.GetVersionsResponse>);
 
   @override
-  _i14.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
+  _i15.Future<bool> authenticatedMediaSupported() => (super.noSuchMethod(
         Invocation.method(
           #authenticatedMediaSupported,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.MediaConfig> getConfig({
+  _i15.Future<_i4.MediaConfig> getConfig({
     Duration? cacheLifetime = const Duration(days: 3),
     bool? throwOnUpdateFailure = false,
   }) =>
@@ -5169,7 +5205,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #throwOnUpdateFailure: throwOnUpdateFailure,
           },
         ),
-        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfig,
@@ -5181,7 +5217,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfig,
@@ -5192,10 +5228,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.MediaConfig>);
+      ) as _i15.Future<_i4.MediaConfig>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContent(
+  _i15.Future<_i16.FileResponse> getContent(
     String? serverName,
     String? mediaId, {
     bool? allowRemote,
@@ -5215,7 +5251,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContent,
@@ -5231,7 +5267,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContent,
@@ -5246,10 +5282,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentOverrideName(
+  _i15.Future<_i16.FileResponse> getContentOverrideName(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -5271,7 +5307,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #allowRedirect: allowRedirect,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5288,7 +5324,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideName,
@@ -5304,10 +5340,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentThumbnail(
+  _i15.Future<_i16.FileResponse> getContentThumbnail(
     String? serverName,
     String? mediaId,
     int? width,
@@ -5335,7 +5371,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5355,7 +5391,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnail,
@@ -5374,10 +5410,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i4.PreviewForUrl> getUrlPreview(
+  _i15.Future<_i4.PreviewForUrl> getUrlPreview(
     Uri? url, {
     int? ts,
   }) =>
@@ -5387,7 +5423,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5396,7 +5432,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreview,
@@ -5404,11 +5440,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i14.Future<_i4.PreviewForUrl>);
+      ) as _i15.Future<_i4.PreviewForUrl>);
 
   @override
-  _i14.Future<Uri> uploadContent(
-    _i24.Uint8List? file, {
+  _i15.Future<Uri> uploadContent(
+    _i25.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -5421,7 +5457,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #contentType: contentType,
           },
         ),
-        returnValue: _i14.Future<Uri>.value(_FakeUri_17(
+        returnValue: _i15.Future<Uri>.value(_FakeUri_18(
           this,
           Invocation.method(
             #uploadContent,
@@ -5432,7 +5468,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<Uri>.value(_FakeUri_17(
+        returnValueForMissingStub: _i15.Future<Uri>.value(_FakeUri_18(
           this,
           Invocation.method(
             #uploadContent,
@@ -5443,10 +5479,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<Uri>);
+      ) as _i15.Future<Uri>);
 
   @override
-  _i14.Future<void> setTyping(
+  _i15.Future<void> setTyping(
     String? userId,
     String? roomId,
     bool? typing, {
@@ -5462,42 +5498,42 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> exportDump() => (super.noSuchMethod(
+  _i15.Future<String?> exportDump() => (super.noSuchMethod(
         Invocation.method(
           #exportDump,
           [],
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<bool> importDump(String? export) => (super.noSuchMethod(
+  _i15.Future<bool> importDump(String? export) => (super.noSuchMethod(
         Invocation.method(
           #importDump,
           [export],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
+  _i15.Future<void> setAvatar(_i4.MatrixFile? file) => (super.noSuchMethod(
         Invocation.method(
           #setAvatar,
           [file],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Event?> getEventByPushNotification(
+  _i15.Future<_i4.Event?> getEventByPushNotification(
     _i4.PushNotification? notification, {
     bool? storeInDatabase = true,
     Duration? timeoutForServerRequests = const Duration(seconds: 8),
@@ -5513,12 +5549,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #returnNullIfSeen: returnNullIfSeen,
           },
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
-  _i14.Future<void> init({
+  _i15.Future<void> init({
     String? newToken,
     DateTime? newTokenExpiresAt,
     String? newRefreshToken,
@@ -5553,9 +5589,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onInitStateChanged: onInitStateChanged,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void setUserId(String? s) => super.noSuchMethod(
@@ -5567,40 +5603,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
       );
 
   @override
-  _i14.Future<void> clear() => (super.noSuchMethod(
+  _i15.Future<void> clear() => (super.noSuchMethod(
         Invocation.method(
           #clear,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
+  _i15.Future<void> oneShotSync({Duration? timeout}) => (super.noSuchMethod(
         Invocation.method(
           #oneShotSync,
           [],
           {#timeout: timeout},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ensureNotSoftLoggedOut(
+  _i15.Future<void> ensureNotSoftLoggedOut(
           [Duration? expiresIn = const Duration(minutes: 1)]) =>
       (super.noSuchMethod(
         Invocation.method(
           #ensureNotSoftLoggedOut,
           [expiresIn],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> handleSync(
+  _i15.Future<void> handleSync(
     _i4.SyncUpdate? sync, {
     _i4.Direction? direction,
   }) =>
@@ -5610,9 +5646,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [sync],
           {#direction: direction},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   _i4.DeviceKeys? getUserDeviceKeysByCurve25519Key(String? senderKey) =>
@@ -5625,29 +5661,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as _i4.DeviceKeys?);
 
   @override
-  _i14.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
+  _i15.Future<void> updateUserDeviceKeys({Set<String>? additionalUsers}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateUserDeviceKeys,
           [],
           {#additionalUsers: additionalUsers},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> processToDeviceQueue() => (super.noSuchMethod(
+  _i15.Future<void> processToDeviceQueue() => (super.noSuchMethod(
         Invocation.method(
           #processToDeviceQueue,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDevice(
+  _i15.Future<void> sendToDevice(
     String? eventType,
     String? txnId,
     Map<String, Map<String, Map<String, dynamic>>>? messages,
@@ -5661,12 +5697,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             messages,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDevicesOfUserIds(
+  _i15.Future<void> sendToDevicesOfUserIds(
     Set<String>? users,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5682,12 +5718,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#messageId: messageId},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDeviceEncrypted(
+  _i15.Future<void> sendToDeviceEncrypted(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message, {
@@ -5707,12 +5743,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #onlyVerified: onlyVerified,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> sendToDeviceEncryptedChunked(
+  _i15.Future<void> sendToDeviceEncryptedChunked(
     List<_i4.DeviceKeys>? deviceKeys,
     String? eventType,
     Map<String, dynamic>? message,
@@ -5726,23 +5762,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             message,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setMuteAllPushNotifications(bool? muted) =>
+  _i15.Future<void> setMuteAllPushNotifications(bool? muted) =>
       (super.noSuchMethod(
         Invocation.method(
           #setMuteAllPushNotifications,
           [muted],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> joinRoom(
+  _i15.Future<String> joinRoom(
     String? roomIdOrAlias, {
     List<String>? serverName,
     List<String>? via,
@@ -5760,7 +5796,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5774,7 +5810,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -5787,10 +5823,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> changePassword(
+  _i15.Future<void> changePassword(
     String? newPassword, {
     String? oldPassword,
     _i4.AuthenticationData? auth,
@@ -5806,22 +5842,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #logoutDevices: logoutDevices,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> clearCache() => (super.noSuchMethod(
+  _i15.Future<void> clearCache() => (super.noSuchMethod(
         Invocation.method(
           #clearCache,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ignoreUser(
+  _i15.Future<void> ignoreUser(
     String? userId, {
     bool? leaveRooms = true,
   }) =>
@@ -5831,22 +5867,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [userId],
           {#leaveRooms: leaveRooms},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
+  _i15.Future<void> unignoreUser(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #unignoreUser,
           [userId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.CachedPresence> fetchCurrentPresence(
+  _i15.Future<_i4.CachedPresence> fetchCurrentPresence(
     String? userId, {
     bool? fetchOnlyFromCached = false,
   }) =>
@@ -5857,7 +5893,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fetchOnlyFromCached: fetchOnlyFromCached},
         ),
         returnValue:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_36(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5866,7 +5902,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_36(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -5874,32 +5910,32 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#fetchOnlyFromCached: fetchOnlyFromCached},
           ),
         )),
-      ) as _i14.Future<_i4.CachedPresence>);
+      ) as _i15.Future<_i4.CachedPresence>);
 
   @override
-  _i14.Future<void> abortSync() => (super.noSuchMethod(
+  _i15.Future<void> abortSync() => (super.noSuchMethod(
         Invocation.method(
           #abortSync,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> dispose({bool? closeDatabase = true}) =>
+  _i15.Future<void> dispose({bool? closeDatabase = true}) =>
       (super.noSuchMethod(
         Invocation.method(
           #dispose,
           [],
           {#closeDatabase: closeDatabase},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEventWithMetadata(
+  _i15.Future<String?> redactEventWithMetadata(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -5919,14 +5955,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #metadata: metadata,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
   Never unexpectedResponse(
-    _i13.BaseResponse? response,
-    _i24.Uint8List? body,
+    _i14.BaseResponse? response,
+    _i25.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -5958,7 +5994,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
       ) as Never);
 
   @override
-  _i14.Future<Map<String, Object?>> request(
+  _i15.Future<Map<String, Object?>> request(
     _i4.RequestType? type,
     String? action, {
     dynamic data = '',
@@ -5979,13 +6015,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> postPusher(
+  _i15.Future<void> postPusher(
     _i4.Pusher? pusher, {
     bool? append,
   }) =>
@@ -5995,57 +6031,57 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [pusher],
           {#append: append},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
+  _i15.Future<void> deletePusher(_i4.PusherId? pusher) => (super.noSuchMethod(
         Invocation.method(
           #deletePusher,
           [pusher],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteDeviceDisplayName(String? deviceId) =>
+  _i15.Future<void> deleteDeviceDisplayName(String? deviceId) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteDeviceDisplayName,
           [deviceId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
+  _i15.Future<_i4.TurnServerCredentials> getTurnServer() => (super.noSuchMethod(
         Invocation.method(
           #getTurnServer,
           [],
         ),
-        returnValue: _i14.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_36(
+        returnValue: _i15.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_37(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.TurnServerCredentials>.value(
-            _FakeTurnServerCredentials_36(
+        returnValueForMissingStub: _i15.Future<_i4.TurnServerCredentials>.value(
+            _FakeTurnServerCredentials_37(
           this,
           Invocation.method(
             #getTurnServer,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.TurnServerCredentials>);
+      ) as _i15.Future<_i4.TurnServerCredentials>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6059,8 +6095,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6072,8 +6108,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeysBySessionId,
@@ -6084,10 +6120,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6103,8 +6139,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             data,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6117,8 +6153,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeysBySessionId,
@@ -6130,10 +6166,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
+  _i15.Future<_i4.KeyBackupData> getRoomKeysBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -6147,7 +6183,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
+        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6159,7 +6195,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
+            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
           this,
           Invocation.method(
             #getRoomKeysBySessionId,
@@ -6170,17 +6206,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.KeyBackupData>);
+      ) as _i15.Future<_i4.KeyBackupData>);
 
   @override
-  _i14.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
+  _i15.Future<_i4.GetWellknownSupportResponse> getWellknownSupport() =>
       (super.noSuchMethod(
         Invocation.method(
           #getWellknownSupport,
           [],
         ),
-        returnValue: _i14.Future<_i4.GetWellknownSupportResponse>.value(
-            _FakeGetWellknownSupportResponse_39(
+        returnValue: _i15.Future<_i4.GetWellknownSupportResponse>.value(
+            _FakeGetWellknownSupportResponse_40(
           this,
           Invocation.method(
             #getWellknownSupport,
@@ -6188,18 +6224,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetWellknownSupportResponse>.value(
-                _FakeGetWellknownSupportResponse_39(
+            _i15.Future<_i4.GetWellknownSupportResponse>.value(
+                _FakeGetWellknownSupportResponse_40(
           this,
           Invocation.method(
             #getWellknownSupport,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.GetWellknownSupportResponse>);
+      ) as _i15.Future<_i4.GetWellknownSupportResponse>);
 
   @override
-  _i14.Future<int> pingAppservice(
+  _i15.Future<int> pingAppservice(
     String? appserviceId, {
     String? transactionId,
   }) =>
@@ -6209,12 +6245,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [appserviceId],
           {#transactionId: transactionId},
         ),
-        returnValue: _i14.Future<int>.value(0),
-        returnValueForMissingStub: _i14.Future<int>.value(0),
-      ) as _i14.Future<int>);
+        returnValue: _i15.Future<int>.value(0),
+        returnValueForMissingStub: _i15.Future<int>.value(0),
+      ) as _i15.Future<int>);
 
   @override
-  _i14.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
+  _i15.Future<_i4.GenerateLoginTokenResponse> generateLoginToken(
           {_i4.AuthenticationData? auth}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -6222,8 +6258,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<_i4.GenerateLoginTokenResponse>.value(
-            _FakeGenerateLoginTokenResponse_40(
+        returnValue: _i15.Future<_i4.GenerateLoginTokenResponse>.value(
+            _FakeGenerateLoginTokenResponse_41(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6232,8 +6268,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GenerateLoginTokenResponse>.value(
-                _FakeGenerateLoginTokenResponse_40(
+            _i15.Future<_i4.GenerateLoginTokenResponse>.value(
+                _FakeGenerateLoginTokenResponse_41(
           this,
           Invocation.method(
             #generateLoginToken,
@@ -6241,15 +6277,15 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#auth: auth},
           ),
         )),
-      ) as _i14.Future<_i4.GenerateLoginTokenResponse>);
+      ) as _i15.Future<_i4.GenerateLoginTokenResponse>);
 
   @override
-  _i14.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
+  _i15.Future<_i4.MediaConfig> getConfigAuthed() => (super.noSuchMethod(
         Invocation.method(
           #getConfigAuthed,
           [],
         ),
-        returnValue: _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+        returnValue: _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfigAuthed,
@@ -6257,17 +6293,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MediaConfig>.value(_FakeMediaConfig_32(
+            _i15.Future<_i4.MediaConfig>.value(_FakeMediaConfig_33(
           this,
           Invocation.method(
             #getConfigAuthed,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.MediaConfig>);
+      ) as _i15.Future<_i4.MediaConfig>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentAuthed(
+  _i15.Future<_i16.FileResponse> getContentAuthed(
     String? serverName,
     String? mediaId, {
     int? timeoutMs,
@@ -6281,7 +6317,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6293,7 +6329,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentAuthed,
@@ -6304,10 +6340,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentOverrideNameAuthed(
+  _i15.Future<_i16.FileResponse> getContentOverrideNameAuthed(
     String? serverName,
     String? mediaId,
     String? fileName, {
@@ -6323,7 +6359,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#timeoutMs: timeoutMs},
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6336,7 +6372,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentOverrideNameAuthed,
@@ -6348,10 +6384,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeoutMs: timeoutMs},
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
+  _i15.Future<_i4.PreviewForUrl> getUrlPreviewAuthed(
     Uri? url, {
     int? ts,
   }) =>
@@ -6361,7 +6397,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [url],
           {#ts: ts},
         ),
-        returnValue: _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+        returnValue: _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6370,7 +6406,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_34(
+            _i15.Future<_i4.PreviewForUrl>.value(_FakePreviewForUrl_35(
           this,
           Invocation.method(
             #getUrlPreviewAuthed,
@@ -6378,10 +6414,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#ts: ts},
           ),
         )),
-      ) as _i14.Future<_i4.PreviewForUrl>);
+      ) as _i15.Future<_i4.PreviewForUrl>);
 
   @override
-  _i14.Future<_i15.FileResponse> getContentThumbnailAuthed(
+  _i15.Future<_i16.FileResponse> getContentThumbnailAuthed(
     String? serverName,
     String? mediaId,
     int? width,
@@ -6405,7 +6441,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+        returnValue: _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6423,7 +6459,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i15.FileResponse>.value(_FakeFileResponse_33(
+            _i15.Future<_i16.FileResponse>.value(_FakeFileResponse_34(
           this,
           Invocation.method(
             #getContentThumbnailAuthed,
@@ -6440,21 +6476,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i15.FileResponse>);
+      ) as _i15.Future<_i16.FileResponse>);
 
   @override
-  _i14.Future<bool> registrationTokenValidity(String? token) =>
+  _i15.Future<bool> registrationTokenValidity(String? token) =>
       (super.noSuchMethod(
         Invocation.method(
           #registrationTokenValidity,
           [token],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
+  _i15.Future<_i4.GetRoomSummaryResponse$3> getRoomSummary(
     String? roomIdOrAlias, {
     List<String>? via,
   }) =>
@@ -6464,8 +6500,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomIdOrAlias],
           {#via: via},
         ),
-        returnValue: _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
-            _FakeGetRoomSummaryResponse$3_41(
+        returnValue: _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
+            _FakeGetRoomSummaryResponse$3_42(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6474,8 +6510,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomSummaryResponse$3>.value(
-                _FakeGetRoomSummaryResponse$3_41(
+            _i15.Future<_i4.GetRoomSummaryResponse$3>.value(
+                _FakeGetRoomSummaryResponse$3_42(
           this,
           Invocation.method(
             #getRoomSummary,
@@ -6483,10 +6519,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#via: via},
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomSummaryResponse$3>);
+      ) as _i15.Future<_i4.GetRoomSummaryResponse$3>);
 
   @override
-  _i14.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
+  _i15.Future<_i4.GetSpaceHierarchyResponse> getSpaceHierarchy(
     String? roomId, {
     bool? suggestedOnly,
     int? limit,
@@ -6504,8 +6540,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
-            _FakeGetSpaceHierarchyResponse_42(
+        returnValue: _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
+            _FakeGetSpaceHierarchyResponse_43(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6519,8 +6555,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetSpaceHierarchyResponse>.value(
-                _FakeGetSpaceHierarchyResponse_42(
+            _i15.Future<_i4.GetSpaceHierarchyResponse>.value(
+                _FakeGetSpaceHierarchyResponse_43(
           this,
           Invocation.method(
             #getSpaceHierarchy,
@@ -6533,10 +6569,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetSpaceHierarchyResponse>);
+      ) as _i15.Future<_i4.GetSpaceHierarchyResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
+  _i15.Future<_i4.GetRelatingEventsResponse> getRelatingEvents(
     String? roomId,
     String? eventId, {
     String? from,
@@ -6560,8 +6596,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #recurse: recurse,
           },
         ),
-        returnValue: _i14.Future<_i4.GetRelatingEventsResponse>.value(
-            _FakeGetRelatingEventsResponse_43(
+        returnValue: _i15.Future<_i4.GetRelatingEventsResponse>.value(
+            _FakeGetRelatingEventsResponse_44(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6579,8 +6615,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRelatingEventsResponse>.value(
-                _FakeGetRelatingEventsResponse_43(
+            _i15.Future<_i4.GetRelatingEventsResponse>.value(
+                _FakeGetRelatingEventsResponse_44(
           this,
           Invocation.method(
             #getRelatingEvents,
@@ -6597,10 +6633,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetRelatingEventsResponse>);
+      ) as _i15.Future<_i4.GetRelatingEventsResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>
+  _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>
       getRelatingEventsWithRelType(
     String? roomId,
     String? eventId,
@@ -6628,8 +6664,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               },
             ),
             returnValue:
-                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_44(
+                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6648,8 +6684,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
-                    _FakeGetRelatingEventsWithRelTypeResponse_44(
+                _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>.value(
+                    _FakeGetRelatingEventsWithRelTypeResponse_45(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelType,
@@ -6667,10 +6703,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i14.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
+          ) as _i15.Future<_i4.GetRelatingEventsWithRelTypeResponse>);
 
   @override
-  _i14.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
+  _i15.Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>
       getRelatingEventsWithRelTypeAndEventType(
     String? roomId,
     String? eventId,
@@ -6699,9 +6735,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 #recurse: recurse,
               },
             ),
-            returnValue: _i14.Future<
+            returnValue: _i15.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6720,9 +6756,9 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-            returnValueForMissingStub: _i14.Future<
+            returnValueForMissingStub: _i15.Future<
                     _i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>.value(
-                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_45(
+                _FakeGetRelatingEventsWithRelTypeAndEventTypeResponse_46(
               this,
               Invocation.method(
                 #getRelatingEventsWithRelTypeAndEventType,
@@ -6741,11 +6777,11 @@ class MockClient extends _i1.Mock implements _i4.Client {
                 },
               ),
             )),
-          ) as _i14
+          ) as _i15
               .Future<_i4.GetRelatingEventsWithRelTypeAndEventTypeResponse>);
 
   @override
-  _i14.Future<_i4.GetThreadRootsResponse> getThreadRoots(
+  _i15.Future<_i4.GetThreadRootsResponse> getThreadRoots(
     String? roomId, {
     _i4.Include? include,
     int? limit,
@@ -6761,8 +6797,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #from: from,
           },
         ),
-        returnValue: _i14.Future<_i4.GetThreadRootsResponse>.value(
-            _FakeGetThreadRootsResponse_46(
+        returnValue: _i15.Future<_i4.GetThreadRootsResponse>.value(
+            _FakeGetThreadRootsResponse_47(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6775,8 +6811,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetThreadRootsResponse>.value(
-                _FakeGetThreadRootsResponse_46(
+            _i15.Future<_i4.GetThreadRootsResponse>.value(
+                _FakeGetThreadRootsResponse_47(
           this,
           Invocation.method(
             #getThreadRoots,
@@ -6788,10 +6824,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetThreadRootsResponse>);
+      ) as _i15.Future<_i4.GetThreadRootsResponse>);
 
   @override
-  _i14.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
+  _i15.Future<_i4.GetEventByTimestampResponse> getEventByTimestamp(
     String? roomId,
     int? ts,
     _i4.Direction? dir,
@@ -6805,8 +6841,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             dir,
           ],
         ),
-        returnValue: _i14.Future<_i4.GetEventByTimestampResponse>.value(
-            _FakeGetEventByTimestampResponse_47(
+        returnValue: _i15.Future<_i4.GetEventByTimestampResponse>.value(
+            _FakeGetEventByTimestampResponse_48(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6818,8 +6854,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetEventByTimestampResponse>.value(
-                _FakeGetEventByTimestampResponse_47(
+            _i15.Future<_i4.GetEventByTimestampResponse>.value(
+                _FakeGetEventByTimestampResponse_48(
           this,
           Invocation.method(
             #getEventByTimestamp,
@@ -6830,33 +6866,33 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.GetEventByTimestampResponse>);
+      ) as _i15.Future<_i4.GetEventByTimestampResponse>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
+  _i15.Future<List<_i4.ThirdPartyIdentifier>?> getAccount3PIDs() =>
       (super.noSuchMethod(
         Invocation.method(
           #getAccount3PIDs,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+        returnValue: _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
-      ) as _i14.Future<List<_i4.ThirdPartyIdentifier>?>);
+            _i15.Future<List<_i4.ThirdPartyIdentifier>?>.value(),
+      ) as _i15.Future<List<_i4.ThirdPartyIdentifier>?>);
 
   @override
-  _i14.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
+  _i15.Future<Uri?> post3PIDs(_i4.ThreePidCredentials? threePidCreds) =>
       (super.noSuchMethod(
         Invocation.method(
           #post3PIDs,
           [threePidCreds],
         ),
-        returnValue: _i14.Future<Uri?>.value(),
-        returnValueForMissingStub: _i14.Future<Uri?>.value(),
-      ) as _i14.Future<Uri?>);
+        returnValue: _i15.Future<Uri?>.value(),
+        returnValueForMissingStub: _i15.Future<Uri?>.value(),
+      ) as _i15.Future<Uri?>);
 
   @override
-  _i14.Future<void> add3PID(
+  _i15.Future<void> add3PID(
     String? clientSecret,
     String? sid, {
     _i4.AuthenticationData? auth,
@@ -6870,12 +6906,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> bind3PID(
+  _i15.Future<void> bind3PID(
     String? clientSecret,
     String? idAccessToken,
     String? idServer,
@@ -6891,12 +6927,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             sid,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
+  _i15.Future<_i4.IdServerUnbindResult> delete3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -6910,14 +6946,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -6939,8 +6975,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6956,8 +6992,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenTo3PIDEmail,
@@ -6973,10 +7009,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenTo3PIDMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7000,8 +7036,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -7018,8 +7054,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenTo3PIDMSISDN,
@@ -7036,10 +7072,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
+  _i15.Future<_i4.IdServerUnbindResult> unbind3pidFromAccount(
     String? address,
     _i4.ThirdPartyIdentifierMedium? medium, {
     String? idServer,
@@ -7053,14 +7089,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#idServer: idServer},
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.IdServerUnbindResult> deactivateAccount({
+  _i15.Future<_i4.IdServerUnbindResult> deactivateAccount({
     _i4.AuthenticationData? auth,
     bool? erase,
     String? idServer,
@@ -7075,14 +7111,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValue: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-        returnValueForMissingStub: _i14.Future<_i4.IdServerUnbindResult>.value(
+        returnValueForMissingStub: _i15.Future<_i4.IdServerUnbindResult>.value(
             _i4.IdServerUnbindResult.noSupport),
-      ) as _i14.Future<_i4.IdServerUnbindResult>);
+      ) as _i15.Future<_i4.IdServerUnbindResult>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -7104,8 +7140,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7121,8 +7157,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToResetPasswordEmail,
@@ -7138,10 +7174,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToResetPasswordMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -7165,8 +7201,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7183,8 +7219,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToResetPasswordMSISDN,
@@ -7201,16 +7237,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
+  _i15.Future<_i4.TokenOwnerInfo> getTokenOwner() => (super.noSuchMethod(
         Invocation.method(
           #getTokenOwner,
           [],
         ),
         returnValue:
-            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
+            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_50(
           this,
           Invocation.method(
             #getTokenOwner,
@@ -7218,22 +7254,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_49(
+            _i15.Future<_i4.TokenOwnerInfo>.value(_FakeTokenOwnerInfo_50(
           this,
           Invocation.method(
             #getTokenOwner,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.TokenOwnerInfo>);
+      ) as _i15.Future<_i4.TokenOwnerInfo>);
 
   @override
-  _i14.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
+  _i15.Future<_i4.WhoIsInfo> getWhoIs(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #getWhoIs,
           [userId],
         ),
-        returnValue: _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
+        returnValue: _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_51(
           this,
           Invocation.method(
             #getWhoIs,
@@ -7241,22 +7277,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_50(
+            _i15.Future<_i4.WhoIsInfo>.value(_FakeWhoIsInfo_51(
           this,
           Invocation.method(
             #getWhoIs,
             [userId],
           ),
         )),
-      ) as _i14.Future<_i4.WhoIsInfo>);
+      ) as _i15.Future<_i4.WhoIsInfo>);
 
   @override
-  _i14.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
+  _i15.Future<_i4.Capabilities> getCapabilities() => (super.noSuchMethod(
         Invocation.method(
           #getCapabilities,
           [],
         ),
-        returnValue: _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
+        returnValue: _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_52(
           this,
           Invocation.method(
             #getCapabilities,
@@ -7264,17 +7300,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.Capabilities>.value(_FakeCapabilities_51(
+            _i15.Future<_i4.Capabilities>.value(_FakeCapabilities_52(
           this,
           Invocation.method(
             #getCapabilities,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.Capabilities>);
+      ) as _i15.Future<_i4.Capabilities>);
 
   @override
-  _i14.Future<String> createRoom({
+  _i15.Future<String> createRoom({
     Map<String, Object?>? creationContent,
     List<_i4.StateEvent>? initialState,
     List<String>? invite,
@@ -7307,7 +7343,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7329,7 +7365,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -7350,10 +7386,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> deleteDevices(
+  _i15.Future<void> deleteDevices(
     List<String>? devices, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7363,22 +7399,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [devices],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Device>?> getDevices() => (super.noSuchMethod(
         Invocation.method(
           #getDevices,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Device>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.Device>?>.value(),
-      ) as _i14.Future<List<_i4.Device>?>);
+        returnValue: _i15.Future<List<_i4.Device>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.Device>?>.value(),
+      ) as _i15.Future<List<_i4.Device>?>);
 
   @override
-  _i14.Future<void> deleteDevice(
+  _i15.Future<void> deleteDevice(
     String? deviceId, {
     _i4.AuthenticationData? auth,
   }) =>
@@ -7388,34 +7424,34 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#auth: auth},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
+  _i15.Future<_i4.Device> getDevice(String? deviceId) => (super.noSuchMethod(
         Invocation.method(
           #getDevice,
           [deviceId],
         ),
-        returnValue: _i14.Future<_i4.Device>.value(_FakeDevice_52(
+        returnValue: _i15.Future<_i4.Device>.value(_FakeDevice_53(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Device>.value(_FakeDevice_52(
+        returnValueForMissingStub: _i15.Future<_i4.Device>.value(_FakeDevice_53(
           this,
           Invocation.method(
             #getDevice,
             [deviceId],
           ),
         )),
-      ) as _i14.Future<_i4.Device>);
+      ) as _i15.Future<_i4.Device>);
 
   @override
-  _i14.Future<void> updateDevice(
+  _i15.Future<void> updateDevice(
     String? deviceId, {
     String? displayName,
   }) =>
@@ -7425,12 +7461,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [deviceId],
           {#displayName: displayName},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
+  _i15.Future<Map<String, Object?>> updateAppserviceRoomDirectoryVisibility(
     String? networkId,
     String? roomId,
     _i4.Visibility? visibility,
@@ -7445,24 +7481,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
+  _i15.Future<_i4.Visibility?> getRoomVisibilityOnDirectory(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomVisibilityOnDirectory,
           [roomId],
         ),
-        returnValue: _i14.Future<_i4.Visibility?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Visibility?>.value(),
-      ) as _i14.Future<_i4.Visibility?>);
+        returnValue: _i15.Future<_i4.Visibility?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Visibility?>.value(),
+      ) as _i15.Future<_i4.Visibility?>);
 
   @override
-  _i14.Future<void> setRoomVisibilityOnDirectory(
+  _i15.Future<void> setRoomVisibilityOnDirectory(
     String? roomId, {
     _i4.Visibility? visibility,
   }) =>
@@ -7472,30 +7508,30 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#visibility: visibility},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
+  _i15.Future<void> deleteRoomAlias(String? roomAlias) => (super.noSuchMethod(
         Invocation.method(
           #deleteRoomAlias,
           [roomAlias],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
+  _i15.Future<_i4.GetRoomIdByAliasResponse> getRoomIdByAlias(
           String? roomAlias) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomIdByAlias,
           [roomAlias],
         ),
-        returnValue: _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
-            _FakeGetRoomIdByAliasResponse_53(
+        returnValue: _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
+            _FakeGetRoomIdByAliasResponse_54(
           this,
           Invocation.method(
             #getRoomIdByAlias,
@@ -7503,18 +7539,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomIdByAliasResponse>.value(
-                _FakeGetRoomIdByAliasResponse_53(
+            _i15.Future<_i4.GetRoomIdByAliasResponse>.value(
+                _FakeGetRoomIdByAliasResponse_54(
           this,
           Invocation.method(
             #getRoomIdByAlias,
             [roomAlias],
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomIdByAliasResponse>);
+      ) as _i15.Future<_i4.GetRoomIdByAliasResponse>);
 
   @override
-  _i14.Future<void> setRoomAlias(
+  _i15.Future<void> setRoomAlias(
     String? roomAlias,
     String? roomId,
   ) =>
@@ -7526,12 +7562,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetEventsResponse> getEvents({
+  _i15.Future<_i4.GetEventsResponse> getEvents({
     String? from,
     int? timeout,
   }) =>
@@ -7545,7 +7581,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
+            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_55(
           this,
           Invocation.method(
             #getEvents,
@@ -7557,7 +7593,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_54(
+            _i15.Future<_i4.GetEventsResponse>.value(_FakeGetEventsResponse_55(
           this,
           Invocation.method(
             #getEvents,
@@ -7568,10 +7604,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetEventsResponse>);
+      ) as _i15.Future<_i4.GetEventsResponse>);
 
   @override
-  _i14.Future<_i4.PeekEventsResponse> peekEvents({
+  _i15.Future<_i4.PeekEventsResponse> peekEvents({
     String? from,
     int? timeout,
     String? roomId,
@@ -7586,8 +7622,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #roomId: roomId,
           },
         ),
-        returnValue: _i14.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_55(
+        returnValue: _i15.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_56(
           this,
           Invocation.method(
             #peekEvents,
@@ -7599,8 +7635,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.PeekEventsResponse>.value(
-            _FakePeekEventsResponse_55(
+        returnValueForMissingStub: _i15.Future<_i4.PeekEventsResponse>.value(
+            _FakePeekEventsResponse_56(
           this,
           Invocation.method(
             #peekEvents,
@@ -7612,16 +7648,16 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.PeekEventsResponse>);
+      ) as _i15.Future<_i4.PeekEventsResponse>);
 
   @override
-  _i14.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
+  _i15.Future<_i4.MatrixEvent> getOneEvent(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getOneEvent,
           [eventId],
         ),
-        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
+        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
           this,
           Invocation.method(
             #getOneEvent,
@@ -7629,27 +7665,27 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
+            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
           this,
           Invocation.method(
             #getOneEvent,
             [eventId],
           ),
         )),
-      ) as _i14.Future<_i4.MatrixEvent>);
+      ) as _i15.Future<_i4.MatrixEvent>);
 
   @override
-  _i14.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
+  _i15.Future<List<String>> getJoinedRooms() => (super.noSuchMethod(
         Invocation.method(
           #getJoinedRooms,
           [],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 
   @override
-  _i14.Future<_i4.GetKeysChangesResponse> getKeysChanges(
+  _i15.Future<_i4.GetKeysChangesResponse> getKeysChanges(
     String? from,
     String? to,
   ) =>
@@ -7661,8 +7697,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             to,
           ],
         ),
-        returnValue: _i14.Future<_i4.GetKeysChangesResponse>.value(
-            _FakeGetKeysChangesResponse_57(
+        returnValue: _i15.Future<_i4.GetKeysChangesResponse>.value(
+            _FakeGetKeysChangesResponse_58(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7673,8 +7709,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetKeysChangesResponse>.value(
-                _FakeGetKeysChangesResponse_57(
+            _i15.Future<_i4.GetKeysChangesResponse>.value(
+                _FakeGetKeysChangesResponse_58(
           this,
           Invocation.method(
             #getKeysChanges,
@@ -7684,10 +7720,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.GetKeysChangesResponse>);
+      ) as _i15.Future<_i4.GetKeysChangesResponse>);
 
   @override
-  _i14.Future<_i4.ClaimKeysResponse> claimKeys(
+  _i15.Future<_i4.ClaimKeysResponse> claimKeys(
     Map<String, Map<String, String>>? oneTimeKeys, {
     int? timeout,
   }) =>
@@ -7698,7 +7734,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
+            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_59(
           this,
           Invocation.method(
             #claimKeys,
@@ -7707,7 +7743,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_58(
+            _i15.Future<_i4.ClaimKeysResponse>.value(_FakeClaimKeysResponse_59(
           this,
           Invocation.method(
             #claimKeys,
@@ -7715,10 +7751,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i14.Future<_i4.ClaimKeysResponse>);
+      ) as _i15.Future<_i4.ClaimKeysResponse>);
 
   @override
-  _i14.Future<void> uploadCrossSigningKeys({
+  _i15.Future<void> uploadCrossSigningKeys({
     _i4.AuthenticationData? auth,
     _i4.MatrixCrossSigningKey? masterKey,
     _i4.MatrixCrossSigningKey? selfSigningKey,
@@ -7735,12 +7771,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #userSigningKey: userSigningKey,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.QueryKeysResponse> queryKeys(
+  _i15.Future<_i4.QueryKeysResponse> queryKeys(
     Map<String, List<String>>? deviceKeys, {
     int? timeout,
   }) =>
@@ -7751,7 +7787,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#timeout: timeout},
         ),
         returnValue:
-            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
+            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_60(
           this,
           Invocation.method(
             #queryKeys,
@@ -7760,7 +7796,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_59(
+            _i15.Future<_i4.QueryKeysResponse>.value(_FakeQueryKeysResponse_60(
           this,
           Invocation.method(
             #queryKeys,
@@ -7768,10 +7804,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#timeout: timeout},
           ),
         )),
-      ) as _i14.Future<_i4.QueryKeysResponse>);
+      ) as _i15.Future<_i4.QueryKeysResponse>);
 
   @override
-  _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>
+  _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>
       uploadCrossSigningSignatures(
               Map<String, Map<String, Map<String, Object?>>>? body) =>
           (super.noSuchMethod(
@@ -7779,14 +7815,14 @@ class MockClient extends _i1.Mock implements _i4.Client {
               #uploadCrossSigningSignatures,
               [body],
             ),
-            returnValue: _i14.Future<
+            returnValue: _i15.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-            returnValueForMissingStub: _i14.Future<
+            returnValueForMissingStub: _i15.Future<
                 Map<String, Map<String, Map<String, Object?>>>?>.value(),
-          ) as _i14.Future<Map<String, Map<String, Map<String, Object?>>>?>);
+          ) as _i15.Future<Map<String, Map<String, Map<String, Object?>>>?>);
 
   @override
-  _i14.Future<Map<String, int>> uploadKeys({
+  _i15.Future<Map<String, int>> uploadKeys({
     _i4.MatrixDeviceKeys? deviceKeys,
     Map<String, Object?>? fallbackKeys,
     Map<String, Object?>? oneTimeKeys,
@@ -7801,13 +7837,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #oneTimeKeys: oneTimeKeys,
           },
         ),
-        returnValue: _i14.Future<Map<String, int>>.value(<String, int>{}),
+        returnValue: _i15.Future<Map<String, int>>.value(<String, int>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, int>>.value(<String, int>{}),
-      ) as _i14.Future<Map<String, int>>);
+            _i15.Future<Map<String, int>>.value(<String, int>{}),
+      ) as _i15.Future<Map<String, int>>);
 
   @override
-  _i14.Future<String> knockRoom(
+  _i15.Future<String> knockRoom(
     String? roomIdOrAlias, {
     List<String>? via,
     String? reason,
@@ -7821,7 +7857,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7833,7 +7869,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -7844,20 +7880,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
+  _i15.Future<List<_i4.LoginFlow>?> getLoginFlows() => (super.noSuchMethod(
         Invocation.method(
           #getLoginFlows,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.LoginFlow>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.LoginFlow>?>.value(),
-      ) as _i14.Future<List<_i4.LoginFlow>?>);
+        returnValue: _i15.Future<List<_i4.LoginFlow>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.LoginFlow>?>.value(),
+      ) as _i15.Future<List<_i4.LoginFlow>?>);
 
   @override
-  _i14.Future<_i4.GetNotificationsResponse> getNotifications({
+  _i15.Future<_i4.GetNotificationsResponse> getNotifications({
     String? from,
     int? limit,
     String? only,
@@ -7872,8 +7908,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #only: only,
           },
         ),
-        returnValue: _i14.Future<_i4.GetNotificationsResponse>.value(
-            _FakeGetNotificationsResponse_60(
+        returnValue: _i15.Future<_i4.GetNotificationsResponse>.value(
+            _FakeGetNotificationsResponse_61(
           this,
           Invocation.method(
             #getNotifications,
@@ -7886,8 +7922,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetNotificationsResponse>.value(
-                _FakeGetNotificationsResponse_60(
+            _i15.Future<_i4.GetNotificationsResponse>.value(
+                _FakeGetNotificationsResponse_61(
           this,
           Invocation.method(
             #getNotifications,
@@ -7899,35 +7935,35 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetNotificationsResponse>);
+      ) as _i15.Future<_i4.GetNotificationsResponse>);
 
   @override
-  _i14.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
+  _i15.Future<_i4.GetPresenceResponse> getPresence(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPresence,
           [userId],
         ),
-        returnValue: _i14.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_61(
+        returnValue: _i15.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_62(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetPresenceResponse>.value(
-            _FakeGetPresenceResponse_61(
+        returnValueForMissingStub: _i15.Future<_i4.GetPresenceResponse>.value(
+            _FakeGetPresenceResponse_62(
           this,
           Invocation.method(
             #getPresence,
             [userId],
           ),
         )),
-      ) as _i14.Future<_i4.GetPresenceResponse>);
+      ) as _i15.Future<_i4.GetPresenceResponse>);
 
   @override
-  _i14.Future<void> setPresence(
+  _i15.Future<void> setPresence(
     String? userId,
     _i4.PresenceType? presence, {
     String? statusMsg,
@@ -7941,12 +7977,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#statusMsg: statusMsg},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, Object?>> deleteProfileField(
+  _i15.Future<Map<String, Object?>> deleteProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7959,13 +7995,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getProfileField(
+  _i15.Future<Map<String, Object?>> getProfileField(
     String? userId,
     String? keyName,
   ) =>
@@ -7978,13 +8014,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<Map<String, Object?>> setProfileField(
+  _i15.Future<Map<String, Object?>> setProfileField(
     String? userId,
     String? keyName,
     Map<String, Object?>? body,
@@ -7999,13 +8035,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
+  _i15.Future<_i4.GetPublicRoomsResponse> getPublicRooms({
     int? limit,
     String? since,
     String? server,
@@ -8020,8 +8056,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #server: server,
           },
         ),
-        returnValue: _i14.Future<_i4.GetPublicRoomsResponse>.value(
-            _FakeGetPublicRoomsResponse_62(
+        returnValue: _i15.Future<_i4.GetPublicRoomsResponse>.value(
+            _FakeGetPublicRoomsResponse_63(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -8034,8 +8070,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetPublicRoomsResponse>.value(
-                _FakeGetPublicRoomsResponse_62(
+            _i15.Future<_i4.GetPublicRoomsResponse>.value(
+                _FakeGetPublicRoomsResponse_63(
           this,
           Invocation.method(
             #getPublicRooms,
@@ -8047,10 +8083,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetPublicRoomsResponse>);
+      ) as _i15.Future<_i4.GetPublicRoomsResponse>);
 
   @override
-  _i14.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
+  _i15.Future<_i4.QueryPublicRoomsResponse> queryPublicRooms({
     String? server,
     _i4.PublicRoomQueryFilter? filter,
     bool? includeAllNetworks,
@@ -8071,8 +8107,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartyInstanceId: thirdPartyInstanceId,
           },
         ),
-        returnValue: _i14.Future<_i4.QueryPublicRoomsResponse>.value(
-            _FakeQueryPublicRoomsResponse_63(
+        returnValue: _i15.Future<_i4.QueryPublicRoomsResponse>.value(
+            _FakeQueryPublicRoomsResponse_64(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8088,8 +8124,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.QueryPublicRoomsResponse>.value(
-                _FakeQueryPublicRoomsResponse_63(
+            _i15.Future<_i4.QueryPublicRoomsResponse>.value(
+                _FakeQueryPublicRoomsResponse_64(
           this,
           Invocation.method(
             #queryPublicRooms,
@@ -8104,25 +8140,25 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.QueryPublicRoomsResponse>);
+      ) as _i15.Future<_i4.QueryPublicRoomsResponse>);
 
   @override
-  _i14.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
+  _i15.Future<List<_i4.Pusher>?> getPushers() => (super.noSuchMethod(
         Invocation.method(
           #getPushers,
           [],
         ),
-        returnValue: _i14.Future<List<_i4.Pusher>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.Pusher>?>.value(),
-      ) as _i14.Future<List<_i4.Pusher>?>);
+        returnValue: _i15.Future<List<_i4.Pusher>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.Pusher>?>.value(),
+      ) as _i15.Future<List<_i4.Pusher>?>);
 
   @override
-  _i14.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
+  _i15.Future<_i4.PushRuleSet> getPushRules() => (super.noSuchMethod(
         Invocation.method(
           #getPushRules,
           [],
         ),
-        returnValue: _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
+        returnValue: _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_65(
           this,
           Invocation.method(
             #getPushRules,
@@ -8130,24 +8166,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_64(
+            _i15.Future<_i4.PushRuleSet>.value(_FakePushRuleSet_65(
           this,
           Invocation.method(
             #getPushRules,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.PushRuleSet>);
+      ) as _i15.Future<_i4.PushRuleSet>);
 
   @override
-  _i14.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
+  _i15.Future<_i4.GetPushRulesGlobalResponse> getPushRulesGlobal() =>
       (super.noSuchMethod(
         Invocation.method(
           #getPushRulesGlobal,
           [],
         ),
-        returnValue: _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
-            _FakeGetPushRulesGlobalResponse_65(
+        returnValue: _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
+            _FakeGetPushRulesGlobalResponse_66(
           this,
           Invocation.method(
             #getPushRulesGlobal,
@@ -8155,18 +8191,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetPushRulesGlobalResponse>.value(
-                _FakeGetPushRulesGlobalResponse_65(
+            _i15.Future<_i4.GetPushRulesGlobalResponse>.value(
+                _FakeGetPushRulesGlobalResponse_66(
           this,
           Invocation.method(
             #getPushRulesGlobal,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.GetPushRulesGlobalResponse>);
+      ) as _i15.Future<_i4.GetPushRulesGlobalResponse>);
 
   @override
-  _i14.Future<void> deletePushRule(
+  _i15.Future<void> deletePushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8178,12 +8214,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.PushRule> getPushRule(
+  _i15.Future<_i4.PushRule> getPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8195,7 +8231,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<_i4.PushRule>.value(_FakePushRule_66(
+        returnValue: _i15.Future<_i4.PushRule>.value(_FakePushRule_67(
           this,
           Invocation.method(
             #getPushRule,
@@ -8206,7 +8242,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.PushRule>.value(_FakePushRule_66(
+            _i15.Future<_i4.PushRule>.value(_FakePushRule_67(
           this,
           Invocation.method(
             #getPushRule,
@@ -8216,10 +8252,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.PushRule>);
+      ) as _i15.Future<_i4.PushRule>);
 
   @override
-  _i14.Future<void> setPushRule(
+  _i15.Future<void> setPushRule(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions, {
@@ -8243,12 +8279,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #pattern: pattern,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<Object?>> getPushRuleActions(
+  _i15.Future<List<Object?>> getPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8260,13 +8296,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<List<Object?>>.value(<Object?>[]),
+        returnValue: _i15.Future<List<Object?>>.value(<Object?>[]),
         returnValueForMissingStub:
-            _i14.Future<List<Object?>>.value(<Object?>[]),
-      ) as _i14.Future<List<Object?>>);
+            _i15.Future<List<Object?>>.value(<Object?>[]),
+      ) as _i15.Future<List<Object?>>);
 
   @override
-  _i14.Future<void> setPushRuleActions(
+  _i15.Future<void> setPushRuleActions(
     _i4.PushRuleKind? kind,
     String? ruleId,
     List<Object?>? actions,
@@ -8280,12 +8316,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             actions,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<bool> isPushRuleEnabled(
+  _i15.Future<bool> isPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
   ) =>
@@ -8297,12 +8333,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ruleId,
           ],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> setPushRuleEnabled(
+  _i15.Future<void> setPushRuleEnabled(
     _i4.PushRuleKind? kind,
     String? ruleId,
     bool? enabled,
@@ -8316,19 +8352,19 @@ class MockClient extends _i1.Mock implements _i4.Client {
             enabled,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
+  _i15.Future<_i4.RefreshResponse> refresh(String? refreshToken) =>
       (super.noSuchMethod(
         Invocation.method(
           #refresh,
           [refreshToken],
         ),
         returnValue:
-            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
+            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_68(
           this,
           Invocation.method(
             #refresh,
@@ -8336,28 +8372,28 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_67(
+            _i15.Future<_i4.RefreshResponse>.value(_FakeRefreshResponse_68(
           this,
           Invocation.method(
             #refresh,
             [refreshToken],
           ),
         )),
-      ) as _i14.Future<_i4.RefreshResponse>);
+      ) as _i15.Future<_i4.RefreshResponse>);
 
   @override
-  _i14.Future<bool?> checkUsernameAvailability(String? username) =>
+  _i15.Future<bool?> checkUsernameAvailability(String? username) =>
       (super.noSuchMethod(
         Invocation.method(
           #checkUsernameAvailability,
           [username],
         ),
-        returnValue: _i14.Future<bool?>.value(),
-        returnValueForMissingStub: _i14.Future<bool?>.value(),
-      ) as _i14.Future<bool?>);
+        returnValue: _i15.Future<bool?>.value(),
+        returnValueForMissingStub: _i15.Future<bool?>.value(),
+      ) as _i15.Future<bool?>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterEmail(
     String? clientSecret,
     String? email,
     int? sendAttempt, {
@@ -8379,8 +8415,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8396,8 +8432,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToRegisterEmail,
@@ -8413,10 +8449,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
+  _i15.Future<_i4.RequestTokenResponse> requestTokenToRegisterMSISDN(
     String? clientSecret,
     String? country,
     String? phoneNumber,
@@ -8440,8 +8476,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #idServer: idServer,
           },
         ),
-        returnValue: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValue: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8458,8 +8494,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.RequestTokenResponse>.value(
-            _FakeRequestTokenResponse_48(
+        returnValueForMissingStub: _i15.Future<_i4.RequestTokenResponse>.value(
+            _FakeRequestTokenResponse_49(
           this,
           Invocation.method(
             #requestTokenToRegisterMSISDN,
@@ -8476,17 +8512,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.RequestTokenResponse>);
+      ) as _i15.Future<_i4.RequestTokenResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeys(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeys,
           [version],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeys,
@@ -8494,23 +8530,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeys,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
+  _i15.Future<_i4.RoomKeys> getRoomKeys(String? version) => (super.noSuchMethod(
         Invocation.method(
           #getRoomKeys,
           [version],
         ),
-        returnValue: _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
+        returnValue: _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_69(
           this,
           Invocation.method(
             #getRoomKeys,
@@ -8518,17 +8554,17 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeys>.value(_FakeRoomKeys_68(
+            _i15.Future<_i4.RoomKeys>.value(_FakeRoomKeys_69(
           this,
           Invocation.method(
             #getRoomKeys,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeys>);
+      ) as _i15.Future<_i4.RoomKeys>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeys(
     String? version,
     _i4.RoomKeys? body,
   ) =>
@@ -8540,8 +8576,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8552,8 +8588,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeys,
@@ -8563,10 +8599,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8578,8 +8614,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8590,8 +8626,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeysByRoomId,
@@ -8601,10 +8637,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeyBackup> getRoomKeysByRoomId(
     String? roomId,
     String? version,
   ) =>
@@ -8616,7 +8652,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
+        returnValue: _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_70(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8627,7 +8663,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_69(
+            _i15.Future<_i4.RoomKeyBackup>.value(_FakeRoomKeyBackup_70(
           this,
           Invocation.method(
             #getRoomKeysByRoomId,
@@ -8637,10 +8673,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeyBackup>);
+      ) as _i15.Future<_i4.RoomKeyBackup>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeysByRoomId(
     String? roomId,
     String? version,
     _i4.RoomKeyBackup? body,
@@ -8654,8 +8690,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8667,8 +8703,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeysByRoomId,
@@ -8679,10 +8715,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> deleteRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8696,8 +8732,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8709,8 +8745,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #deleteRoomKeyBySessionId,
@@ -8721,10 +8757,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
+  _i15.Future<_i4.KeyBackupData> getRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8738,7 +8774,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             version,
           ],
         ),
-        returnValue: _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
+        returnValue: _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8750,7 +8786,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_38(
+            _i15.Future<_i4.KeyBackupData>.value(_FakeKeyBackupData_39(
           this,
           Invocation.method(
             #getRoomKeyBySessionId,
@@ -8761,10 +8797,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.KeyBackupData>);
+      ) as _i15.Future<_i4.KeyBackupData>);
 
   @override
-  _i14.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
+  _i15.Future<_i4.RoomKeysUpdateResponse> putRoomKeyBySessionId(
     String? roomId,
     String? sessionId,
     String? version,
@@ -8780,8 +8816,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-            _FakeRoomKeysUpdateResponse_37(
+        returnValue: _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+            _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8794,8 +8830,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.RoomKeysUpdateResponse>.value(
-                _FakeRoomKeysUpdateResponse_37(
+            _i15.Future<_i4.RoomKeysUpdateResponse>.value(
+                _FakeRoomKeysUpdateResponse_38(
           this,
           Invocation.method(
             #putRoomKeyBySessionId,
@@ -8807,18 +8843,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.RoomKeysUpdateResponse>);
+      ) as _i15.Future<_i4.RoomKeysUpdateResponse>);
 
   @override
-  _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>
+  _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>
       getRoomKeysVersionCurrent() => (super.noSuchMethod(
             Invocation.method(
               #getRoomKeysVersionCurrent,
               [],
             ),
             returnValue:
-                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_70(
+                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_71(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
@@ -8826,18 +8862,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
               ),
             )),
             returnValueForMissingStub:
-                _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
-                    _FakeGetRoomKeysVersionCurrentResponse_70(
+                _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>.value(
+                    _FakeGetRoomKeysVersionCurrentResponse_71(
               this,
               Invocation.method(
                 #getRoomKeysVersionCurrent,
                 [],
               ),
             )),
-          ) as _i14.Future<_i4.GetRoomKeysVersionCurrentResponse>);
+          ) as _i15.Future<_i4.GetRoomKeysVersionCurrentResponse>);
 
   @override
-  _i14.Future<String> postRoomKeysVersion(
+  _i15.Future<String> postRoomKeysVersion(
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
   ) =>
@@ -8849,7 +8885,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             authData,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8860,7 +8896,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -8870,29 +8906,29 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> deleteRoomKeysVersion(String? version) =>
+  _i15.Future<void> deleteRoomKeysVersion(String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteRoomKeysVersion,
           [version],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
+  _i15.Future<_i4.GetRoomKeysVersionResponse> getRoomKeysVersion(
           String? version) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomKeysVersion,
           [version],
         ),
-        returnValue: _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
-            _FakeGetRoomKeysVersionResponse_71(
+        returnValue: _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
+            _FakeGetRoomKeysVersionResponse_72(
           this,
           Invocation.method(
             #getRoomKeysVersion,
@@ -8900,18 +8936,18 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetRoomKeysVersionResponse>.value(
-                _FakeGetRoomKeysVersionResponse_71(
+            _i15.Future<_i4.GetRoomKeysVersionResponse>.value(
+                _FakeGetRoomKeysVersionResponse_72(
           this,
           Invocation.method(
             #getRoomKeysVersion,
             [version],
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomKeysVersionResponse>);
+      ) as _i15.Future<_i4.GetRoomKeysVersionResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> putRoomKeysVersion(
+  _i15.Future<Map<String, Object?>> putRoomKeysVersion(
     String? version,
     _i4.BackupAlgorithm? algorithm,
     Map<String, Object?>? authData,
@@ -8926,24 +8962,24 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<List<String>> getLocalAliases(String? roomId) =>
+  _i15.Future<List<String>> getLocalAliases(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getLocalAliases,
           [roomId],
         ),
-        returnValue: _i14.Future<List<String>>.value(<String>[]),
-        returnValueForMissingStub: _i14.Future<List<String>>.value(<String>[]),
-      ) as _i14.Future<List<String>>);
+        returnValue: _i15.Future<List<String>>.value(<String>[]),
+        returnValueForMissingStub: _i15.Future<List<String>>.value(<String>[]),
+      ) as _i15.Future<List<String>>);
 
   @override
-  _i14.Future<void> ban(
+  _i15.Future<void> ban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -8957,12 +8993,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.EventContext> getEventContext(
+  _i15.Future<_i4.EventContext> getEventContext(
     String? roomId,
     String? eventId, {
     int? limit,
@@ -8980,7 +9016,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i4.EventContext>.value(_FakeEventContext_72(
+        returnValue: _i15.Future<_i4.EventContext>.value(_FakeEventContext_73(
           this,
           Invocation.method(
             #getEventContext,
@@ -8995,7 +9031,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.EventContext>.value(_FakeEventContext_72(
+            _i15.Future<_i4.EventContext>.value(_FakeEventContext_73(
           this,
           Invocation.method(
             #getEventContext,
@@ -9009,10 +9045,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.EventContext>);
+      ) as _i15.Future<_i4.EventContext>);
 
   @override
-  _i14.Future<_i4.MatrixEvent> getOneRoomEvent(
+  _i15.Future<_i4.MatrixEvent> getOneRoomEvent(
     String? roomId,
     String? eventId,
   ) =>
@@ -9024,7 +9060,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             eventId,
           ],
         ),
-        returnValue: _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
+        returnValue: _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -9035,7 +9071,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_56(
+            _i15.Future<_i4.MatrixEvent>.value(_FakeMatrixEvent_57(
           this,
           Invocation.method(
             #getOneRoomEvent,
@@ -9045,20 +9081,20 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.MatrixEvent>);
+      ) as _i15.Future<_i4.MatrixEvent>);
 
   @override
-  _i14.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> forgetRoom(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #forgetRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> inviteBy3PID(
+  _i15.Future<void> inviteBy3PID(
     String? roomId,
     _i4.Invite3pid? body,
   ) =>
@@ -9070,12 +9106,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> inviteUser(
+  _i15.Future<void> inviteUser(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9089,12 +9125,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> joinRoomById(
+  _i15.Future<String> joinRoomById(
     String? roomId, {
     String? reason,
     _i4.ThirdPartySigned? thirdPartySigned,
@@ -9108,7 +9144,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9120,7 +9156,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -9131,23 +9167,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
+  _i15.Future<Map<String, _i4.RoomMember>?> getJoinedMembersByRoom(
           String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getJoinedMembersByRoom,
           [roomId],
         ),
-        returnValue: _i14.Future<Map<String, _i4.RoomMember>?>.value(),
+        returnValue: _i15.Future<Map<String, _i4.RoomMember>?>.value(),
         returnValueForMissingStub:
-            _i14.Future<Map<String, _i4.RoomMember>?>.value(),
-      ) as _i14.Future<Map<String, _i4.RoomMember>?>);
+            _i15.Future<Map<String, _i4.RoomMember>?>.value(),
+      ) as _i15.Future<Map<String, _i4.RoomMember>?>);
 
   @override
-  _i14.Future<void> kick(
+  _i15.Future<void> kick(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9161,12 +9197,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> leaveRoom(
+  _i15.Future<void> leaveRoom(
     String? roomId, {
     String? reason,
   }) =>
@@ -9176,12 +9212,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [roomId],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
+  _i15.Future<List<_i4.MatrixEvent>?> getMembersByRoom(
     String? roomId, {
     String? at,
     _i4.Membership? membership,
@@ -9197,12 +9233,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #notMembership: notMembership,
           },
         ),
-        returnValue: _i14.Future<List<_i4.MatrixEvent>?>.value(),
-        returnValueForMissingStub: _i14.Future<List<_i4.MatrixEvent>?>.value(),
-      ) as _i14.Future<List<_i4.MatrixEvent>?>);
+        returnValue: _i15.Future<List<_i4.MatrixEvent>?>.value(),
+        returnValueForMissingStub: _i15.Future<List<_i4.MatrixEvent>?>.value(),
+      ) as _i15.Future<List<_i4.MatrixEvent>?>);
 
   @override
-  _i14.Future<_i4.GetRoomEventsResponse> getRoomEvents(
+  _i15.Future<_i4.GetRoomEventsResponse> getRoomEvents(
     String? roomId,
     _i4.Direction? dir, {
     String? from,
@@ -9224,8 +9260,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #filter: filter,
           },
         ),
-        returnValue: _i14.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_73(
+        returnValue: _i15.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_74(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9241,8 +9277,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.GetRoomEventsResponse>.value(
-            _FakeGetRoomEventsResponse_73(
+        returnValueForMissingStub: _i15.Future<_i4.GetRoomEventsResponse>.value(
+            _FakeGetRoomEventsResponse_74(
           this,
           Invocation.method(
             #getRoomEvents,
@@ -9258,10 +9294,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.GetRoomEventsResponse>);
+      ) as _i15.Future<_i4.GetRoomEventsResponse>);
 
   @override
-  _i14.Future<void> setReadMarker(
+  _i15.Future<void> setReadMarker(
     String? roomId, {
     String? mFullyRead,
     String? mRead,
@@ -9277,12 +9313,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #mReadPrivate: mReadPrivate,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> postReceipt(
+  _i15.Future<void> postReceipt(
     String? roomId,
     _i4.ReceiptType? receiptType,
     String? eventId, {
@@ -9298,12 +9334,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#threadId: threadId},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> redactEvent(
+  _i15.Future<String?> redactEvent(
     String? roomId,
     String? eventId,
     String? txnId, {
@@ -9319,12 +9355,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<void> reportRoom(
+  _i15.Future<void> reportRoom(
     String? roomId,
     String? reason,
   ) =>
@@ -9336,12 +9372,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             reason,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> reportEvent(
+  _i15.Future<void> reportEvent(
     String? roomId,
     String? eventId, {
     String? reason,
@@ -9359,12 +9395,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #score: score,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> sendMessage(
+  _i15.Future<String> sendMessage(
     String? roomId,
     String? eventType,
     String? txnId,
@@ -9380,7 +9416,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9393,7 +9429,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -9405,23 +9441,23 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
+  _i15.Future<List<_i4.MatrixEvent>> getRoomState(String? roomId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getRoomState,
           [roomId],
         ),
         returnValue:
-            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
-      ) as _i14.Future<List<_i4.MatrixEvent>>);
+            _i15.Future<List<_i4.MatrixEvent>>.value(<_i4.MatrixEvent>[]),
+      ) as _i15.Future<List<_i4.MatrixEvent>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getRoomStateWithKey(
+  _i15.Future<Map<String, Object?>> getRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey, {
@@ -9438,13 +9474,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#format: format},
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<String> setRoomStateWithKey(
+  _i15.Future<String> setRoomStateWithKey(
     String? roomId,
     String? eventType,
     String? stateKey,
@@ -9460,7 +9496,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9473,7 +9509,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -9485,10 +9521,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<void> unban(
+  _i15.Future<void> unban(
     String? roomId,
     String? userId, {
     String? reason,
@@ -9502,12 +9538,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#reason: reason},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> upgradeRoom(
+  _i15.Future<String> upgradeRoom(
     String? roomId,
     String? newVersion, {
     List<String>? additionalCreators,
@@ -9521,7 +9557,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9533,7 +9569,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -9544,10 +9580,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#additionalCreators: additionalCreators},
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.SearchResults> search(
+  _i15.Future<_i4.SearchResults> search(
     _i4.Categories? searchCategories, {
     String? nextBatch,
   }) =>
@@ -9557,7 +9593,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchCategories],
           {#nextBatch: nextBatch},
         ),
-        returnValue: _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
+        returnValue: _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_75(
           this,
           Invocation.method(
             #search,
@@ -9566,7 +9602,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SearchResults>.value(_FakeSearchResults_74(
+            _i15.Future<_i4.SearchResults>.value(_FakeSearchResults_75(
           this,
           Invocation.method(
             #search,
@@ -9574,10 +9610,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#nextBatch: nextBatch},
           ),
         )),
-      ) as _i14.Future<_i4.SearchResults>);
+      ) as _i15.Future<_i4.SearchResults>);
 
   @override
-  _i14.Future<_i4.SyncUpdate> sync({
+  _i15.Future<_i4.SyncUpdate> sync({
     String? filter,
     String? since,
     bool? fullState,
@@ -9598,7 +9634,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             #useStateAfter: useStateAfter,
           },
         ),
-        returnValue: _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+        returnValue: _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #sync,
@@ -9614,7 +9650,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_14(
+            _i15.Future<_i4.SyncUpdate>.value(_FakeSyncUpdate_15(
           this,
           Invocation.method(
             #sync,
@@ -9629,22 +9665,22 @@ class MockClient extends _i1.Mock implements _i4.Client {
             },
           ),
         )),
-      ) as _i14.Future<_i4.SyncUpdate>);
+      ) as _i15.Future<_i4.SyncUpdate>);
 
   @override
-  _i14.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
+  _i15.Future<List<_i4.Location>> queryLocationByAlias(String? alias) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryLocationByAlias,
           [alias],
         ),
-        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i14.Future<List<_i4.Location>>);
+            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i15.Future<List<_i4.Location>>);
 
   @override
-  _i14.Future<List<_i4.Location>> queryLocationByProtocol(
+  _i15.Future<List<_i4.Location>> queryLocationByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9654,21 +9690,21 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [protocol],
           {#fields: fields},
         ),
-        returnValue: _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+        returnValue: _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.Location>>.value(<_i4.Location>[]),
-      ) as _i14.Future<List<_i4.Location>>);
+            _i15.Future<List<_i4.Location>>.value(<_i4.Location>[]),
+      ) as _i15.Future<List<_i4.Location>>);
 
   @override
-  _i14.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
+  _i15.Future<_i4.GetProtocolMetadataResponse$2> getProtocolMetadata(
           String? protocol) =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocolMetadata,
           [protocol],
         ),
-        returnValue: _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
-            _FakeGetProtocolMetadataResponse$2_75(
+        returnValue: _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
+            _FakeGetProtocolMetadataResponse$2_76(
           this,
           Invocation.method(
             #getProtocolMetadata,
@@ -9676,45 +9712,45 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.GetProtocolMetadataResponse$2>.value(
-                _FakeGetProtocolMetadataResponse$2_75(
+            _i15.Future<_i4.GetProtocolMetadataResponse$2>.value(
+                _FakeGetProtocolMetadataResponse$2_76(
           this,
           Invocation.method(
             #getProtocolMetadata,
             [protocol],
           ),
         )),
-      ) as _i14.Future<_i4.GetProtocolMetadataResponse$2>);
+      ) as _i15.Future<_i4.GetProtocolMetadataResponse$2>);
 
   @override
-  _i14.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
+  _i15.Future<Map<String, _i4.GetProtocolsResponse$2>> getProtocols() =>
       (super.noSuchMethod(
         Invocation.method(
           #getProtocols,
           [],
         ),
-        returnValue: _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+        returnValue: _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
             <String, _i4.GetProtocolsResponse$2>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
+            _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>.value(
                 <String, _i4.GetProtocolsResponse$2>{}),
-      ) as _i14.Future<Map<String, _i4.GetProtocolsResponse$2>>);
+      ) as _i15.Future<Map<String, _i4.GetProtocolsResponse$2>>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
+  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByID(String? userid) =>
       (super.noSuchMethod(
         Invocation.method(
           #queryUserByID,
           [userid],
         ),
         returnValue:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i14.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
+  _i15.Future<List<_i4.ThirdPartyUser>> queryUserByProtocol(
     String? protocol, {
     Map<String, String>? fields,
   }) =>
@@ -9725,13 +9761,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           {#fields: fields},
         ),
         returnValue:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
         returnValueForMissingStub:
-            _i14.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
-      ) as _i14.Future<List<_i4.ThirdPartyUser>>);
+            _i15.Future<List<_i4.ThirdPartyUser>>.value(<_i4.ThirdPartyUser>[]),
+      ) as _i15.Future<List<_i4.ThirdPartyUser>>);
 
   @override
-  _i14.Future<Map<String, Object?>> getAccountData(
+  _i15.Future<Map<String, Object?>> getAccountData(
     String? userId,
     String? type,
   ) =>
@@ -9744,13 +9780,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> setAccountData(
+  _i15.Future<void> setAccountData(
     String? userId,
     String? type,
     Map<String, Object?>? body,
@@ -9764,12 +9800,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> defineFilter(
+  _i15.Future<String> defineFilter(
     String? userId,
     _i4.Filter? body,
   ) =>
@@ -9781,7 +9817,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9792,7 +9828,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -9802,10 +9838,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.Filter> getFilter(
+  _i15.Future<_i4.Filter> getFilter(
     String? userId,
     String? filterId,
   ) =>
@@ -9817,7 +9853,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             filterId,
           ],
         ),
-        returnValue: _i14.Future<_i4.Filter>.value(_FakeFilter_19(
+        returnValue: _i15.Future<_i4.Filter>.value(_FakeFilter_20(
           this,
           Invocation.method(
             #getFilter,
@@ -9827,7 +9863,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.Filter>.value(_FakeFilter_19(
+        returnValueForMissingStub: _i15.Future<_i4.Filter>.value(_FakeFilter_20(
           this,
           Invocation.method(
             #getFilter,
@@ -9837,10 +9873,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.Filter>);
+      ) as _i15.Future<_i4.Filter>);
 
   @override
-  _i14.Future<_i4.OpenIdCredentials> requestOpenIdToken(
+  _i15.Future<_i4.OpenIdCredentials> requestOpenIdToken(
     String? userId,
     Map<String, Object?>? body,
   ) =>
@@ -9853,7 +9889,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
+            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_77(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9864,7 +9900,7 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_76(
+            _i15.Future<_i4.OpenIdCredentials>.value(_FakeOpenIdCredentials_77(
           this,
           Invocation.method(
             #requestOpenIdToken,
@@ -9874,10 +9910,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             ],
           ),
         )),
-      ) as _i14.Future<_i4.OpenIdCredentials>);
+      ) as _i15.Future<_i4.OpenIdCredentials>);
 
   @override
-  _i14.Future<Map<String, Object?>> getAccountDataPerRoom(
+  _i15.Future<Map<String, Object?>> getAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9892,13 +9928,13 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<void> setAccountDataPerRoom(
+  _i15.Future<void> setAccountDataPerRoom(
     String? userId,
     String? roomId,
     String? type,
@@ -9914,12 +9950,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<Map<String, _i4.Tag>?> getRoomTags(
+  _i15.Future<Map<String, _i4.Tag>?> getRoomTags(
     String? userId,
     String? roomId,
   ) =>
@@ -9931,12 +9967,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             roomId,
           ],
         ),
-        returnValue: _i14.Future<Map<String, _i4.Tag>?>.value(),
-        returnValueForMissingStub: _i14.Future<Map<String, _i4.Tag>?>.value(),
-      ) as _i14.Future<Map<String, _i4.Tag>?>);
+        returnValue: _i15.Future<Map<String, _i4.Tag>?>.value(),
+        returnValueForMissingStub: _i15.Future<Map<String, _i4.Tag>?>.value(),
+      ) as _i15.Future<Map<String, _i4.Tag>?>);
 
   @override
-  _i14.Future<void> deleteRoomTag(
+  _i15.Future<void> deleteRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9950,12 +9986,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             tag,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setRoomTag(
+  _i15.Future<void> setRoomTag(
     String? userId,
     String? roomId,
     String? tag,
@@ -9971,12 +10007,12 @@ class MockClient extends _i1.Mock implements _i4.Client {
             body,
           ],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
+  _i15.Future<_i4.SearchUserDirectoryResponse> searchUserDirectory(
     String? searchTerm, {
     int? limit,
   }) =>
@@ -9986,8 +10022,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           [searchTerm],
           {#limit: limit},
         ),
-        returnValue: _i14.Future<_i4.SearchUserDirectoryResponse>.value(
-            _FakeSearchUserDirectoryResponse_77(
+        returnValue: _i15.Future<_i4.SearchUserDirectoryResponse>.value(
+            _FakeSearchUserDirectoryResponse_78(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -9996,8 +10032,8 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.SearchUserDirectoryResponse>.value(
-                _FakeSearchUserDirectoryResponse_77(
+            _i15.Future<_i4.SearchUserDirectoryResponse>.value(
+                _FakeSearchUserDirectoryResponse_78(
           this,
           Invocation.method(
             #searchUserDirectory,
@@ -10005,10 +10041,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
             {#limit: limit},
           ),
         )),
-      ) as _i14.Future<_i4.SearchUserDirectoryResponse>);
+      ) as _i15.Future<_i4.SearchUserDirectoryResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> reportUser(
+  _i15.Future<Map<String, Object?>> reportUser(
     String? userId,
     String? reason,
   ) =>
@@ -10021,40 +10057,40 @@ class MockClient extends _i1.Mock implements _i4.Client {
           ],
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 
   @override
-  _i14.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
+  _i15.Future<_i4.CreateContentResponse> createContent() => (super.noSuchMethod(
         Invocation.method(
           #createContent,
           [],
         ),
-        returnValue: _i14.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_78(
+        returnValue: _i15.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_79(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-        returnValueForMissingStub: _i14.Future<_i4.CreateContentResponse>.value(
-            _FakeCreateContentResponse_78(
+        returnValueForMissingStub: _i15.Future<_i4.CreateContentResponse>.value(
+            _FakeCreateContentResponse_79(
           this,
           Invocation.method(
             #createContent,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.CreateContentResponse>);
+      ) as _i15.Future<_i4.CreateContentResponse>);
 
   @override
-  _i14.Future<Map<String, Object?>> uploadContentToMXC(
+  _i15.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i24.Uint8List? body, {
+    _i25.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -10072,10 +10108,10 @@ class MockClient extends _i1.Mock implements _i4.Client {
           },
         ),
         returnValue:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
         returnValueForMissingStub:
-            _i14.Future<Map<String, Object?>>.value(<String, Object?>{}),
-      ) as _i14.Future<Map<String, Object?>>);
+            _i15.Future<Map<String, Object?>>.value(<String, Object?>{}),
+      ) as _i15.Future<Map<String, Object?>>);
 }
 
 /// A class which mocks [Event].
@@ -10085,11 +10121,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   _i4.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_16(
+        returnValue: _FakeUser_17(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_16(
+        returnValueForMissingStub: _FakeUser_17(
           this,
           Invocation.getter(#sender),
         ),
@@ -10098,11 +10134,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   _i4.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_16(
+        returnValue: _FakeUser_17(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_16(
+        returnValueForMissingStub: _FakeUser_17(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10111,11 +10147,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   _i4.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_79(
+        returnValue: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_79(
+        returnValueForMissingStub: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
@@ -10138,11 +10174,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   _i4.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_16(
+        returnValue: _FakeUser_17(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_16(
+        returnValueForMissingStub: _FakeUser_17(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10151,11 +10187,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10164,11 +10200,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10177,11 +10213,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10190,11 +10226,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10203,11 +10239,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10272,11 +10308,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10285,11 +10321,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10342,11 +10378,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10355,11 +10391,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   DateTime get originServerTs => (super.noSuchMethod(
         Invocation.getter(#originServerTs),
-        returnValue: _FakeDateTime_12(
+        returnValue: _FakeDateTime_13(
           this,
           Invocation.getter(#originServerTs),
         ),
-        returnValueForMissingStub: _FakeDateTime_12(
+        returnValueForMissingStub: _FakeDateTime_13(
           this,
           Invocation.getter(#originServerTs),
         ),
@@ -10431,11 +10467,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10453,11 +10489,11 @@ class MockEvent extends _i1.Mock implements _i4.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10489,14 +10525,14 @@ class MockEvent extends _i1.Mock implements _i4.Event {
       );
 
   @override
-  _i14.Future<_i4.User?> fetchSenderUser() => (super.noSuchMethod(
+  _i15.Future<_i4.User?> fetchSenderUser() => (super.noSuchMethod(
         Invocation.method(
           #fetchSenderUser,
           [],
         ),
-        returnValue: _i14.Future<_i4.User?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.User?>.value(),
-      ) as _i14.Future<_i4.User?>);
+        returnValue: _i15.Future<_i4.User?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.User?>.value(),
+      ) as _i15.Future<_i4.User?>);
 
   @override
   Map<String, dynamic> toJson() => (super.noSuchMethod(
@@ -10518,38 +10554,38 @@ class MockEvent extends _i1.Mock implements _i4.Event {
       );
 
   @override
-  _i14.Future<bool> remove() => (super.noSuchMethod(
+  _i15.Future<bool> remove() => (super.noSuchMethod(
         Invocation.method(
           #remove,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<void> cancelSend() => (super.noSuchMethod(
+  _i15.Future<void> cancelSend() => (super.noSuchMethod(
         Invocation.method(
           #cancelSend,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String?> sendAgain({String? txid}) => (super.noSuchMethod(
+  _i15.Future<String?> sendAgain({String? txid}) => (super.noSuchMethod(
         Invocation.method(
           #sendAgain,
           [],
           {#txid: txid},
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<String?> redactEvent({
+  _i15.Future<String?> redactEvent({
     String? reason,
     String? txid,
   }) =>
@@ -10562,30 +10598,30 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #txid: txid,
           },
         ),
-        returnValue: _i14.Future<String?>.value(),
-        returnValueForMissingStub: _i14.Future<String?>.value(),
-      ) as _i14.Future<String?>);
+        returnValue: _i15.Future<String?>.value(),
+        returnValueForMissingStub: _i15.Future<String?>.value(),
+      ) as _i15.Future<String?>);
 
   @override
-  _i14.Future<_i4.Event?> getReplyEvent(_i4.Timeline? timeline) =>
+  _i15.Future<_i4.Event?> getReplyEvent(_i4.Timeline? timeline) =>
       (super.noSuchMethod(
         Invocation.method(
           #getReplyEvent,
           [timeline],
         ),
-        returnValue: _i14.Future<_i4.Event?>.value(),
-        returnValueForMissingStub: _i14.Future<_i4.Event?>.value(),
-      ) as _i14.Future<_i4.Event?>);
+        returnValue: _i15.Future<_i4.Event?>.value(),
+        returnValueForMissingStub: _i15.Future<_i4.Event?>.value(),
+      ) as _i15.Future<_i4.Event?>);
 
   @override
-  _i14.Future<void> requestKey() => (super.noSuchMethod(
+  _i15.Future<void> requestKey() => (super.noSuchMethod(
         Invocation.method(
           #requestKey,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   Uri? attachmentOrThumbnailMxcUrl({bool? getThumbnail = false}) =>
@@ -10599,7 +10635,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
       ) as Uri?);
 
   @override
-  _i14.Future<Uri?> getAttachmentUri({
+  _i15.Future<Uri?> getAttachmentUri({
     bool? getThumbnail = false,
     bool? useThumbnailMxcUrl = false,
     double? width = 800.0,
@@ -10622,9 +10658,9 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #animated: animated,
           },
         ),
-        returnValue: _i14.Future<Uri?>.value(),
-        returnValueForMissingStub: _i14.Future<Uri?>.value(),
-      ) as _i14.Future<Uri?>);
+        returnValue: _i15.Future<Uri?>.value(),
+        returnValueForMissingStub: _i15.Future<Uri?>.value(),
+      ) as _i15.Future<Uri?>);
 
   @override
   Uri? getAttachmentUrl({
@@ -10654,21 +10690,21 @@ class MockEvent extends _i1.Mock implements _i4.Event {
       ) as Uri?);
 
   @override
-  _i14.Future<bool> isAttachmentInLocalStore({bool? getThumbnail = false}) =>
+  _i15.Future<bool> isAttachmentInLocalStore({bool? getThumbnail = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #isAttachmentInLocalStore,
           [],
           {#getThumbnail: getThumbnail},
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<_i4.MatrixFile> downloadAndDecryptAttachment({
+  _i15.Future<_i4.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i14.Future<_i24.Uint8List> Function(Uri)? downloadCallback,
+    _i15.Future<_i25.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10683,7 +10719,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i14.Future<_i4.MatrixFile>.value(_FakeMatrixFile_80(
+        returnValue: _i15.Future<_i4.MatrixFile>.value(_FakeMatrixFile_81(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10697,7 +10733,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.MatrixFile>.value(_FakeMatrixFile_80(
+            _i15.Future<_i4.MatrixFile>.value(_FakeMatrixFile_81(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10710,10 +10746,10 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             },
           ),
         )),
-      ) as _i14.Future<_i4.MatrixFile>);
+      ) as _i15.Future<_i4.MatrixFile>);
 
   @override
-  _i14.Future<String> calcLocalizedBody(
+  _i15.Future<String> calcLocalizedBody(
     _i4.MatrixLocalizations? i18n, {
     bool? withSenderNamePrefix = false,
     bool? hideReply = false,
@@ -10733,7 +10769,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10748,7 +10784,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10762,7 +10798,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
   String getLocalizedBody(
@@ -10785,7 +10821,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10799,7 +10835,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10836,7 +10872,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10850,7 +10886,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10884,7 +10920,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10897,7 +10933,7 @@ class MockEvent extends _i1.Mock implements _i4.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10973,14 +11009,14 @@ class MockEvent extends _i1.Mock implements _i4.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_81(
+        returnValue: _FakeEvent_82(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_81(
+        returnValueForMissingStub: _FakeEvent_82(
           this,
           Invocation.method(
             #getDisplayEvent,
@@ -10997,11 +11033,11 @@ class MockUser extends _i1.Mock implements _i4.User {
   @override
   _i4.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_79(
+        returnValue: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_79(
+        returnValueForMissingStub: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
@@ -11010,11 +11046,11 @@ class MockUser extends _i1.Mock implements _i4.User {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -11035,19 +11071,19 @@ class MockUser extends _i1.Mock implements _i4.User {
       ) as _i4.Membership);
 
   @override
-  _i14.Future<_i4.CachedPresence> get currentPresence => (super.noSuchMethod(
+  _i15.Future<_i4.CachedPresence> get currentPresence => (super.noSuchMethod(
         Invocation.getter(#currentPresence),
         returnValue:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_36(
           this,
           Invocation.getter(#currentPresence),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_36(
           this,
           Invocation.getter(#currentPresence),
         )),
-      ) as _i14.Future<_i4.CachedPresence>);
+      ) as _i15.Future<_i4.CachedPresence>);
 
   @override
   bool get canBan => (super.noSuchMethod(
@@ -11080,11 +11116,11 @@ class MockUser extends _i1.Mock implements _i4.User {
   @override
   String get mention => (super.noSuchMethod(
         Invocation.getter(#mention),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#mention),
         ),
@@ -11109,11 +11145,11 @@ class MockUser extends _i1.Mock implements _i4.User {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -11131,11 +11167,11 @@ class MockUser extends _i1.Mock implements _i4.User {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -11182,7 +11218,7 @@ class MockUser extends _i1.Mock implements _i4.User {
             #i18n: i18n,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11194,7 +11230,7 @@ class MockUser extends _i1.Mock implements _i4.User {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcDisplayname,
@@ -11209,47 +11245,47 @@ class MockUser extends _i1.Mock implements _i4.User {
       ) as String);
 
   @override
-  _i14.Future<void> kick() => (super.noSuchMethod(
+  _i15.Future<void> kick() => (super.noSuchMethod(
         Invocation.method(
           #kick,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> ban() => (super.noSuchMethod(
+  _i15.Future<void> ban() => (super.noSuchMethod(
         Invocation.method(
           #ban,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> unban() => (super.noSuchMethod(
+  _i15.Future<void> unban() => (super.noSuchMethod(
         Invocation.method(
           #unban,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setPower(int? power) => (super.noSuchMethod(
+  _i15.Future<void> setPower(int? power) => (super.noSuchMethod(
         Invocation.method(
           #setPower,
           [power],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<String> startDirectChat({
+  _i15.Future<String> startDirectChat({
     bool? enableEncryption,
     List<_i4.StateEvent>? initialState,
     bool? waitForSync = true,
@@ -11264,7 +11300,7 @@ class MockUser extends _i1.Mock implements _i4.User {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i14.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11277,7 +11313,7 @@ class MockUser extends _i1.Mock implements _i4.User {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<String>.value(_i17.dummyValue<String>(
+            _i15.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -11289,16 +11325,16 @@ class MockUser extends _i1.Mock implements _i4.User {
             },
           ),
         )),
-      ) as _i14.Future<String>);
+      ) as _i15.Future<String>);
 
   @override
-  _i14.Future<_i4.CachedPresence> fetchCurrentPresence() => (super.noSuchMethod(
+  _i15.Future<_i4.CachedPresence> fetchCurrentPresence() => (super.noSuchMethod(
         Invocation.method(
           #fetchCurrentPresence,
           [],
         ),
         returnValue:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_36(
           this,
           Invocation.method(
             #fetchCurrentPresence,
@@ -11306,14 +11342,14 @@ class MockUser extends _i1.Mock implements _i4.User {
           ),
         )),
         returnValueForMissingStub:
-            _i14.Future<_i4.CachedPresence>.value(_FakeCachedPresence_35(
+            _i15.Future<_i4.CachedPresence>.value(_FakeCachedPresence_36(
           this,
           Invocation.method(
             #fetchCurrentPresence,
             [],
           ),
         )),
-      ) as _i14.Future<_i4.CachedPresence>);
+      ) as _i15.Future<_i4.CachedPresence>);
 
   @override
   Map<String, Object?> toJson() => (super.noSuchMethod(
@@ -11329,7 +11365,7 @@ class MockUser extends _i1.Mock implements _i4.User {
 /// A class which mocks [CallService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockCallService extends _i1.Mock implements _i25.CallService {
+class MockCallService extends _i1.Mock implements _i26.CallService {
   @override
   _i4.Client get client => (super.noSuchMethod(
         Invocation.getter(#client),
@@ -11351,36 +11387,36 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       ) as bool);
 
   @override
-  _i26.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
+  _i27.HttpPostFunction get httpPostForTest => (super.noSuchMethod(
         Invocation.getter(#httpPostForTest),
         returnValue: (
-          _i13.Client httpClient,
+          _i14.Client httpClient,
           Uri url, {
           Object? body,
           Map<String, String>? headers,
         }) =>
-            _i14.Future<_i13.Response>.value(_FakeResponse_82(
+            _i15.Future<_i14.Response>.value(_FakeResponse_83(
           this,
           Invocation.getter(#httpPostForTest),
         )),
         returnValueForMissingStub: (
-          _i13.Client httpClient,
+          _i14.Client httpClient,
           Uri url, {
           Object? body,
           Map<String, String>? headers,
         }) =>
-            _i14.Future<_i13.Response>.value(_FakeResponse_82(
+            _i15.Future<_i14.Response>.value(_FakeResponse_83(
           this,
           Invocation.getter(#httpPostForTest),
         )),
-      ) as _i26.HttpPostFunction);
+      ) as _i27.HttpPostFunction);
 
   @override
-  List<_i27.RemoteParticipant> get participants => (super.noSuchMethod(
+  List<_i28.RemoteParticipant> get participants => (super.noSuchMethod(
         Invocation.getter(#participants),
-        returnValue: <_i27.RemoteParticipant>[],
-        returnValueForMissingStub: <_i27.RemoteParticipant>[],
-      ) as List<_i27.RemoteParticipant>);
+        returnValue: <_i28.RemoteParticipant>[],
+        returnValueForMissingStub: <_i28.RemoteParticipant>[],
+      ) as List<_i28.RemoteParticipant>);
 
   @override
   bool get isMicEnabled => (super.noSuchMethod(
@@ -11411,14 +11447,14 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       ) as bool);
 
   @override
-  List<_i27.Participant<_i27.TrackPublication<_i27.Track>>>
+  List<_i28.Participant<_i28.TrackPublication<_i28.Track>>>
       get activeSpeakers => (super.noSuchMethod(
             Invocation.getter(#activeSpeakers),
-            returnValue: <_i27
-                .Participant<_i27.TrackPublication<_i27.Track>>>[],
-            returnValueForMissingStub: <_i27
-                .Participant<_i27.TrackPublication<_i27.Track>>>[],
-          ) as List<_i27.Participant<_i27.TrackPublication<_i27.Track>>>);
+            returnValue: <_i28
+                .Participant<_i28.TrackPublication<_i28.Track>>>[],
+            returnValueForMissingStub: <_i28
+                .Participant<_i28.TrackPublication<_i28.Track>>>[],
+          ) as List<_i28.Participant<_i28.TrackPublication<_i28.Track>>>);
 
   @override
   bool get isCallingAvailable => (super.noSuchMethod(
@@ -11428,11 +11464,11 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       ) as bool);
 
   @override
-  List<_i28.CallParticipant> get allParticipants => (super.noSuchMethod(
+  List<_i29.CallParticipant> get allParticipants => (super.noSuchMethod(
         Invocation.getter(#allParticipants),
-        returnValue: <_i28.CallParticipant>[],
-        returnValueForMissingStub: <_i28.CallParticipant>[],
-      ) as List<_i28.CallParticipant>);
+        returnValue: <_i29.CallParticipant>[],
+        returnValueForMissingStub: <_i29.CallParticipant>[],
+      ) as List<_i29.CallParticipant>);
 
   @override
   bool get isSpeakerOn => (super.noSuchMethod(
@@ -11442,29 +11478,29 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       ) as bool);
 
   @override
-  _i14.Stream<_i29.IncomingCallInfo> get incomingCallStream =>
+  _i15.Stream<_i30.IncomingCallInfo> get incomingCallStream =>
       (super.noSuchMethod(
         Invocation.getter(#incomingCallStream),
-        returnValue: _i14.Stream<_i29.IncomingCallInfo>.empty(),
-        returnValueForMissingStub: _i14.Stream<_i29.IncomingCallInfo>.empty(),
-      ) as _i14.Stream<_i29.IncomingCallInfo>);
+        returnValue: _i15.Stream<_i30.IncomingCallInfo>.empty(),
+        returnValueForMissingStub: _i15.Stream<_i30.IncomingCallInfo>.empty(),
+      ) as _i15.Stream<_i30.IncomingCallInfo>);
 
   @override
-  _i14.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
+  _i15.Stream<String> get nativeAcceptedCallStream => (super.noSuchMethod(
         Invocation.getter(#nativeAcceptedCallStream),
-        returnValue: _i14.Stream<String>.empty(),
-        returnValueForMissingStub: _i14.Stream<String>.empty(),
-      ) as _i14.Stream<String>);
+        returnValue: _i15.Stream<String>.empty(),
+        returnValueForMissingStub: _i15.Stream<String>.empty(),
+      ) as _i15.Stream<String>);
 
   @override
-  _i30.KoheraCallState get callState => (super.noSuchMethod(
+  _i31.KoheraCallState get callState => (super.noSuchMethod(
         Invocation.getter(#callState),
-        returnValue: _i30.KoheraCallState.idle,
-        returnValueForMissingStub: _i30.KoheraCallState.idle,
-      ) as _i30.KoheraCallState);
+        returnValue: _i31.KoheraCallState.idle,
+        returnValueForMissingStub: _i31.KoheraCallState.idle,
+      ) as _i31.KoheraCallState);
 
   @override
-  set preferencesService(_i31.PreferencesService? prefs) => super.noSuchMethod(
+  set preferencesService(_i32.PreferencesService? prefs) => super.noSuchMethod(
         Invocation.setter(
           #preferencesService,
           prefs,
@@ -11473,7 +11509,7 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  set ringtoneService(_i32.RingtoneService? service) => super.noSuchMethod(
+  set ringtoneService(_i33.RingtoneService? service) => super.noSuchMethod(
         Invocation.setter(
           #ringtoneService,
           service,
@@ -11482,7 +11518,7 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  set roomFactoryForTest(_i26.LiveKitRoomFactory? factory) =>
+  set roomFactoryForTest(_i27.LiveKitRoomFactory? factory) =>
       super.noSuchMethod(
         Invocation.setter(
           #roomFactoryForTest,
@@ -11492,7 +11528,7 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  set httpPostForTest(_i26.HttpPostFunction? fn) => super.noSuchMethod(
+  set httpPostForTest(_i27.HttpPostFunction? fn) => super.noSuchMethod(
         Invocation.setter(
           #httpPostForTest,
           fn,
@@ -11526,27 +11562,27 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  _i14.Future<void> toggleMicrophone() => (super.noSuchMethod(
+  _i15.Future<void> toggleMicrophone() => (super.noSuchMethod(
         Invocation.method(
           #toggleMicrophone,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> toggleCamera() => (super.noSuchMethod(
+  _i15.Future<void> toggleCamera() => (super.noSuchMethod(
         Invocation.method(
           #toggleCamera,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> toggleScreenShare({
+  _i15.Future<void> toggleScreenShare({
     String? sourceId,
     bool? captureScreenAudio = false,
   }) =>
@@ -11559,39 +11595,39 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
             #captureScreenAudio: captureScreenAudio,
           },
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> toggleScreenAudio() => (super.noSuchMethod(
+  _i15.Future<void> toggleScreenAudio() => (super.noSuchMethod(
         Invocation.method(
           #toggleScreenAudio,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> setOutputVolume(double? volume) => (super.noSuchMethod(
+  _i15.Future<void> setOutputVolume(double? volume) => (super.noSuchMethod(
         Invocation.method(
           #setOutputVolume,
           [volume],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> toggleSpeaker() => (super.noSuchMethod(
+  _i15.Future<void> toggleSpeaker() => (super.noSuchMethod(
         Invocation.method(
           #toggleSpeaker,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void setVoipPushHandlesCallKit(bool? value) => super.noSuchMethod(
@@ -11621,7 +11657,7 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i18.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i19.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -11649,36 +11685,36 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  _i14.Future<void> joinCall(String? roomId) => (super.noSuchMethod(
+  _i15.Future<void> joinCall(String? roomId) => (super.noSuchMethod(
         Invocation.method(
           #joinCall,
           [roomId],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> leaveCall() => (super.noSuchMethod(
+  _i15.Future<void> leaveCall() => (super.noSuchMethod(
         Invocation.method(
           #leaveCall,
           [],
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
-  _i14.Future<void> acceptCall({bool? withVideo = false}) =>
+  _i15.Future<void> acceptCall({bool? withVideo = false}) =>
       (super.noSuchMethod(
         Invocation.method(
           #acceptCall,
           [],
           {#withVideo: withVideo},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   void declineCall() => super.noSuchMethod(
@@ -11700,9 +11736,9 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  _i14.Future<void> initiateCall(
+  _i15.Future<void> initiateCall(
     String? roomId, {
-    _i29.CallType? type = _i29.CallType.voice,
+    _i30.CallType? type = _i30.CallType.voice,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -11710,9 +11746,9 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
           [roomId],
           {#type: type},
         ),
-        returnValue: _i14.Future<void>.value(),
-        returnValueForMissingStub: _i14.Future<void>.value(),
-      ) as _i14.Future<void>);
+        returnValue: _i15.Future<void>.value(),
+        returnValueForMissingStub: _i15.Future<void>.value(),
+      ) as _i15.Future<void>);
 
   @override
   bool roomHasActiveCall(String? roomId) => (super.noSuchMethod(
@@ -11805,7 +11841,7 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  void addListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -11814,7 +11850,7 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  void removeListener(_i18.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i19.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -11823,17 +11859,17 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  _i14.Future<bool> didPopRoute() => (super.noSuchMethod(
+  _i15.Future<bool> didPopRoute() => (super.noSuchMethod(
         Invocation.method(
           #didPopRoute,
           [],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i19.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i20.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -11844,7 +11880,7 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i19.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i20.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -11881,26 +11917,26 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  _i14.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
+  _i15.Future<bool> didPushRoute(String? route) => (super.noSuchMethod(
         Invocation.method(
           #didPushRoute,
           [route],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
-  _i14.Future<bool> didPushRouteInformation(
-          _i20.RouteInformation? routeInformation) =>
+  _i15.Future<bool> didPushRouteInformation(
+          _i21.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
           [routeInformation],
         ),
-        returnValue: _i14.Future<bool>.value(false),
-        returnValueForMissingStub: _i14.Future<bool>.value(false),
-      ) as _i14.Future<bool>);
+        returnValue: _i15.Future<bool>.value(false),
+        returnValueForMissingStub: _i15.Future<bool>.value(false),
+      ) as _i15.Future<bool>);
 
   @override
   void didChangeMetrics() => super.noSuchMethod(
@@ -11930,7 +11966,7 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  void didChangeLocales(List<_i18.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i19.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -11939,7 +11975,7 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  void didChangeViewFocus(_i18.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i19.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -11948,16 +11984,16 @@ class MockCallService extends _i1.Mock implements _i25.CallService {
       );
 
   @override
-  _i14.Future<_i18.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i15.Future<_i19.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
+            _i15.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i14.Future<_i18.AppExitResponse>.value(_i18.AppExitResponse.exit),
-      ) as _i14.Future<_i18.AppExitResponse>);
+            _i15.Future<_i19.AppExitResponse>.value(_i19.AppExitResponse.exit),
+      ) as _i15.Future<_i19.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/space_action_dialog_test.mocks.dart
+++ b/test/widgets/space_action_dialog_test.mocks.dart
@@ -4,13 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -25,14 +26,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i25;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i23;
+import 'package:matrix/src/utils/space_child.dart' as _i24;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -846,8 +847,9 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_75(
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -856,9 +858,19 @@ class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_76 extends _i1.SmartFake
+class _FakeRoomSummary_76 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_76(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_77 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_76(
+  _FakeLatestReceiptState_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,8 +879,8 @@ class _FakeLatestReceiptState_76 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_77(
+class _FakeTimeline_78 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -877,8 +889,8 @@ class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_78(
+class _FakeUser_79 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -905,12 +917,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1030,11 +1042,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1071,11 +1083,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1105,11 +1117,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1118,11 +1130,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1408,34 +1420,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1591,7 +1603,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1880,14 +1892,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2275,8 +2287,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2292,8 +2304,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2334,7 +2346,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2350,7 +2362,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2399,7 +2411,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2420,7 +2432,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2523,7 +2535,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2541,7 +2553,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3060,7 +3072,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3412,7 +3424,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3426,7 +3438,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3577,7 +3589,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4955,7 +4967,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4977,7 +4989,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5471,7 +5483,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5483,7 +5495,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6491,7 +6503,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6502,7 +6514,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6750,7 +6762,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6762,7 +6774,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7022,7 +7034,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7035,7 +7047,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7102,7 +7114,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7115,7 +7127,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7163,7 +7175,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7175,7 +7187,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7423,7 +7435,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7434,7 +7446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7696,7 +7708,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7723,7 +7735,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7753,11 +7765,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7882,6 +7894,19 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7979,6 +8004,15 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -8023,7 +8057,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8048,6 +8082,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8057,6 +8092,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8117,7 +8153,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8126,7 +8162,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8145,7 +8181,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8156,7 +8192,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8204,7 +8240,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8242,7 +8278,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8251,7 +8287,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8260,16 +8296,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8297,11 +8333,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8331,11 +8367,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_75(
+        returnValue: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_75(
+        returnValueForMissingStub: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
@@ -8388,11 +8424,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8428,11 +8464,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8448,11 +8484,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8461,11 +8497,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8508,11 +8544,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8555,11 +8591,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_76(
+        returnValue: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_76(
+        returnValueForMissingStub: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8778,18 +8814,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i23.SpaceParent>[],
-        returnValueForMissingStub: <_i23.SpaceParent>[],
-      ) as List<_i23.SpaceParent>);
+        returnValue: <_i24.SpaceParent>[],
+        returnValueForMissingStub: <_i24.SpaceParent>[],
+      ) as List<_i24.SpaceParent>);
 
   @override
-  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i23.SpaceChild>[],
-        returnValueForMissingStub: <_i23.SpaceChild>[],
-      ) as List<_i23.SpaceChild>);
+        returnValue: <_i24.SpaceChild>[],
+        returnValueForMissingStub: <_i24.SpaceChild>[],
+      ) as List<_i24.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8956,14 +8992,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9011,7 +9047,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9019,7 +9055,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9034,7 +9070,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9042,7 +9078,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9136,7 +9172,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9144,7 +9180,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9386,7 +9422,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9397,7 +9433,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9486,15 +9522,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i25.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i24.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i24.TimelineChunk?>.value(),
-      ) as _i5.Future<_i24.TimelineChunk?>);
+        returnValue: _i5.Future<_i25.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i25.TimelineChunk?>.value(),
+      ) as _i5.Future<_i25.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9535,7 +9571,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9552,7 +9588,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9616,14 +9652,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9639,14 +9675,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9702,7 +9738,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9710,7 +9746,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,

--- a/test/widgets/space_context_menu_test.mocks.dart
+++ b/test/widgets/space_context_menu_test.mocks.dart
@@ -4,13 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -25,14 +26,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i25;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i23;
+import 'package:matrix/src/utils/space_child.dart' as _i24;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -846,8 +847,9 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_75(
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -856,9 +858,19 @@ class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_76 extends _i1.SmartFake
+class _FakeRoomSummary_76 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_76(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_77 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_76(
+  _FakeLatestReceiptState_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -867,8 +879,8 @@ class _FakeLatestReceiptState_76 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_77(
+class _FakeTimeline_78 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -877,8 +889,8 @@ class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_78(
+class _FakeUser_79 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -887,8 +899,8 @@ class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeRoom_79 extends _i1.SmartFake implements _i2.Room {
-  _FakeRoom_79(
+class _FakeRoom_80 extends _i1.SmartFake implements _i2.Room {
+  _FakeRoom_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -897,8 +909,8 @@ class _FakeRoom_79 extends _i1.SmartFake implements _i2.Room {
         );
 }
 
-class _FakeMatrixFile_80 extends _i1.SmartFake implements _i2.MatrixFile {
-  _FakeMatrixFile_80(
+class _FakeMatrixFile_81 extends _i1.SmartFake implements _i2.MatrixFile {
+  _FakeMatrixFile_81(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -907,8 +919,8 @@ class _FakeMatrixFile_80 extends _i1.SmartFake implements _i2.MatrixFile {
         );
 }
 
-class _FakeEvent_81 extends _i1.SmartFake implements _i2.Event {
-  _FakeEvent_81(
+class _FakeEvent_82 extends _i1.SmartFake implements _i2.Event {
+  _FakeEvent_82(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -935,12 +947,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1060,11 +1072,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1101,11 +1113,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1135,11 +1147,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1148,11 +1160,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1438,34 +1450,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1621,7 +1633,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1910,14 +1922,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2305,8 +2317,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2322,8 +2334,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2364,7 +2376,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2380,7 +2392,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2429,7 +2441,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2450,7 +2462,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2553,7 +2565,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2571,7 +2583,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3090,7 +3102,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3442,7 +3454,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3456,7 +3468,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3607,7 +3619,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4985,7 +4997,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5007,7 +5019,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5501,7 +5513,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5513,7 +5525,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6521,7 +6533,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6532,7 +6544,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6780,7 +6792,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6792,7 +6804,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7052,7 +7064,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7065,7 +7077,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7132,7 +7144,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7145,7 +7157,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7193,7 +7205,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7205,7 +7217,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7453,7 +7465,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7464,7 +7476,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7726,7 +7738,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7753,7 +7765,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7783,11 +7795,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7912,6 +7924,19 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -8009,6 +8034,15 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -8053,7 +8087,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8078,6 +8112,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8087,6 +8122,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8147,7 +8183,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8156,7 +8192,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8175,7 +8211,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8186,7 +8222,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8234,7 +8270,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8272,7 +8308,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8281,7 +8317,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8290,16 +8326,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8327,11 +8363,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8361,11 +8397,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_75(
+        returnValue: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_75(
+        returnValueForMissingStub: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
@@ -8418,11 +8454,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8458,11 +8494,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8478,11 +8514,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8491,11 +8527,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8538,11 +8574,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8585,11 +8621,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_76(
+        returnValue: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_76(
+        returnValueForMissingStub: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8808,18 +8844,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i23.SpaceParent>[],
-        returnValueForMissingStub: <_i23.SpaceParent>[],
-      ) as List<_i23.SpaceParent>);
+        returnValue: <_i24.SpaceParent>[],
+        returnValueForMissingStub: <_i24.SpaceParent>[],
+      ) as List<_i24.SpaceParent>);
 
   @override
-  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i23.SpaceChild>[],
-        returnValueForMissingStub: <_i23.SpaceChild>[],
-      ) as List<_i23.SpaceChild>);
+        returnValue: <_i24.SpaceChild>[],
+        returnValueForMissingStub: <_i24.SpaceChild>[],
+      ) as List<_i24.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8986,14 +9022,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9041,7 +9077,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9049,7 +9085,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9064,7 +9100,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9072,7 +9108,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9166,7 +9202,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9174,7 +9210,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9416,7 +9452,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9427,7 +9463,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9516,15 +9552,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i25.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i24.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i24.TimelineChunk?>.value(),
-      ) as _i5.Future<_i24.TimelineChunk?>);
+        returnValue: _i5.Future<_i25.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i25.TimelineChunk?>.value(),
+      ) as _i5.Future<_i25.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9565,7 +9601,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9582,7 +9618,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9646,14 +9682,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9669,14 +9705,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9732,7 +9768,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9740,7 +9776,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10052,11 +10088,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get sender => (super.noSuchMethod(
         Invocation.getter(#sender),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.getter(#sender),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.getter(#sender),
         ),
@@ -10065,11 +10101,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get senderFromMemoryOrFallback => (super.noSuchMethod(
         Invocation.getter(#senderFromMemoryOrFallback),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.getter(#senderFromMemoryOrFallback),
         ),
@@ -10078,11 +10114,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.Room get room => (super.noSuchMethod(
         Invocation.getter(#room),
-        returnValue: _FakeRoom_79(
+        returnValue: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
-        returnValueForMissingStub: _FakeRoom_79(
+        returnValueForMissingStub: _FakeRoom_80(
           this,
           Invocation.getter(#room),
         ),
@@ -10105,11 +10141,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i2.User get asUser => (super.noSuchMethod(
         Invocation.getter(#asUser),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.getter(#asUser),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.getter(#asUser),
         ),
@@ -10118,11 +10154,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get messageType => (super.noSuchMethod(
         Invocation.getter(#messageType),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#messageType),
         ),
@@ -10131,11 +10167,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get text => (super.noSuchMethod(
         Invocation.getter(#text),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#text),
         ),
@@ -10144,11 +10180,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get formattedText => (super.noSuchMethod(
         Invocation.getter(#formattedText),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#formattedText),
         ),
@@ -10157,11 +10193,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get body => (super.noSuchMethod(
         Invocation.getter(#body),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#body),
         ),
@@ -10170,11 +10206,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get plaintextBody => (super.noSuchMethod(
         Invocation.getter(#plaintextBody),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#plaintextBody),
         ),
@@ -10239,11 +10275,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get attachmentMimetype => (super.noSuchMethod(
         Invocation.getter(#attachmentMimetype),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#attachmentMimetype),
         ),
@@ -10252,11 +10288,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get thumbnailMimetype => (super.noSuchMethod(
         Invocation.getter(#thumbnailMimetype),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#thumbnailMimetype),
         ),
@@ -10309,11 +10345,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get eventId => (super.noSuchMethod(
         Invocation.getter(#eventId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#eventId),
         ),
@@ -10398,11 +10434,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get senderId => (super.noSuchMethod(
         Invocation.getter(#senderId),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#senderId),
         ),
@@ -10420,11 +10456,11 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   String get type => (super.noSuchMethod(
         Invocation.getter(#type),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#type),
         ),
@@ -10635,7 +10671,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
   @override
   _i5.Future<_i2.MatrixFile> downloadAndDecryptAttachment({
     bool? getThumbnail = false,
-    _i5.Future<_i18.Uint8List> Function(Uri)? downloadCallback,
+    _i5.Future<_i19.Uint8List> Function(Uri)? downloadCallback,
     bool? fromLocalStoreOnly = false,
     void Function(int)? onDownloadProgress,
   }) =>
@@ -10650,7 +10686,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #onDownloadProgress: onDownloadProgress,
           },
         ),
-        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_80(
+        returnValue: _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_81(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10664,7 +10700,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_80(
+            _i5.Future<_i2.MatrixFile>.value(_FakeMatrixFile_81(
           this,
           Invocation.method(
             #downloadAndDecryptAttachment,
@@ -10700,7 +10736,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10715,7 +10751,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBody,
@@ -10752,7 +10788,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10766,7 +10802,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedBody,
@@ -10803,7 +10839,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10817,7 +10853,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcLocalizedBodyFallback,
@@ -10851,7 +10887,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             #removeMarkdown: removeMarkdown,
           },
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10864,7 +10900,7 @@ class MockEvent extends _i1.Mock implements _i2.Event {
             },
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #calcUnlocalizedBody,
@@ -10940,14 +10976,14 @@ class MockEvent extends _i1.Mock implements _i2.Event {
           #getDisplayEvent,
           [timeline],
         ),
-        returnValue: _FakeEvent_81(
+        returnValue: _FakeEvent_82(
           this,
           Invocation.method(
             #getDisplayEvent,
             [timeline],
           ),
         ),
-        returnValueForMissingStub: _FakeEvent_81(
+        returnValueForMissingStub: _FakeEvent_82(
           this,
           Invocation.method(
             #getDisplayEvent,

--- a/test/widgets/space_details_panel_test.mocks.dart
+++ b/test/widgets/space_details_panel_test.mocks.dart
@@ -4,14 +4,15 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/models/join_mode.dart' as _i25;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/models/join_mode.dart' as _i26;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -26,14 +27,14 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
-import 'package:matrix/src/models/timeline_chunk.dart' as _i24;
+import 'package:matrix/src/models/timeline_chunk.dart' as _i25;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
-import 'package:matrix/src/utils/space_child.dart' as _i23;
+import 'package:matrix/src/utils/space_child.dart' as _i24;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -847,8 +848,9 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
-class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
-  _FakeRoomSummary_75(
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -857,9 +859,19 @@ class _FakeRoomSummary_75 extends _i1.SmartFake implements _i2.RoomSummary {
         );
 }
 
-class _FakeLatestReceiptState_76 extends _i1.SmartFake
+class _FakeRoomSummary_76 extends _i1.SmartFake implements _i2.RoomSummary {
+  _FakeRoomSummary_76(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeLatestReceiptState_77 extends _i1.SmartFake
     implements _i2.LatestReceiptState {
-  _FakeLatestReceiptState_76(
+  _FakeLatestReceiptState_77(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -868,8 +880,8 @@ class _FakeLatestReceiptState_76 extends _i1.SmartFake
         );
 }
 
-class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
-  _FakeTimeline_77(
+class _FakeTimeline_78 extends _i1.SmartFake implements _i2.Timeline {
+  _FakeTimeline_78(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -878,8 +890,8 @@ class _FakeTimeline_77 extends _i1.SmartFake implements _i2.Timeline {
         );
 }
 
-class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
-  _FakeUser_78(
+class _FakeUser_79 extends _i1.SmartFake implements _i2.User {
+  _FakeUser_79(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -888,8 +900,8 @@ class _FakeUser_78 extends _i1.SmartFake implements _i2.User {
         );
 }
 
-class _FakeStateEvent_79 extends _i1.SmartFake implements _i2.StateEvent {
-  _FakeStateEvent_79(
+class _FakeStateEvent_80 extends _i1.SmartFake implements _i2.StateEvent {
+  _FakeStateEvent_80(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -916,12 +928,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -1041,11 +1053,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1082,11 +1094,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1116,11 +1128,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1129,11 +1141,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1419,34 +1431,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1602,7 +1614,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1891,14 +1903,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2286,8 +2298,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2303,8 +2315,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2345,7 +2357,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2361,7 +2373,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2410,7 +2422,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2431,7 +2443,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2534,7 +2546,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2552,7 +2564,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3071,7 +3083,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3423,7 +3435,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3437,7 +3449,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3588,7 +3600,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4966,7 +4978,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4988,7 +5000,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5482,7 +5494,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5494,7 +5506,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6502,7 +6514,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6513,7 +6525,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6761,7 +6773,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6773,7 +6785,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -7033,7 +7045,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7046,7 +7058,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7113,7 +7125,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7126,7 +7138,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7174,7 +7186,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7186,7 +7198,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7434,7 +7446,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7445,7 +7457,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7707,7 +7719,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7734,7 +7746,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7764,11 +7776,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7893,6 +7905,19 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7990,6 +8015,15 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -8034,7 +8068,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8059,6 +8093,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8068,6 +8103,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8128,7 +8164,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8137,7 +8173,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8156,7 +8192,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8167,7 +8203,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8215,7 +8251,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8253,7 +8289,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8262,7 +8298,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8271,16 +8307,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8308,11 +8344,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get id => (super.noSuchMethod(
         Invocation.getter(#id),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#id),
         ),
@@ -8342,11 +8378,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.RoomSummary get summary => (super.noSuchMethod(
         Invocation.getter(#summary),
-        returnValue: _FakeRoomSummary_75(
+        returnValue: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
-        returnValueForMissingStub: _FakeRoomSummary_75(
+        returnValueForMissingStub: _FakeRoomSummary_76(
           this,
           Invocation.getter(#summary),
         ),
@@ -8399,11 +8435,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get fullyRead => (super.noSuchMethod(
         Invocation.getter(#fullyRead),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fullyRead),
         ),
@@ -8439,11 +8475,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get name => (super.noSuchMethod(
         Invocation.getter(#name),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#name),
         ),
@@ -8459,11 +8495,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get topic => (super.noSuchMethod(
         Invocation.getter(#topic),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#topic),
         ),
@@ -8472,11 +8508,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get canonicalAlias => (super.noSuchMethod(
         Invocation.getter(#canonicalAlias),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#canonicalAlias),
         ),
@@ -8519,11 +8555,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   String get displayname => (super.noSuchMethod(
         Invocation.getter(#displayname),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#displayname),
         ),
@@ -8566,11 +8602,11 @@ class MockRoom extends _i1.Mock implements _i2.Room {
   @override
   _i2.LatestReceiptState get receiptState => (super.noSuchMethod(
         Invocation.getter(#receiptState),
-        returnValue: _FakeLatestReceiptState_76(
+        returnValue: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
-        returnValueForMissingStub: _FakeLatestReceiptState_76(
+        returnValueForMissingStub: _FakeLatestReceiptState_77(
           this,
           Invocation.getter(#receiptState),
         ),
@@ -8789,18 +8825,18 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as bool);
 
   @override
-  List<_i23.SpaceParent> get spaceParents => (super.noSuchMethod(
+  List<_i24.SpaceParent> get spaceParents => (super.noSuchMethod(
         Invocation.getter(#spaceParents),
-        returnValue: <_i23.SpaceParent>[],
-        returnValueForMissingStub: <_i23.SpaceParent>[],
-      ) as List<_i23.SpaceParent>);
+        returnValue: <_i24.SpaceParent>[],
+        returnValueForMissingStub: <_i24.SpaceParent>[],
+      ) as List<_i24.SpaceParent>);
 
   @override
-  List<_i23.SpaceChild> get spaceChildren => (super.noSuchMethod(
+  List<_i24.SpaceChild> get spaceChildren => (super.noSuchMethod(
         Invocation.getter(#spaceChildren),
-        returnValue: <_i23.SpaceChild>[],
-        returnValueForMissingStub: <_i23.SpaceChild>[],
-      ) as List<_i23.SpaceChild>);
+        returnValue: <_i24.SpaceChild>[],
+        returnValueForMissingStub: <_i24.SpaceChild>[],
+      ) as List<_i24.SpaceChild>);
 
   @override
   set membership(_i2.Membership? value) => super.noSuchMethod(
@@ -8967,14 +9003,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getLocalizedDisplayname,
           [i18n],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
             [i18n],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #getLocalizedDisplayname,
@@ -9022,7 +9058,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setName,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9030,7 +9066,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setName,
@@ -9045,7 +9081,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setDescription,
           [newName],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9053,7 +9089,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setDescription,
@@ -9147,7 +9183,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setPinnedEvents,
           [pinnedEventIds],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9155,7 +9191,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPinnedEvents,
@@ -9397,7 +9433,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             power,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9408,7 +9444,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setPower,
@@ -9497,15 +9533,15 @@ class MockRoom extends _i1.Mock implements _i2.Room {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<_i24.TimelineChunk?> getEventContext(String? eventId) =>
+  _i5.Future<_i25.TimelineChunk?> getEventContext(String? eventId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getEventContext,
           [eventId],
         ),
-        returnValue: _i5.Future<_i24.TimelineChunk?>.value(),
-        returnValueForMissingStub: _i5.Future<_i24.TimelineChunk?>.value(),
-      ) as _i5.Future<_i24.TimelineChunk?>);
+        returnValue: _i5.Future<_i25.TimelineChunk?>.value(),
+        returnValueForMissingStub: _i5.Future<_i25.TimelineChunk?>.value(),
+      ) as _i5.Future<_i25.TimelineChunk?>);
 
   @override
   _i5.Future<void> postReceipt(
@@ -9546,7 +9582,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
             #limit: limit,
           },
         ),
-        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+        returnValue: _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9563,7 +9599,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<_i2.Timeline>.value(_FakeTimeline_77(
+            _i5.Future<_i2.Timeline>.value(_FakeTimeline_78(
           this,
           Invocation.method(
             #getTimeline,
@@ -9627,14 +9663,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #getUserByMXIDSync,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #getUserByMXIDSync,
@@ -9650,14 +9686,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #unsafeGetUserFromMemoryOrFallback,
           [mxID],
         ),
-        returnValue: _FakeUser_78(
+        returnValue: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
             [mxID],
           ),
         ),
-        returnValueForMissingStub: _FakeUser_78(
+        returnValueForMissingStub: _FakeUser_79(
           this,
           Invocation.method(
             #unsafeGetUserFromMemoryOrFallback,
@@ -9713,7 +9749,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           #setAvatar,
           [file],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -9721,7 +9757,7 @@ class MockRoom extends _i1.Mock implements _i2.Room {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setAvatar,
@@ -10032,14 +10068,14 @@ class MockRoom extends _i1.Mock implements _i2.Room {
 class MockSpaceAccessService extends _i1.Mock
     implements _i12.SpaceAccessService {
   @override
-  _i25.JoinMode getJoinMode(_i2.Room? room) => (super.noSuchMethod(
+  _i26.JoinMode getJoinMode(_i2.Room? room) => (super.noSuchMethod(
         Invocation.method(
           #getJoinMode,
           [room],
         ),
-        returnValue: _i25.JoinMode.invite,
-        returnValueForMissingStub: _i25.JoinMode.invite,
-      ) as _i25.JoinMode);
+        returnValue: _i26.JoinMode.invite,
+        returnValueForMissingStub: _i26.JoinMode.invite,
+      ) as _i26.JoinMode);
 
   @override
   List<String> allowedSpaceIds(_i2.Room? room) => (super.noSuchMethod(
@@ -10123,7 +10159,7 @@ class MockSpaceAccessService extends _i1.Mock
   @override
   _i5.Future<void> applyJoinMode({
     required String? roomId,
-    required _i25.JoinMode? mode,
+    required _i26.JoinMode? mode,
     List<String>? allowSpaceIds = const [],
   }) =>
       (super.noSuchMethod(
@@ -10142,7 +10178,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   Map<String, Object?> buildJoinRulesPayload(
-    _i25.JoinMode? mode,
+    _i26.JoinMode? mode,
     List<String>? allowSpaceIds, {
     List<Map<String, Object?>>? preserveEntries = const [],
   }) =>
@@ -10161,7 +10197,7 @@ class MockSpaceAccessService extends _i1.Mock
 
   @override
   _i2.StateEvent buildJoinRulesStateEvent(
-    _i25.JoinMode? mode,
+    _i26.JoinMode? mode,
     List<String>? allowSpaceIds,
   ) =>
       (super.noSuchMethod(
@@ -10172,7 +10208,7 @@ class MockSpaceAccessService extends _i1.Mock
             allowSpaceIds,
           ],
         ),
-        returnValue: _FakeStateEvent_79(
+        returnValue: _FakeStateEvent_80(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -10182,7 +10218,7 @@ class MockSpaceAccessService extends _i1.Mock
             ],
           ),
         ),
-        returnValueForMissingStub: _FakeStateEvent_79(
+        returnValueForMissingStub: _FakeStateEvent_80(
           this,
           Invocation.method(
             #buildJoinRulesStateEvent,
@@ -10207,7 +10243,7 @@ class MockSpaceAccessService extends _i1.Mock
             newVersion,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,
@@ -10218,7 +10254,7 @@ class MockSpaceAccessService extends _i1.Mock
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoomTo,

--- a/test/widgets/space_discovery_search_test.mocks.dart
+++ b/test/widgets/space_discovery_search_test.mocks.dart
@@ -4,13 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -25,12 +26,12 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -844,6 +845,17 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -862,12 +874,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -987,11 +999,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1028,11 +1040,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1062,11 +1074,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1075,11 +1087,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1365,34 +1377,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1548,7 +1560,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1837,14 +1849,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2232,8 +2244,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2249,8 +2261,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2291,7 +2303,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2307,7 +2319,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2356,7 +2368,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2377,7 +2389,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2480,7 +2492,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2498,7 +2510,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3017,7 +3029,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3369,7 +3381,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3383,7 +3395,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3534,7 +3546,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4912,7 +4924,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4934,7 +4946,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5428,7 +5440,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5440,7 +5452,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6448,7 +6460,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6459,7 +6471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6707,7 +6719,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6719,7 +6731,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6979,7 +6991,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6992,7 +7004,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7059,7 +7071,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7072,7 +7084,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7120,7 +7132,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7132,7 +7144,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7380,7 +7392,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7391,7 +7403,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7653,7 +7665,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7680,7 +7692,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7710,11 +7722,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7839,6 +7851,19 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7936,6 +7961,15 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7980,7 +8014,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8005,6 +8039,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8014,6 +8049,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8074,7 +8110,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8083,7 +8119,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8102,7 +8138,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8113,7 +8149,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8161,7 +8197,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8199,7 +8235,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8208,7 +8244,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8217,16 +8253,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/space_discovery_server_test.mocks.dart
+++ b/test/widgets/space_discovery_server_test.mocks.dart
@@ -4,13 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -25,12 +26,12 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -844,6 +845,17 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -862,12 +874,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -987,11 +999,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1028,11 +1040,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1062,11 +1074,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1075,11 +1087,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1365,34 +1377,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1548,7 +1560,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1837,14 +1849,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2232,8 +2244,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2249,8 +2261,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2291,7 +2303,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2307,7 +2319,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2356,7 +2368,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2377,7 +2389,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2480,7 +2492,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2498,7 +2510,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3017,7 +3029,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3369,7 +3381,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3383,7 +3395,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3534,7 +3546,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4912,7 +4924,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4934,7 +4946,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5428,7 +5440,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5440,7 +5452,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6448,7 +6460,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6459,7 +6471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6707,7 +6719,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6719,7 +6731,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6979,7 +6991,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6992,7 +7004,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7059,7 +7071,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7072,7 +7084,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7120,7 +7132,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7132,7 +7144,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7380,7 +7392,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7391,7 +7403,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7653,7 +7665,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7680,7 +7692,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7710,11 +7722,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7839,6 +7851,19 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7936,6 +7961,15 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7980,7 +8014,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8005,6 +8039,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8014,6 +8049,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8074,7 +8110,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8083,7 +8119,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8102,7 +8138,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8113,7 +8149,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8161,7 +8197,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8199,7 +8235,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8208,7 +8244,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8217,16 +8253,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/space_discovery_servers_edit_test.mocks.dart
+++ b/test/widgets/space_discovery_servers_edit_test.mocks.dart
@@ -4,13 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -25,12 +26,12 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -844,6 +845,17 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -862,12 +874,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -987,11 +999,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1028,11 +1040,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1062,11 +1074,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1075,11 +1087,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1365,34 +1377,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1548,7 +1560,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1837,14 +1849,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2232,8 +2244,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2249,8 +2261,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2291,7 +2303,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2307,7 +2319,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2356,7 +2368,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2377,7 +2389,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2480,7 +2492,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2498,7 +2510,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3017,7 +3029,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3369,7 +3381,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3383,7 +3395,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3534,7 +3546,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4912,7 +4924,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4934,7 +4946,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5428,7 +5440,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5440,7 +5452,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6448,7 +6460,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6459,7 +6471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6707,7 +6719,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6719,7 +6731,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6979,7 +6991,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6992,7 +7004,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7059,7 +7071,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7072,7 +7084,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7120,7 +7132,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7132,7 +7144,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7380,7 +7392,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7391,7 +7403,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7653,7 +7665,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7680,7 +7692,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7710,11 +7722,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7839,6 +7851,19 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7936,6 +7961,15 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7980,7 +8014,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8005,6 +8039,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8014,6 +8049,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8074,7 +8110,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8083,7 +8119,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8102,7 +8138,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8113,7 +8149,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8161,7 +8197,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8199,7 +8235,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8208,7 +8244,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8217,16 +8253,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(

--- a/test/widgets/verification_request_listener_test.mocks.dart
+++ b/test/widgets/verification_request_listener_test.mocks.dart
@@ -4,13 +4,14 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'dart:async' as _i5;
-import 'dart:typed_data' as _i18;
-import 'dart:ui' as _i20;
+import 'dart:typed_data' as _i19;
+import 'dart:ui' as _i21;
 
-import 'package:flutter/services.dart' as _i21;
-import 'package:flutter/widgets.dart' as _i22;
+import 'package:flutter/services.dart' as _i22;
+import 'package:flutter/widgets.dart' as _i23;
 import 'package:http/http.dart' as _i4;
-import 'package:kohera/core/services/matrix_service.dart' as _i19;
+import 'package:kohera/core/services/matrix_service.dart' as _i20;
+import 'package:kohera/core/services/sticker_pack_service.dart' as _i16;
 import 'package:kohera/core/services/sub_services/auth_service.dart' as _i14;
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart'
     as _i10;
@@ -25,12 +26,12 @@ import 'package:kohera/features/notifications/services/call_push_rule_manager.da
     as _i7;
 import 'package:kohera/features/notifications/services/megolm_key_mirror.dart'
     as _i8;
-import 'package:matrix/encryption.dart' as _i16;
+import 'package:matrix/encryption.dart' as _i17;
 import 'package:matrix/matrix.dart' as _i2;
 import 'package:matrix/matrix_api_lite/generated/fixed_model.dart' as _i6;
 import 'package:matrix/src/utils/cached_stream_controller.dart' as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i17;
+import 'package:mockito/src/dummies.dart' as _i18;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -844,6 +845,17 @@ class _FakeOutboxService_74 extends _i1.SmartFake
         );
 }
 
+class _FakeStickerPackService_75 extends _i1.SmartFake
+    implements _i16.StickerPackService {
+  _FakeStickerPackService_75(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [Client].
 ///
 /// See the documentation for Mockito's code generation for more information.
@@ -862,12 +874,12 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i2.DatabaseApi);
 
   @override
-  Set<_i16.KeyVerificationMethod> get verificationMethods =>
+  Set<_i17.KeyVerificationMethod> get verificationMethods =>
       (super.noSuchMethod(
         Invocation.getter(#verificationMethods),
-        returnValue: <_i16.KeyVerificationMethod>{},
-        returnValueForMissingStub: <_i16.KeyVerificationMethod>{},
-      ) as Set<_i16.KeyVerificationMethod>);
+        returnValue: <_i17.KeyVerificationMethod>{},
+        returnValueForMissingStub: <_i17.KeyVerificationMethod>{},
+      ) as Set<_i17.KeyVerificationMethod>);
 
   @override
   Set<String> get importantStateEvents => (super.noSuchMethod(
@@ -987,11 +999,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -1028,11 +1040,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get dehydratedDeviceDisplayName => (super.noSuchMethod(
         Invocation.getter(#dehydratedDeviceDisplayName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#dehydratedDeviceDisplayName),
         ),
@@ -1062,11 +1074,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get identityKey => (super.noSuchMethod(
         Invocation.getter(#identityKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#identityKey),
         ),
@@ -1075,11 +1087,11 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   String get fingerprintKey => (super.noSuchMethod(
         Invocation.getter(#fingerprintKey),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#fingerprintKey),
         ),
@@ -1365,34 +1377,34 @@ class MockClient extends _i1.Mock implements _i2.Client {
       ) as _i3.CachedStreamController<_i2.BasicEvent>);
 
   @override
-  _i3.CachedStreamController<_i16.RoomKeyRequest> get onRoomKeyRequest =>
+  _i3.CachedStreamController<_i17.RoomKeyRequest> get onRoomKeyRequest =>
       (super.noSuchMethod(
         Invocation.getter(#onRoomKeyRequest),
-        returnValue: _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+        returnValue: _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
         returnValueForMissingStub:
-            _FakeCachedStreamController_6<_i16.RoomKeyRequest>(
+            _FakeCachedStreamController_6<_i17.RoomKeyRequest>(
           this,
           Invocation.getter(#onRoomKeyRequest),
         ),
-      ) as _i3.CachedStreamController<_i16.RoomKeyRequest>);
+      ) as _i3.CachedStreamController<_i17.RoomKeyRequest>);
 
   @override
-  _i3.CachedStreamController<_i16.KeyVerification>
+  _i3.CachedStreamController<_i17.KeyVerification>
       get onKeyVerificationRequest => (super.noSuchMethod(
             Invocation.getter(#onKeyVerificationRequest),
-            returnValue: _FakeCachedStreamController_6<_i16.KeyVerification>(
+            returnValue: _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
             returnValueForMissingStub:
-                _FakeCachedStreamController_6<_i16.KeyVerification>(
+                _FakeCachedStreamController_6<_i17.KeyVerification>(
               this,
               Invocation.getter(#onKeyVerificationRequest),
             ),
-          ) as _i3.CachedStreamController<_i16.KeyVerification>);
+          ) as _i3.CachedStreamController<_i17.KeyVerification>);
 
   @override
   _i3.CachedStreamController<_i2.UiaRequest<dynamic>> get onUiaRequest =>
@@ -1548,7 +1560,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
       );
 
   @override
-  set verificationMethods(Set<_i16.KeyVerificationMethod>? value) =>
+  set verificationMethods(Set<_i17.KeyVerificationMethod>? value) =>
       super.noSuchMethod(
         Invocation.setter(
           #verificationMethods,
@@ -1837,14 +1849,14 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #generateUniqueTransactionId,
           [],
         ),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
             [],
           ),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.method(
             #generateUniqueTransactionId,
@@ -2232,8 +2244,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
           #uiaRequestBackground,
           [request],
         ),
-        returnValue: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValue: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2249,8 +2261,8 @@ class MockClient extends _i1.Mock implements _i2.Client {
                 [request],
               ),
             ),
-        returnValueForMissingStub: _i17.ifNotNull(
-              _i17.dummyValueOrNull<T>(
+        returnValueForMissingStub: _i18.ifNotNull(
+              _i18.dummyValueOrNull<T>(
                 this,
                 Invocation.method(
                   #uiaRequestBackground,
@@ -2291,7 +2303,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #skipExistingChat: skipExistingChat,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2307,7 +2319,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #startDirectChat,
@@ -2356,7 +2368,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #powerLevelContentOverride: powerLevelContentOverride,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2377,7 +2389,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createGroupChat,
@@ -2480,7 +2492,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #waitForSync: waitForSync,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -2498,7 +2510,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createSpace,
@@ -3017,7 +3029,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 
   @override
   _i5.Future<Uri> uploadContent(
-    _i18.Uint8List? file, {
+    _i19.Uint8List? file, {
     String? filename,
     String? contentType,
   }) =>
@@ -3369,7 +3381,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3383,7 +3395,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoom,
@@ -3534,7 +3546,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   @override
   Never unexpectedResponse(
     _i4.BaseResponse? response,
-    _i18.Uint8List? body,
+    _i19.Uint8List? body,
   ) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -4912,7 +4924,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #visibility: visibility,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -4934,7 +4946,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #createRoom,
@@ -5428,7 +5440,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #reason: reason,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -5440,7 +5452,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #knockRoom,
@@ -6448,7 +6460,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             authData,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6459,7 +6471,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #postRoomKeysVersion,
@@ -6707,7 +6719,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             #thirdPartySigned: thirdPartySigned,
           },
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6719,7 +6731,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #joinRoomById,
@@ -6979,7 +6991,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -6992,7 +7004,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #sendMessage,
@@ -7059,7 +7071,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7072,7 +7084,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #setRoomStateWithKey,
@@ -7120,7 +7132,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ],
           {#additionalCreators: additionalCreators},
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7132,7 +7144,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #upgradeRoom,
@@ -7380,7 +7392,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
             body,
           ],
         ),
-        returnValue: _i5.Future<String>.value(_i17.dummyValue<String>(
+        returnValue: _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7391,7 +7403,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
           ),
         )),
         returnValueForMissingStub:
-            _i5.Future<String>.value(_i17.dummyValue<String>(
+            _i5.Future<String>.value(_i18.dummyValue<String>(
           this,
           Invocation.method(
             #defineFilter,
@@ -7653,7 +7665,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
   _i5.Future<Map<String, Object?>> uploadContentToMXC(
     String? serverName,
     String? mediaId,
-    _i18.Uint8List? body, {
+    _i19.Uint8List? body, {
     String? filename,
     String? contentType,
   }) =>
@@ -7680,7 +7692,7 @@ class MockClient extends _i1.Mock implements _i2.Client {
 /// A class which mocks [MatrixService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
+class MockMatrixService extends _i1.Mock implements _i20.MatrixService {
   @override
   _i7.CallPushRuleManager get callPushRuleManager => (super.noSuchMethod(
         Invocation.getter(#callPushRuleManager),
@@ -7710,11 +7722,11 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
   @override
   String get clientName => (super.noSuchMethod(
         Invocation.getter(#clientName),
-        returnValue: _i17.dummyValue<String>(
+        returnValue: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
-        returnValueForMissingStub: _i17.dummyValue<String>(
+        returnValueForMissingStub: _i18.dummyValue<String>(
           this,
           Invocation.getter(#clientName),
         ),
@@ -7839,6 +7851,19 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i15.OutboxService);
 
   @override
+  _i16.StickerPackService get stickerPacks => (super.noSuchMethod(
+        Invocation.getter(#stickerPacks),
+        returnValue: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+        returnValueForMissingStub: _FakeStickerPackService_75(
+          this,
+          Invocation.getter(#stickerPacks),
+        ),
+      ) as _i16.StickerPackService);
+
+  @override
   bool get hasSkippedSetup => (super.noSuchMethod(
         Invocation.getter(#hasSkippedSetup),
         returnValue: false,
@@ -7936,6 +7961,15 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
+  set stickerPacks(_i16.StickerPackService? value) => super.noSuchMethod(
+        Invocation.setter(
+          #stickerPacks,
+          value,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
@@ -7980,7 +8014,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeAppLifecycleState(_i20.AppLifecycleState? state) =>
+  void didChangeAppLifecycleState(_i21.AppLifecycleState? state) =>
       super.noSuchMethod(
         Invocation.method(
           #didChangeAppLifecycleState,
@@ -8005,6 +8039,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
     required String? homeserver,
     required String? username,
     required String? password,
+    bool? rememberCredentials = false,
   }) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -8014,6 +8049,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
             #homeserver: homeserver,
             #username: username,
             #password: password,
+            #rememberCredentials: rememberCredentials,
           },
         ),
         returnValue: _i5.Future<bool>.value(false),
@@ -8074,7 +8110,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8083,7 +8119,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -8102,7 +8138,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as _i5.Future<bool>);
 
   @override
-  bool handleStartBackGesture(_i21.PredictiveBackEvent? backEvent) =>
+  bool handleStartBackGesture(_i22.PredictiveBackEvent? backEvent) =>
       (super.noSuchMethod(
         Invocation.method(
           #handleStartBackGesture,
@@ -8113,7 +8149,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       ) as bool);
 
   @override
-  void handleUpdateBackGestureProgress(_i21.PredictiveBackEvent? backEvent) =>
+  void handleUpdateBackGestureProgress(_i22.PredictiveBackEvent? backEvent) =>
       super.noSuchMethod(
         Invocation.method(
           #handleUpdateBackGestureProgress,
@@ -8161,7 +8197,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
 
   @override
   _i5.Future<bool> didPushRouteInformation(
-          _i22.RouteInformation? routeInformation) =>
+          _i23.RouteInformation? routeInformation) =>
       (super.noSuchMethod(
         Invocation.method(
           #didPushRouteInformation,
@@ -8199,7 +8235,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeLocales(List<_i20.Locale>? locales) => super.noSuchMethod(
+  void didChangeLocales(List<_i21.Locale>? locales) => super.noSuchMethod(
         Invocation.method(
           #didChangeLocales,
           [locales],
@@ -8208,7 +8244,7 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  void didChangeViewFocus(_i20.ViewFocusEvent? event) => super.noSuchMethod(
+  void didChangeViewFocus(_i21.ViewFocusEvent? event) => super.noSuchMethod(
         Invocation.method(
           #didChangeViewFocus,
           [event],
@@ -8217,16 +8253,16 @@ class MockMatrixService extends _i1.Mock implements _i19.MatrixService {
       );
 
   @override
-  _i5.Future<_i20.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
+  _i5.Future<_i21.AppExitResponse> didRequestAppExit() => (super.noSuchMethod(
         Invocation.method(
           #didRequestAppExit,
           [],
         ),
         returnValue:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
         returnValueForMissingStub:
-            _i5.Future<_i20.AppExitResponse>.value(_i20.AppExitResponse.exit),
-      ) as _i5.Future<_i20.AppExitResponse>);
+            _i5.Future<_i21.AppExitResponse>.value(_i21.AppExitResponse.exit),
+      ) as _i5.Future<_i21.AppExitResponse>);
 
   @override
   void didHaveMemoryPressure() => super.noSuchMethod(
@@ -8312,7 +8348,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  _i5.Future<void> runKeyRecovery({_i16.OpenSSSS? ssssKey}) =>
+  _i5.Future<void> runKeyRecovery({_i17.OpenSSSS? ssssKey}) =>
       (super.noSuchMethod(
         Invocation.method(
           #runKeyRecovery,
@@ -8366,7 +8402,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       ) as _i5.Future<void>);
 
   @override
-  void addListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -8375,7 +8411,7 @@ class MockChatBackupService extends _i1.Mock implements _i10.ChatBackupService {
       );
 
   @override
-  void removeListener(_i20.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i21.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],


### PR DESCRIPTION
## Summary

- Adds a **Remember Me** checkbox to the login screen; when checked, username and password are saved to `flutter_secure_storage` immediately after a successful login
- On return to the login screen (after sign-out or session expiry) both fields are pre-filled and the checkbox is re-checked automatically
- Unchecking Remember Me and signing in clears any previously saved credentials
- Works on all platforms (Windows DPAPI, macOS/iOS Keychain, Android Keystore, Linux libsecret)

## Why not `TextInput.finishAutofillContext`?

The OS credential-save prompt is a browser feature on desktop — Windows does not expose it to native apps via an autofill API. `finishAutofillContext` is kept in place as a bonus for iOS/Android where the platform autofill framework is fully implemented.

## Key implementation detail

The save happens inside `auth_service.login()` right after the Matrix SDK login succeeds, **before** `notifyListeners()` fires. This is intentional: `notifyListeners()` triggers the go_router redirect synchronously, which disposes the login screen before `MatrixService.login()` ever returns (it also awaits a 5-minute sync). Saving earlier ensures the write always completes.

## Test plan

- [x] Sign in with Remember Me checked → `flutter_secure_storage` saves username/password
- [x] Sign out, navigate back through homeserver screen → login fields are pre-filled and checkbox is checked
- [x] Sign in with Remember Me unchecked → saved credentials are cleared
- [x] Failed login does not save credentials

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)