### PR TITLE
feat(#587): render decimal SAS in device verification

### DIFF
--- a/lib/features/e2ee/widgets/key_verification_content.dart
+++ b/lib/features/e2ee/widgets/key_verification_content.dart
@@ -13,6 +13,12 @@ class KeyVerificationContent extends StatelessWidget {
   final KeyVerificationState state;
   final KeyVerification verification;
 
+  bool get _showSasNumbers {
+    final types = verification.sasTypes;
+    final emojiNegotiated = types.isEmpty || types.contains('emoji');
+    return !emojiNegotiated || verification.sasEmojis.isEmpty;
+  }
+
   String get title {
     switch (state) {
       case KeyVerificationState.askChoice:
@@ -21,7 +27,7 @@ class KeyVerificationContent extends StatelessWidget {
       case KeyVerificationState.askAccept:
         return 'Incoming verification';
       case KeyVerificationState.askSas:
-        return 'Compare emoji';
+        return _showSasNumbers ? 'Compare numbers' : 'Compare emoji';
       case KeyVerificationState.askSSSS:
         return 'Unlocking secrets';
       case KeyVerificationState.waitingSas:
@@ -60,7 +66,9 @@ class KeyVerificationContent extends StatelessWidget {
         return _buildWaiting('Starting verification...');
 
       case KeyVerificationState.askSas:
-        return _buildSasEmoji(context);
+        return _showSasNumbers
+            ? _buildSasNumbers(context)
+            : _buildSasEmoji(context);
 
       case KeyVerificationState.askSSSS:
         return _buildWaiting('Unlocking encryption secrets...');
@@ -119,6 +127,34 @@ class KeyVerificationContent extends StatelessWidget {
         const CircularProgressIndicator(),
         const SizedBox(height: 16),
         Text(message),
+      ],
+    );
+  }
+
+  Widget _buildSasNumbers(BuildContext context) {
+    final numbers = verification.sasNumbers;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const Text(
+          'Verify that the following numbers appear on both devices, '
+          'in the same order:',
+        ),
+        const SizedBox(height: 16),
+        Wrap(
+          alignment: WrapAlignment.center,
+          spacing: 24,
+          runSpacing: 8,
+          children: numbers
+              .map((n) => Text(
+                    '$n',
+                    style: const TextStyle(
+                      fontSize: 32,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),)
+              .toList(),
+        ),
       ],
     );
   }

--- a/test/widgets/key_verification_dialog_test.dart
+++ b/test/widgets/key_verification_dialog_test.dart
@@ -27,6 +27,16 @@ class FakeKeyVerification extends Fake implements KeyVerification {
   @override
   List<KeyVerificationEmoji> get sasEmojis => _sasEmojis;
 
+  List<int> _sasNumbers = [];
+
+  @override
+  List<int> get sasNumbers => _sasNumbers;
+
+  List<String> _sasTypes = [];
+
+  @override
+  List<String> get sasTypes => _sasTypes;
+
   @override
   List<String> possibleMethods = [];
 
@@ -44,6 +54,14 @@ class FakeKeyVerification extends Fake implements KeyVerification {
 
   void setSasEmojis(List<KeyVerificationEmoji> emojis) {
     _sasEmojis = emojis;
+  }
+
+  void setSasNumbers(List<int> numbers) {
+    _sasNumbers = numbers;
+  }
+
+  void setSasTypes(List<String> types) {
+    _sasTypes = types;
   }
 
   void simulateStateChange(KeyVerificationState newState) {
@@ -159,6 +177,56 @@ void main() {
 
       // Verify ExcludeSemantics wraps the emoji text (at least 2 from our code)
       expect(find.byType(ExcludeSemantics), findsAtLeast(2));
+      expect(find.text('Compare emoji'), findsOneWidget);
+    });
+
+    testWidgets('renders decimal SAS when decimal is negotiated',
+        (tester) async {
+      final verification = FakeKeyVerification(
+        state: KeyVerificationState.askSas,
+      );
+      verification.setSasTypes(['decimal']);
+      verification.setSasNumbers([1234, 5678, 9012]);
+
+      await openDialog(tester, verification: verification);
+
+      // Title and numbers reflect the decimal representation.
+      expect(find.text('Compare numbers'), findsOneWidget);
+      expect(find.text('1234'), findsOneWidget);
+      expect(find.text('5678'), findsOneWidget);
+      expect(find.text('9012'), findsOneWidget);
+
+      // The match/reject actions still work for decimal.
+      await tester.tap(find.text('They match'));
+      expect(verification.acceptSasCalled, isTrue);
+    });
+
+    testWidgets('prefers emoji when both emoji and decimal are negotiated',
+        (tester) async {
+      final verification = FakeKeyVerification(
+        state: KeyVerificationState.askSas,
+      );
+      verification.setSasTypes(['emoji', 'decimal']);
+      verification.setSasEmojis([KeyVerificationEmoji(0)]);
+      verification.setSasNumbers([1234, 5678, 9012]);
+
+      await openDialog(tester, verification: verification);
+
+      expect(find.text('Compare emoji'), findsOneWidget);
+      expect(find.text('1234'), findsNothing);
+    });
+
+    testWidgets('falls back to decimal when no emoji are available',
+        (tester) async {
+      final verification = FakeKeyVerification(
+        state: KeyVerificationState.askSas,
+      );
+      verification.setSasNumbers([42, 4242, 8191]);
+
+      await openDialog(tester, verification: verification);
+
+      expect(find.text('Compare numbers'), findsOneWidget);
+      expect(find.text('4242'), findsOneWidget);
     });
 
     testWidgets('cancel calls verification.cancel() and pops', (tester) async {


### PR DESCRIPTION
## Summary

Device verification now renders the numeric (decimal) Short Authentication String, not only emoji. Previously, when a verification negotiated the `decimal` SAS method, `_buildSasEmoji` was still used and the comparison screen could be blank. This closes that latent bug and gives users a working numeric alternative. Emoji stays the preferred method when both sides support it.

Closes #587

## Changes

- `lib/features/e2ee/widgets/key_verification_content.dart`
  - Added a `_showSasNumbers` decision based on the negotiated `sasTypes`: emoji is shown whenever it was negotiated (or the methods are unknown) and emoji are available; otherwise the decimal SAS is rendered. This also covers the "no emoji available" fallback.
  - The `askSas` dialog title is now `Compare numbers` or `Compare emoji` to match the representation shown (was hardcoded `Compare emoji`).
  - Added `_buildSasNumbers` to render `verification.sasNumbers`.
- `test/widgets/key_verification_dialog_test.dart`
  - Extended the `FakeKeyVerification` with `sasNumbers` / `sasTypes`.
  - Added tests: decimal render path, emoji-preferred-when-both, and decimal fallback when no emoji are available. Also assert the emoji title is unchanged.

## Implementation note

The `matrix` SDK's `sasEmojis` getter always computes 7 emoji for any SAS verification, so it is **not** empty when decimal is negotiated — the reliable signal is `sasTypes` (the negotiated `authenticationTypes`). The decision keys on that, with an empty-`sasEmojis` fallback to satisfy the "blank screen" case literally.

The issue's open question (silent fallback vs. a user-facing emoji/numbers toggle) is implemented as a **silent fallback** per the acceptance criteria; a toggle can be a follow-up if desired.

## Testing

- [x] `flutter analyze` clean on the changed files
- [x] `flutter test test/widgets/key_verification_dialog_test.dart` — 12/12 pass (3 new decimal-path tests)

## Checklist

- [x] Conventional Commits subject; issue ref in footer
- [x] No stray comments added to lib code
- [x] Tests added covering the change
- [x] Targets `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
