### PR TITLE
fix: resolve iOS/macOS release build failures

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -309,7 +309,7 @@ import UserNotifications
   // cannot route through the Flutter plugin (malformed payloads, or the plugin
   // not being registered yet on a cold background launch).
   private lazy var placeholderCallProvider: CXProvider = {
-    let configuration = CXProviderConfiguration()
+    let configuration = CXProviderConfiguration(localizedName: "Kohera")
     configuration.supportsVideo = true
     configuration.supportedHandleTypes = [.generic]
     return CXProvider(configuration: configuration)

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -221,10 +221,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "62ffa266d9a23b79fb3fcbc206afc00bb979417ba57b1324c546b5aab95ba057"
+      sha256: "33bae12a398f841c6cda09d1064212957265869104c478e5ad51e2fb26c3973c"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.1"
+    version: "7.0.0"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   cached_network_image_platform_interface: ^4.0.0
   canonical_json: ^1.1.2
   clock: ^1.1.1
-  connectivity_plus: ^7.0.0
+  connectivity_plus: 7.0.0
   desktop_drop: ^0.7.0
   desktop_notifications: ^0.6.3
   dynamic_color: ^1.7.0


### PR DESCRIPTION
## Summary

Fix the two compile failures that broke the v1.5.0 release run ([build-ios](https://github.com/Quantumheart/Kohera/actions/runs/27240102119) and build-macos). Each job failed for an independent reason.

## Changes

- **iOS** (`ios/Runner/AppDelegate.swift`): the no-argument `CXProviderConfiguration()` initializer is only available on iOS 14+, but the deployment target is 13.0, so the release archive failed with `'init()' is only available in iOS 14.0 or newer`. Switched to `CXProviderConfiguration(localizedName:)`, available since iOS 10.
- **macOS** (`pubspec.yaml`, `pubspec.lock`): `connectivity_plus` 7.1.0 added a reference to `NWPath.isUltraConstrained`, an API that only exists in the macOS 26 SDK. The release runner uses Xcode 16.4 (SDK 15.5), where the symbol is undefined, so the macOS build failed with `value of type 'NWPath' has no member 'isUltraConstrained'`. Pinned to `7.0.0`, the last release without that reference.

## Testing

- [x] `flutter build ios --release --no-codesign` — succeeds (the iOS availability error is deployment-target based and reproduces locally regardless of SDK)
- [x] `flutter build macos --release` — succeeds
- [ ] `flutter analyze` is clean
- [ ] `flutter test` passes

## Linked issues

Refs #563

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [ ] Tests added or updated to cover the change
- [x] Targets `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
