### PR TITLE
fix(#592): constrain OpenMoji image size in WidgetSpans on web

### DIFF
--- a/lib/shared/widgets/openmoji_image.dart
+++ b/lib/shared/widgets/openmoji_image.dart
@@ -33,13 +33,18 @@ class OpenMojiImage extends StatelessWidget {
     // Decode at native resolution (no cacheWidth): the 72px source upscales and
     // pixelates if decoded smaller than its painted size. Downsampling from
     // native uses the default medium filter quality and stays crisp.
-    return Image.asset(
+    final image = Image.asset(
       asset,
       width: s,
       height: s,
       fit: BoxFit.contain,
       errorBuilder: (context, error, stackTrace) => _fallback(),
     );
+    if (s == null) return image;
+    // Pin the painted box. Inside a WidgetSpan (inline emoji, reaction chips)
+    // the web renderer can ignore Image.width/height and paint the asset at its
+    // native 72px, blowing out the layout; an explicit SizedBox constrains it.
+    return SizedBox(width: s, height: s, child: image);
   }
 
   Widget _fallback() => Text(

--- a/test/widgets/shared/openmoji_image_test.dart
+++ b/test/widgets/shared/openmoji_image_test.dart
@@ -35,6 +35,34 @@ void main() {
     expect(_assetOf(image), 'assets/openmoji/2764.png');
   });
 
+  testWidgets('constrains the painted box to size', (tester) async {
+    await tester.pumpWidget(
+      _wrap(const OpenMojiImage(grapheme: '\u{1F44D}', size: 24)),
+    );
+
+    expect(tester.getSize(find.byType(OpenMojiImage)), const Size(24, 24));
+  });
+
+  testWidgets('stays constrained when rendered inline in a WidgetSpan',
+      (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        const Text.rich(
+          TextSpan(
+            children: [
+              WidgetSpan(
+                alignment: PlaceholderAlignment.middle,
+                child: OpenMojiImage(grapheme: '\u{1F44D}', size: 16),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byType(OpenMojiImage)), const Size(16, 16));
+  });
+
   testWidgets('falls back to text when no asset is bundled', (tester) async {
     await tester.pumpWidget(
       _wrap(const OpenMojiImage(grapheme: 'x', size: 24)),


### PR DESCRIPTION
## Summary

Emoji reaction chips (and inline message emoji) render oversized on web — the OpenMoji image paints at its native 72px instead of the intended ~16px, blowing out the chip styling. This pins the image size so it renders correctly on every renderer.

## Changes

- `lib/shared/widgets/openmoji_image.dart`: when a `size` is provided, wrap the `Image.asset` in a `SizedBox(width/height: size)`. Inside a `WidgetSpan` (reaction chips, inline emoji) the web renderer can ignore `Image.width/height` and paint the asset at its native size; the explicit `SizedBox` constrains it. The picker path (`size == null`, fills its parent) is unchanged.

## Testing

- [x] `flutter analyze` is clean
- [x] `flutter test` — new + existing OpenMoji/reaction/emoji-span suites pass

New regression tests in `test/widgets/shared/openmoji_image_test.dart`: the rendered box is `24×24`, and stays `16×16` when rendered inline inside a `WidgetSpan` (the reaction/inline path).

> Note: the defect is web-renderer-specific. Widget tests run on the Flutter VM where `Image.width/height` is already honoured, so they guard the size plumbing but do not reproduce the web bug itself. The `SizedBox` is the standard remedy for the known Flutter-web `WidgetSpan` + `Image` sizing issue and can only constrain (no behaviour change on desktop). Visual confirmation on `flutter run -d chrome` still recommended before close.

## Screenshots / recordings

N/A here — see the screenshot in #592 for the broken state.

## Linked issues

Closes #592

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline refs)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master`
