### PR TITLE
fix: decode OpenMoji at painted size so small emoji aren't blurry

### DIFF
--- a/lib/shared/widgets/openmoji_image.dart
+++ b/lib/shared/widgets/openmoji_image.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:kohera/core/utils/emoji_style.dart';
 import 'package:kohera/core/utils/openmoji.dart';
 
+/// Edge length in pixels of the bundled OpenMoji source assets.
+const _openMojiSourcePx = 72;
+
 /// Renders a single emoji [grapheme] as its bundled OpenMoji image, falling
 /// back to system-font text when no asset is bundled or the asset fails to
 /// load. This is the single shared OpenMoji render+fallback path used by both
@@ -30,14 +33,23 @@ class OpenMojiImage extends StatelessWidget {
     if (asset == null) return _fallback();
 
     final s = size;
-    // Decode at native resolution (no cacheWidth): the 72px source upscales and
-    // pixelates if decoded smaller than its painted size. Downsampling from
-    // native uses the default medium filter quality and stays crisp.
+    // Resize at decode time so small targets (reaction chips, inline emoji) are
+    // downsampled with the decoder's high-quality resampling instead of being
+    // shrunk ~4x from the 72px source at draw time, which looks blurry. Cap the
+    // decode at the native source size so larger paints still upscale from the
+    // full 72px (avoids the blocky decode that motivated dropping cacheWidth).
+    final cacheSize = s == null
+        ? null
+        : (s * (MediaQuery.maybeDevicePixelRatioOf(context) ?? 1.0))
+            .round()
+            .clamp(1, _openMojiSourcePx);
     final image = Image.asset(
       asset,
       width: s,
       height: s,
       fit: BoxFit.contain,
+      cacheWidth: cacheSize,
+      cacheHeight: cacheSize,
       errorBuilder: (context, error, stackTrace) => _fallback(),
     );
     if (s == null) return image;

--- a/test/widgets/shared/openmoji_image_test.dart
+++ b/test/widgets/shared/openmoji_image_test.dart
@@ -63,6 +63,38 @@ void main() {
     expect(tester.getSize(find.byType(OpenMojiImage)), const Size(16, 16));
   });
 
+  testWidgets('resizes at decode time to the painted physical size',
+      (tester) async {
+    tester.view.devicePixelRatio = 2.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      _wrap(const OpenMojiImage(grapheme: '\u{1F44D}', size: 16)),
+    );
+
+    final image = tester.widget<Image>(find.byType(Image));
+    final provider = image.image as ResizeImage;
+    // 16 logical px * 2.0 dpr = 32 physical px, well below the 72px source.
+    expect(provider.width, 32);
+    expect(provider.height, 32);
+  });
+
+  testWidgets('caps the decode at the 72px native source size',
+      (tester) async {
+    tester.view.devicePixelRatio = 2.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      _wrap(const OpenMojiImage(grapheme: '\u{1F44D}', size: 64)),
+    );
+
+    final image = tester.widget<Image>(find.byType(Image));
+    final provider = image.image as ResizeImage;
+    // 64 * 2.0 = 128 px would exceed the source; clamps to 72.
+    expect(provider.width, 72);
+    expect(provider.height, 72);
+  });
+
   testWidgets('falls back to text when no asset is bundled', (tester) async {
     await tester.pumpWidget(
       _wrap(const OpenMojiImage(grapheme: 'x', size: 24)),


### PR DESCRIPTION
## Summary

- OpenMoji emoji rendered blurry at small sizes (reaction chips, inline emoji) — a quality regression from `ec031067` (#580), which dropped `cacheWidth` and let the GPU downsample the 72px source at draw time. At ~17px that is a ~4x minification with low-quality filtering; worst at DPR 1.0.
- Fix: resize at **decode time** via `cacheWidth/cacheHeight = round(size * devicePixelRatio)`, so the decoder's high-quality resampling produces the small bitmap.
- The decode is **capped at the 72px source** (`min(72, ...)`), so larger paints (enlarged emoji-only messages) still upscale from the full source — preserving the `#580` fix rather than reverting it.
- No change when `size == null` (picker grid fills its parent → native decode).

## Test plan

- [x] `flutter analyze` clean
- [x] New regression tests in `test/widgets/shared/openmoji_image_test.dart`:
  - resizes at decode time to the painted physical size (`size 16 @ dpr 2 → ResizeImage 32px`)
  - caps the decode at the 72px native source (`size 64 @ dpr 2 → 72px`, not 128)
  - both fail on the unfixed code (no `cacheWidth` → `image.image` is `AssetImage`, not `ResizeImage`)
- [x] Existing OpenMoji, reaction-chip, picker, and emoji-span suites pass

Closes #608
