### PR TITLE
ci: drop redundant analyze/test gate from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  analyze-and-test:
+  verify-tag:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -24,24 +24,9 @@ jobs:
             echo "::error::Tag must point to a commit on master"
             exit 1
           fi
-      - uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # v2
-        with:
-          channel: stable
-          flutter-version: '3.44.1'
-          cache: true
-      - name: Cache pub dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/.pub-cache
-          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
-          restore-keys: pub-${{ runner.os }}-
-      - run: flutter pub get
-      - run: dart run build_runner build --delete-conflicting-outputs
-      - run: flutter analyze
-      - run: flutter test
 
   build-linux:
-    needs: analyze-and-test
+    needs: verify-tag
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -73,7 +58,7 @@ jobs:
             kohera-linux-x64.tar.gz.sha256
 
   build-windows:
-    needs: analyze-and-test
+    needs: verify-tag
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -104,7 +89,7 @@ jobs:
             build/windows/installer/kohera-windows-x64-setup.exe.sha256
 
   build-macos:
-    needs: analyze-and-test
+    needs: verify-tag
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -144,7 +129,7 @@ jobs:
             kohera-macos-universal.zip.sha256
 
   build-ios:
-    needs: analyze-and-test
+    needs: verify-tag
     runs-on: macos-26
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -218,7 +203,7 @@ jobs:
         run: security delete-keychain $RUNNER_TEMP/app-signing.keychain-db
 
   build-android:
-    needs: analyze-and-test
+    needs: verify-tag
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Summary

Drop the redundant `analyze` + `test` gate from the release workflow so all platform builds start in parallel. Those checks already run on every pull request and every master push (`ci.yml`), and release tags are cut by release-please on `master`, so the released commit has always passed them. This removes ~6 min from the front of every release's critical path.

> **Stacked on #603** (caching + version pin). Base is `ci/release-build-caching`; review/merge that first, or rebase this onto `master` after it lands.

## Changes

- Replace the `analyze-and-test` job with a lightweight **`verify-tag`** job that keeps only the release-specific "tag is on master" ancestor check (this check runs nowhere else, so it's preserved).
- All build jobs now `needs: verify-tag` (a ~20s check) instead of `needs: analyze-and-test` (~6 min), so every platform — including iOS, the long pole — builds in parallel from the start.

## Why this is safe

- `ci.yml` runs `flutter analyze` and `flutter test` on every `pull_request` and `push` to `master`.
- The `v*` tag is created by release-please on `master`; `verify-tag` still enforces the tag points at a `master` commit.
- Therefore the analyze/test run inside the release workflow was always re-validating already-validated code.

## Effect

Release wall-clock goes from ~`6m (gate) + 13m (slowest build)` to ~`max(builds)` ≈ **13m** (before caching) — and lower once #603's caches warm.

## Testing

- [x] `release.yml` parses as valid YAML; job graph verified (`verify-tag` → all builds → `publish-release`)
- [ ] Confirmed on the next tag-triggered release

## Linked issues

N/A — CI performance improvement.

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type
- [x] No stray comments added
- [x] Targets `master` (stacked on #603 until it merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
