### PR TITLE
fix(#583): clamp quick-react bar inside the viewport

### DIFF
--- a/lib/features/chat/widgets/hover_action_bar.dart
+++ b/lib/features/chat/widgets/hover_action_bar.dart
@@ -44,7 +44,6 @@ class HoverActionBar extends StatefulWidget {
 
 class _HoverActionBarState extends State<HoverActionBar> {
   OverlayEntry? _overlayEntry;
-  final LayerLink _layerLink = LayerLink();
 
   bool _disposing = false;
   bool _precached = false;
@@ -79,12 +78,17 @@ class _HoverActionBarState extends State<HoverActionBar> {
     final box = context.findRenderObject() as RenderBox?;
     if (box == null || !box.hasSize) return;
 
+    final overlayBox = overlay.context.findRenderObject() as RenderBox?;
+    final anchorTopCenter = box.localToGlobal(
+      Offset(box.size.width / 2, 0),
+      ancestor: overlayBox,
+    );
+
     widget.onQuickReactOpenChanged?.call(true);
 
     _overlayEntry = OverlayEntry(
       builder: (ctx) => _QuickReactOverlay(
-        link: _layerLink,
-        anchorSize: box.size,
+        anchorTopCenter: anchorTopCenter,
         cs: widget.cs,
         hasMore: widget.onReact != null,
         onEmojiSelected: (emoji) {
@@ -100,49 +104,46 @@ class _HoverActionBarState extends State<HoverActionBar> {
   @override
   Widget build(BuildContext context) {
     final hasReact = widget.onReact != null || widget.onQuickReact != null;
-    return CompositedTransformTarget(
-      link: _layerLink,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 4),
-        child: Material(
-          elevation: 2,
-          borderRadius: BorderRadius.circular(16),
-          color: widget.cs.surfaceContainerHighest,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (hasReact)
-                _ActionIcon(
-                  icon: Icons.add_reaction_outlined,
-                  onTap: _showQuickReactPopup,
-                  cs: widget.cs,
-                  borderRadius: const BorderRadius.horizontal(
-                    left: Radius.circular(16),
-                  ),
-                ),
-              if (widget.onReply != null)
-                _ActionIcon(
-                  icon: Icons.reply_rounded,
-                  onTap: widget.onReply!,
-                  cs: widget.cs,
-                ),
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      child: Material(
+        elevation: 2,
+        borderRadius: BorderRadius.circular(16),
+        color: widget.cs.surfaceContainerHighest,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (hasReact)
               _ActionIcon(
-                icon: Icons.more_horiz_rounded,
-                onTap: () {
-                  final box = context.findRenderObject() as RenderBox?;
-                  if (box == null || !box.hasSize) return;
-                  final pos = box.localToGlobal(
-                    Offset(box.size.width, box.size.height / 2),
-                  );
-                  widget.onMore(pos);
-                },
+                icon: Icons.add_reaction_outlined,
+                onTap: _showQuickReactPopup,
                 cs: widget.cs,
                 borderRadius: const BorderRadius.horizontal(
-                  right: Radius.circular(16),
+                  left: Radius.circular(16),
                 ),
               ),
-            ],
-          ),
+            if (widget.onReply != null)
+              _ActionIcon(
+                icon: Icons.reply_rounded,
+                onTap: widget.onReply!,
+                cs: widget.cs,
+              ),
+            _ActionIcon(
+              icon: Icons.more_horiz_rounded,
+              onTap: () {
+                final box = context.findRenderObject() as RenderBox?;
+                if (box == null || !box.hasSize) return;
+                final pos = box.localToGlobal(
+                  Offset(box.size.width, box.size.height / 2),
+                );
+                widget.onMore(pos);
+              },
+              cs: widget.cs,
+              borderRadius: const BorderRadius.horizontal(
+                right: Radius.circular(16),
+              ),
+            ),
+          ],
         ),
       ),
     );
@@ -181,16 +182,15 @@ class _ActionIcon extends StatelessWidget {
 
 class _QuickReactOverlay extends StatefulWidget {
   const _QuickReactOverlay({
-    required this.link,
-    required this.anchorSize,
+    required this.anchorTopCenter,
     required this.cs,
     required this.hasMore,
     required this.onEmojiSelected,
     required this.onDismiss,
   });
 
-  final LayerLink link;
-  final Size anchorSize;
+  /// Top-center of the action bar, in the overlay's coordinate space.
+  final Offset anchorTopCenter;
   final ColorScheme cs;
 
   /// Whether to show the "..." button (only when a full emoji picker is available).
@@ -210,6 +210,10 @@ class _QuickReactOverlayState extends State<_QuickReactOverlay> {
     final cs = widget.cs;
     final tone = context.watch<PreferencesService>().skinTone;
     const gap = 4.0;
+    const margin = 8.0;
+
+    final pickerWidth =
+        (MediaQuery.sizeOf(context).width - margin * 2).clamp(0.0, 350.0);
 
     return Stack(
       children: [
@@ -220,12 +224,13 @@ class _QuickReactOverlayState extends State<_QuickReactOverlay> {
             onTap: widget.onDismiss,
           ),
         ),
-        CompositedTransformFollower(
-          link: widget.link,
-          targetAnchor: Alignment.topCenter,
-          followerAnchor: Alignment.bottomCenter,
-          offset: const Offset(0, -gap),
-          child: UnconstrainedBox(
+        Positioned.fill(
+          child: CustomSingleChildLayout(
+            delegate: _QuickReactLayoutDelegate(
+              anchorTopCenter: widget.anchorTopCenter,
+              gap: gap,
+              margin: margin,
+            ),
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
@@ -239,7 +244,7 @@ class _QuickReactOverlayState extends State<_QuickReactOverlay> {
                       color: cs.surfaceContainer,
                       clipBehavior: Clip.antiAlias,
                       child: SizedBox(
-                        width: 350,
+                        width: pickerWidth,
                         height: 400,
                         child: OpenMojiPicker(
                           skinTone: context.watch<PreferencesService>().skinTone,
@@ -305,4 +310,46 @@ class _QuickReactOverlayState extends State<_QuickReactOverlay> {
       ],
     );
   }
+}
+
+// ── Quick-react layout delegate ─────────────────────────────
+//
+// Positions the popup so its bottom-center sits above [anchorTopCenter], then
+// clamps it inside the viewport (minus [margin]) so it never overflows a screen
+// edge on narrow layouts.
+class _QuickReactLayoutDelegate extends SingleChildLayoutDelegate {
+  _QuickReactLayoutDelegate({
+    required this.anchorTopCenter,
+    required this.gap,
+    required this.margin,
+  });
+
+  final Offset anchorTopCenter;
+  final double gap;
+  final double margin;
+
+  @override
+  BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
+    return BoxConstraints.loose(
+      Size(
+        (constraints.maxWidth - margin * 2).clamp(0.0, double.infinity),
+        (constraints.maxHeight - margin * 2).clamp(0.0, double.infinity),
+      ),
+    );
+  }
+
+  @override
+  Offset getPositionForChild(Size size, Size childSize) {
+    final dx = (anchorTopCenter.dx - childSize.width / 2)
+        .clamp(margin, size.width - margin - childSize.width);
+    final dy = (anchorTopCenter.dy - gap - childSize.height)
+        .clamp(margin, size.height - margin - childSize.height);
+    return Offset(dx, dy);
+  }
+
+  @override
+  bool shouldRelayout(_QuickReactLayoutDelegate oldDelegate) =>
+      anchorTopCenter != oldDelegate.anchorTopCenter ||
+      gap != oldDelegate.gap ||
+      margin != oldDelegate.margin;
 }

--- a/test/widgets/chat/hover_action_bar_test.dart
+++ b/test/widgets/chat/hover_action_bar_test.dart
@@ -112,6 +112,48 @@ void main() {
       expect(_emojiImage('\u{1F602}'), findsNothing);
     });
 
+    Widget buildEdgeWidget(Alignment alignment) =>
+        ChangeNotifierProvider<PreferencesService>(
+          create: (_) => PreferencesService(),
+          child: MaterialApp(
+            home: Scaffold(
+              body: Align(
+                alignment: alignment,
+                child: HoverActionBar(
+                  cs: const ColorScheme.light(),
+                  onQuickReact: (_) {},
+                  onMore: (_) {},
+                ),
+              ),
+            ),
+          ),
+        );
+
+    testWidgets('quick-react bar stays on-screen near the left edge',
+        (tester) async {
+      await tester.pumpWidget(buildEdgeWidget(Alignment.centerLeft));
+      await tester.tap(find.byIcon(Icons.add_reaction_outlined));
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.getTopLeft(_emojiImage('\u{2764}\u{FE0F}')).dx,
+        greaterThanOrEqualTo(0),
+      );
+    });
+
+    testWidgets('quick-react bar stays on-screen near the right edge',
+        (tester) async {
+      await tester.pumpWidget(buildEdgeWidget(Alignment.centerRight));
+      await tester.tap(find.byIcon(Icons.add_reaction_outlined));
+      await tester.pumpAndSettle();
+
+      final screenWidth = tester.getSize(find.byType(Scaffold)).width;
+      expect(
+        tester.getTopRight(_emojiImage('\u{1F62E}')).dx,
+        lessThanOrEqualTo(screenWidth),
+      );
+    });
+
     testWidgets('quick-react applies the default skin tone', (tester) async {
       SharedPreferences.setMockInitialValues({'emoji_skin_tone': 'dark'});
       final sp = await SharedPreferences.getInstance();


### PR DESCRIPTION
## Summary

On narrow layouts the quick-react emoji bar was clipped at screen edges: it centered on the message bubble with no viewport clamping, so a message near the left/right edge pushed the outermost emoji off-screen. This clamps the overlay inside the viewport so every emoji stays reachable.

## Changes

- `lib/features/chat/widgets/hover_action_bar.dart`:
  - Capture the action bar's top-center in the overlay's coordinate space at show-time and pass it to `_QuickReactOverlay`.
  - Replace the `CompositedTransformFollower` + `UnconstrainedBox` centering with a `CustomSingleChildLayout` + `_QuickReactLayoutDelegate` that anchors the popup's bottom-center above the bar and **clamps both axes** inside the viewport (minus an 8px margin), shifting inward instead of overflowing.
  - Size the full emoji picker to `min(350, screenWidth − margin*2)` so the picker panel can't overflow on narrow screens either (the issue's noted secondary risk).
  - Drop the now-unused `LayerLink` / `CompositedTransformTarget` plumbing. The dismiss scrim still works — the delegate box does not hit-test outside its child, so edge taps fall through.

## Testing

- [x] `flutter analyze` is clean
- [x] `flutter test test/widgets/chat/hover_action_bar_test.dart` passes (12/12)

New regression tests: quick-react bar stays on-screen near the left edge (leftmost emoji `dx ≥ 0`) and right edge (rightmost emoji `≤ screenWidth`). Both fail against the pre-fix centering.

## Screenshots / recordings

N/A — positioning fix; behaviour verified via the edge-case widget tests above.

## Linked issues

Closes #583
Refs #566

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline refs)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master`
