### PR TITLE
fix(#589): add onHover fallback for hover bar on Flutter web canvas

### DIFF
--- a/lib/features/chat/widgets/message_bubble.dart
+++ b/lib/features/chat/widgets/message_bubble.dart
@@ -208,6 +208,10 @@ class _MessageBubbleState extends State<MessageBubble> {
     if (isDesktop) {
       bubble = MouseRegion(
         onEnter: (_) => _hovering.value = true,
+        // Belt-and-suspenders: onEnter can be missed on Flutter web canvas,
+        // so onHover (fires on every mouse-move inside the region) ensures
+        // the bar eventually appears even if the enter event was dropped.
+        onHover: (_) { if (!_hovering.value) _hovering.value = true; },
         onExit: (_) {
           if (!_quickReactOpen.value) _hovering.value = false;
         },


### PR DESCRIPTION
## Summary

- `MouseRegion.onEnter` can be silently dropped in Flutter web's CanvasKit renderer when inside a scrollable list. Adding `onHover` (fires on every mouse-move inside the region) ensures the action bar appears even if the initial enter event was missed.
- Emoji rendering on web is already resolved by the OpenMoji integration on master (images, no font dependency).

## Test plan

- [x] `flutter analyze` — no issues
- [x] Tested on Chrome (`flutter run -d chrome`): hover bar appears on message bubbles
- [x] Emoji rendering confirmed correct (OpenMoji images render natively on web)

Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)