### PR TITLE
fix(#627): make inbox mention detection push-rule-driven and Unicode-aware

### DIFF
--- a/lib/core/utils/notification_filter.dart
+++ b/lib/core/utils/notification_filter.dart
@@ -1,25 +1,6 @@
 import 'package:kohera/core/services/preferences_service.dart';
+import 'package:kohera/core/utils/word_boundary.dart';
 import 'package:matrix/matrix.dart';
-
-/// Whether [text] contains [word] as a whole word (bounded by non-letter
-/// characters or string edges). Avoids per-call RegExp compilation.
-bool _containsWord(String text, String word) {
-  var start = 0;
-  while (true) {
-    final index = text.indexOf(word, start);
-    if (index == -1) return false;
-    final before = index > 0 ? text.codeUnitAt(index - 1) : 0;
-    final afterIdx = index + word.length;
-    final after = afterIdx < text.length ? text.codeUnitAt(afterIdx) : 0;
-    final boundedLeft = !_isLetter(before);
-    final boundedRight = !_isLetter(after);
-    if (boundedLeft && boundedRight) return true;
-    start = index + 1;
-  }
-}
-
-bool _isLetter(int c) =>
-    (c >= 0x41 && c <= 0x5A) || (c >= 0x61 && c <= 0x7A);
 
 // ── Notification-level-aware unread count ───────────────────
 
@@ -79,7 +60,7 @@ bool shouldNotifyForEvent({
               : null);
       if (displayName != null &&
           displayName.length >= 2 &&
-          _containsWord(lower, displayName)) {
+          containsWord(lower, displayName)) {
         return true;
       }
       for (final kw in prefs.notificationKeywords) {

--- a/lib/core/utils/word_boundary.dart
+++ b/lib/core/utils/word_boundary.dart
@@ -1,0 +1,45 @@
+final RegExp _wordCharacter = RegExp(r'[\p{L}\p{M}\p{N}_]', unicode: true);
+
+/// Whether [text] contains [word] bounded by non-word characters or string
+/// edges. Word characters are Unicode letters, marks, digits and underscore,
+/// so boundaries behave correctly for Cyrillic, CJK, Greek and accented names.
+bool containsWord(String text, String word) {
+  if (word.isEmpty) return false;
+  var start = 0;
+  while (true) {
+    final index = text.indexOf(word, start);
+    if (index == -1) return false;
+    if (!_isWordCharacter(_characterBefore(text, index)) &&
+        !_isWordCharacter(_characterAfter(text, index + word.length))) {
+      return true;
+    }
+    start = index + 1;
+  }
+}
+
+bool _isWordCharacter(String character) =>
+    character.isNotEmpty && _wordCharacter.hasMatch(character);
+
+String _characterBefore(String text, int index) {
+  if (index <= 0) return '';
+  final start = _isLowSurrogate(text.codeUnitAt(index - 1)) &&
+          index >= 2 &&
+          _isHighSurrogate(text.codeUnitAt(index - 2))
+      ? index - 2
+      : index - 1;
+  return text.substring(start, index);
+}
+
+String _characterAfter(String text, int index) {
+  if (index >= text.length) return '';
+  final end = _isHighSurrogate(text.codeUnitAt(index)) &&
+          index + 1 < text.length &&
+          _isLowSurrogate(text.codeUnitAt(index + 1))
+      ? index + 2
+      : index + 1;
+  return text.substring(index, end);
+}
+
+bool _isHighSurrogate(int unit) => (unit & 0xFC00) == 0xD800;
+
+bool _isLowSurrogate(int unit) => (unit & 0xFC00) == 0xDC00;

--- a/lib/features/notifications/services/inbox_controller.dart
+++ b/lib/features/notifications/services/inbox_controller.dart
@@ -1,30 +1,23 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:kohera/core/utils/word_boundary.dart';
 import 'package:kohera/features/notifications/services/apns_push_service.dart';
 import 'package:matrix/matrix.dart' as matrix_sdk;
 import 'package:matrix/matrix.dart'
     show Client, Event, EventTypes, MatrixException, Membership;
 
-// ── Word-boundary helper ─────────────────────────────────────
+// ── Push-action helper ───────────────────────────────────────
 
-bool _containsWord(String text, String word) {
-  var start = 0;
-  while (true) {
-    final index = text.indexOf(word, start);
-    if (index == -1) return false;
-    final before = index > 0 ? text.codeUnitAt(index - 1) : 0;
-    final afterIdx = index + word.length;
-    final after = afterIdx < text.length ? text.codeUnitAt(afterIdx) : 0;
-    final boundedLeft = !_isLetter(before);
-    final boundedRight = !_isLetter(after);
-    if (boundedLeft && boundedRight) return true;
-    start = index + 1;
+bool _hasHighlightAction(List<Object?> actions) {
+  for (final action in actions) {
+    if (action is Map && action['set_tweak'] == 'highlight') {
+      final value = action['value'];
+      if (value == null || value == true) return true;
+    }
   }
+  return false;
 }
-
-bool _isLetter(int c) =>
-    (c >= 0x41 && c <= 0x5A) || (c >= 0x61 && c <= 0x7A);
 
 // ── Filter enum ──────────────────────────────────────────────
 enum InboxFilter { all, mentions, threads, invitations }
@@ -362,6 +355,8 @@ class InboxController extends ChangeNotifier {
     final userId = _client.userID;
     if (userId == null) return false;
 
+    if (_hasHighlightAction(n.actions)) return true;
+
     final content =
         _decryptedContent[n.event.eventId] ?? n.event.content;
 
@@ -369,24 +364,24 @@ class InboxController extends ChangeNotifier {
     if (mentions is Map) {
       final userIds = mentions['user_ids'];
       if (userIds is List && userIds.contains(userId)) return true;
+      return mentions['room'] == true;
     }
+
+    if (n.event.type != EventTypes.Encrypted) return false;
 
     final body = content['body'];
-    if (body is String) {
-      final lower = body.toLowerCase();
-      if (lower.contains(userId.toLowerCase())) return true;
-      final displayName = _client
-          .getRoomById(n.roomId)
-          ?.unsafeGetUserFromMemoryOrFallback(userId)
-          .calcDisplayname();
-      if (displayName != null &&
-          displayName.length >= 2 &&
-          _containsWord(lower, displayName.toLowerCase())) {
-        return true;
-      }
-    }
+    if (body is! String) return false;
 
-    return false;
+    final lower = body.toLowerCase();
+    if (lower.contains(userId.toLowerCase())) return true;
+
+    final displayName = _client
+        .getRoomById(n.roomId)
+        ?.unsafeGetUserFromMemoryOrFallback(userId)
+        .calcDisplayname();
+    return displayName != null &&
+        displayName.length >= 2 &&
+        containsWord(lower, displayName.toLowerCase());
   }
 
   // ── Helpers ────────────────────────────────────────────────

--- a/test/services/inbox_controller_test.dart
+++ b/test/services/inbox_controller_test.dart
@@ -23,11 +23,13 @@ Notification _makeNotification({
   bool read = false,
   int ts = 1000,
   Map<String, Object?>? content,
+  String type = 'm.room.message',
+  List<Object?> actions = const [],
 }) {
   return Notification(
-    actions: [],
+    actions: actions,
     event: MatrixEvent(
-      type: 'm.room.message',
+      type: type,
       content: content ?? {'body': 'hello', 'msgtype': 'm.text'},
       senderId: '@alice:example.com',
       eventId: eventId,
@@ -887,7 +889,7 @@ void main() {
       expect(controller.grouped[0].roomId, '!r1:x');
     });
 
-    test('mentions filter includes notification with user ID in body', () async {
+    test('mentions filter includes notification with highlight action', () async {
       when(mockClient.getNotifications(
         limit: anyNamed('limit'),
         only: anyNamed('only'),
@@ -895,6 +897,31 @@ void main() {
             _makeNotification(
               eventId: 'e1',
               roomId: '!r1:x',
+              actions: [
+                'notify',
+                {'set_tweak': 'highlight'},
+              ],
+            ),
+            _makeNotification(eventId: 'e2', roomId: '!r2:x'),
+          ]),);
+
+      controller.setFilter(InboxFilter.mentions);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(controller.grouped, hasLength(1));
+      expect(controller.grouped[0].roomId, '!r1:x');
+    });
+
+    test('mentions filter includes encrypted notification with user ID in body', () async {
+      when(mockClient.getNotifications(
+        limit: anyNamed('limit'),
+        only: anyNamed('only'),
+      ),).thenAnswer((_) async => _makeResponse([
+            _makeNotification(
+              eventId: 'e1',
+              roomId: '!r1:x',
+              type: 'm.room.encrypted',
               content: {
                 'body': 'hey @me:example.com check this',
                 'msgtype': 'm.text',
@@ -911,7 +938,7 @@ void main() {
       expect(controller.grouped[0].roomId, '!r1:x');
     });
 
-    test('mentions filter includes notification with display name in body', () async {
+    test('mentions filter includes encrypted notification with display name in body', () async {
       final displayUser = MockUser();
       when(displayUser.calcDisplayname()).thenReturn('MyName');
       when(defaultRoom.unsafeGetUserFromMemoryOrFallback('@me:example.com'))
@@ -924,6 +951,7 @@ void main() {
             _makeNotification(
               eventId: 'e1',
               roomId: '!r1:x',
+              type: 'm.room.encrypted',
               content: {
                 'body': 'hey MyName check this out',
                 'msgtype': 'm.text',
@@ -938,6 +966,33 @@ void main() {
 
       expect(controller.grouped, hasLength(1));
       expect(controller.grouped[0].roomId, '!r1:x');
+    });
+
+    test('mentions filter excludes plaintext body matches without highlight action', () async {
+      final displayUser = MockUser();
+      when(displayUser.calcDisplayname()).thenReturn('Will');
+      when(defaultRoom.unsafeGetUserFromMemoryOrFallback('@me:example.com'))
+          .thenReturn(displayUser);
+
+      when(mockClient.getNotifications(
+        limit: anyNamed('limit'),
+        only: anyNamed('only'),
+      ),).thenAnswer((_) async => _makeResponse([
+            _makeNotification(
+              eventId: 'e1',
+              roomId: '!r1:x',
+              content: {
+                'body': 'Will you join the call?',
+                'msgtype': 'm.text',
+              },
+            ),
+          ]),);
+
+      controller.setFilter(InboxFilter.mentions);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(controller.grouped, isEmpty);
     });
 
     test('mentions filter excludes notifications without mentions', () async {
@@ -968,6 +1023,169 @@ void main() {
       await controller.fetch();
 
       expect(controller.grouped, hasLength(2));
+    });
+  });
+
+  // ── isMention ─────────────────────────────────────────────
+
+  group('isMention', () {
+    setUp(() {
+      when(mockClient.userID).thenReturn('@me:example.com');
+    });
+
+    void stubDisplayName(String name) {
+      final user = MockUser();
+      when(user.calcDisplayname()).thenReturn(name);
+      when(defaultRoom.unsafeGetUserFromMemoryOrFallback('@me:example.com'))
+          .thenReturn(user);
+    }
+
+    test('true for highlight action without value', () {
+      stubDisplayName('Me');
+      final n = _makeNotification(
+        eventId: 'e1',
+        roomId: '!r1:x',
+        actions: [
+          'notify',
+          {'set_tweak': 'highlight'},
+        ],
+      );
+      expect(controller.isMention(n), isTrue);
+    });
+
+    test('true for highlight action with value true', () {
+      stubDisplayName('Me');
+      final n = _makeNotification(
+        eventId: 'e1',
+        roomId: '!r1:x',
+        actions: [
+          'notify',
+          {'set_tweak': 'highlight', 'value': true},
+        ],
+      );
+      expect(controller.isMention(n), isTrue);
+    });
+
+    test('false for highlight action with value false', () {
+      stubDisplayName('Me');
+      final n = _makeNotification(
+        eventId: 'e1',
+        roomId: '!r1:x',
+        actions: [
+          'notify',
+          {'set_tweak': 'highlight', 'value': false},
+        ],
+      );
+      expect(controller.isMention(n), isFalse);
+    });
+
+    test('true when m.mentions lists the user', () {
+      stubDisplayName('Me');
+      final n = _makeNotification(
+        eventId: 'e1',
+        roomId: '!r1:x',
+        content: {
+          'body': 'hello everyone',
+          'msgtype': 'm.text',
+          'm.mentions': {
+            'user_ids': ['@me:example.com'],
+          },
+        },
+      );
+      expect(controller.isMention(n), isTrue);
+    });
+
+    test('true when m.mentions flags a room mention', () {
+      stubDisplayName('Me');
+      final n = _makeNotification(
+        eventId: 'e1',
+        roomId: '!r1:x',
+        type: 'm.room.encrypted',
+        content: {
+          'body': 'attention everyone',
+          'msgtype': 'm.text',
+          'm.mentions': {'room': true},
+        },
+      );
+      expect(controller.isMention(n), isTrue);
+    });
+
+    test('false when m.mentions is present without the user, even if the body matches', () {
+      stubDisplayName('Me');
+      final n = _makeNotification(
+        eventId: 'e1',
+        roomId: '!r1:x',
+        type: 'm.room.encrypted',
+        content: {
+          'body': 'hey Me, did @other ping you?',
+          'msgtype': 'm.text',
+          'm.mentions': {
+            'user_ids': ['@other:example.com'],
+          },
+        },
+      );
+      expect(controller.isMention(n), isFalse);
+    });
+
+    test('false for plaintext body match without highlight action', () {
+      stubDisplayName('Will');
+      final n = _makeNotification(
+        eventId: 'e1',
+        roomId: '!r1:x',
+        content: {'body': 'Will you join?', 'msgtype': 'm.text'},
+      );
+      expect(controller.isMention(n), isFalse);
+    });
+
+    test('encrypted fallback matches a word-bounded display name', () {
+      stubDisplayName('Will');
+      final n = _makeNotification(
+        eventId: 'e1',
+        roomId: '!r1:x',
+        type: 'm.room.encrypted',
+        content: {'body': 'Will, are you there?', 'msgtype': 'm.text'},
+      );
+      expect(controller.isMention(n), isTrue);
+    });
+
+    test('encrypted fallback ignores the display name inside a larger word', () {
+      stubDisplayName('Will');
+      final n = _makeNotification(
+        eventId: 'e1',
+        roomId: '!r1:x',
+        type: 'm.room.encrypted',
+        content: {'body': 'willpower beats talent', 'msgtype': 'm.text'},
+      );
+      expect(controller.isMention(n), isFalse);
+    });
+
+    test('encrypted fallback treats digits as word characters', () {
+      stubDisplayName('Max');
+      final n = _makeNotification(
+        eventId: 'e1',
+        roomId: '!r1:x',
+        type: 'm.room.encrypted',
+        content: {'body': 'Max99 said hi', 'msgtype': 'm.text'},
+      );
+      expect(controller.isMention(n), isFalse);
+    });
+
+    test('encrypted fallback is Unicode-aware for Cyrillic display names', () {
+      stubDisplayName('Вера');
+      final bounded = _makeNotification(
+        eventId: 'e1',
+        roomId: '!r1:x',
+        type: 'm.room.encrypted',
+        content: {'body': 'Вера, привет', 'msgtype': 'm.text'},
+      );
+      final embedded = _makeNotification(
+        eventId: 'e2',
+        roomId: '!r1:x',
+        type: 'm.room.encrypted',
+        content: {'body': 'проверая текст', 'msgtype': 'm.text'},
+      );
+      expect(controller.isMention(bounded), isTrue);
+      expect(controller.isMention(embedded), isFalse);
     });
   });
 

--- a/test/services/inbox_controller_test.dart
+++ b/test/services/inbox_controller_test.dart
@@ -125,10 +125,10 @@ void main() {
         _makeNotification(
           eventId: 'new1',
           roomId: '!new:x',
-          content: {
-            'body': 'hey @me:example.com',
-            'msgtype': 'm.text',
-          },
+          actions: [
+            'notify',
+            {'set_tweak': 'highlight'},
+          ],
         ),
       ]),);
 
@@ -202,10 +202,10 @@ void main() {
             _makeNotification(
               eventId: 'e2',
               roomId: '!r2:x',
-              content: {
-                'body': 'hey @me:example.com',
-                'msgtype': 'm.text',
-              },
+              actions: [
+                'notify',
+                {'set_tweak': 'highlight'},
+              ],
             ),
           ]),);
 
@@ -286,10 +286,10 @@ void main() {
             _makeNotification(
               eventId: 'new1',
               roomId: '!new:x',
-              content: {
-                'body': 'hey @me:example.com',
-                'msgtype': 'm.text',
-              },
+              actions: [
+                'notify',
+                {'set_tweak': 'highlight'},
+              ],
             ),
           ]),);
       controller.setFilter(InboxFilter.mentions);

--- a/test/utils/word_boundary_test.dart
+++ b/test/utils/word_boundary_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/utils/word_boundary.dart';
+
+void main() {
+  group('containsWord', () {
+    test('matches a word bounded by spaces', () {
+      expect(containsWord('hey max, hello', 'max'), isTrue);
+    });
+
+    test('matches a word at string edges', () {
+      expect(containsWord('max', 'max'), isTrue);
+      expect(containsWord('max!', 'max'), isTrue);
+      expect(containsWord('@max', 'max'), isTrue);
+    });
+
+    test('does not match inside a larger Latin word', () {
+      expect(containsWord('maximum effort', 'max'), isFalse);
+      expect(containsWord('climax', 'max'), isFalse);
+      expect(containsWord('willpower wins', 'will'), isFalse);
+    });
+
+    test('treats digits and underscores as word characters', () {
+      expect(containsWord('max99 said hi', 'max'), isFalse);
+      expect(containsWord('99max said hi', 'max'), isFalse);
+      expect(containsWord('max_99 said hi', 'max'), isFalse);
+    });
+
+    test('matches Cyrillic names bounded by punctuation or spaces', () {
+      expect(containsWord('вера, привет', 'вера'), isTrue);
+      expect(containsWord('привет вера', 'вера'), isTrue);
+    });
+
+    test('does not match inside a larger Cyrillic word', () {
+      expect(containsWord('проверая текст', 'вера'), isFalse);
+      expect(containsWord('вераника', 'вера'), isFalse);
+    });
+
+    test('treats adjacent CJK letters as word characters', () {
+      expect(containsWord('小明你好', '小明'), isFalse);
+      expect(containsWord('小明, 你好', '小明'), isTrue);
+    });
+
+    test('treats Greek and accented letters as word characters', () {
+      expect(containsWord('γειά νίκος', 'νίκος'), isTrue);
+      expect(containsWord('νίκοςα', 'νίκος'), isFalse);
+      expect(containsWord('hey josé!', 'josé'), isTrue);
+      expect(containsWord('joséphine', 'josé'), isFalse);
+    });
+
+    test('treats surrogate-pair letters as word characters', () {
+      expect(containsWord('𝕒max', 'max'), isFalse);
+      expect(containsWord('max𝕒', 'max'), isFalse);
+    });
+
+    test('treats emoji as boundaries', () {
+      expect(containsWord('😀max😀', 'max'), isTrue);
+    });
+
+    test('returns false for an empty word', () {
+      expect(containsWord('anything', ''), isFalse);
+    });
+
+    test('finds a bounded occurrence after an unbounded one', () {
+      expect(containsWord('climax max', 'max'), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`InboxController.isMention` badged messages as mentions from naive body scanning with an ASCII-only word-boundary check, so common-word ("Will", "Max") and non-Latin display names produced false positives in the Mentions filter and the `@you` badge. Mention detection now trusts the server's push-rule evaluation first and only falls back to Unicode-aware body scanning for encrypted events.

## Changes

- `lib/features/notifications/services/inbox_controller.dart` — `isMention` treats the `highlight` tweak in `Notification.actions` as authoritative, then `m.mentions` (`user_ids` and `room: true`, with an `m.mentions` map lacking the user acting as an explicit opt-out per MSC3952), and restricts body scanning to `m.room.encrypted` events the server could not inspect
- `lib/core/utils/word_boundary.dart` (new) — shared `containsWord` helper: word characters are Unicode letters, marks, digits, and underscore (`\p{L}\p{M}\p{N}_`), surrogate-pair safe
- `lib/core/utils/notification_filter.dart` — drops its duplicated ASCII-only helper in favor of the shared one, fixing the same boundary bug in `shouldNotifyForEvent`
- `test/services/inbox_controller_test.dart` — new `isMention` test group (highlight actions, `m.mentions` variants, encrypted fallback with Latin/Cyrillic/digit boundaries); mention-filter and fetch/filter-mechanics fixtures updated to mark mentions via the highlight action instead of body text
- `test/utils/word_boundary_test.dart` (new) — boundary coverage for Latin, Cyrillic, CJK, Greek, accented names, digits/underscore, surrogate pairs, and emoji

## Testing

- [x] `flutter analyze` is clean (CI `analyze` job on `fdb859b`)
- [x] `flutter test` passes — 2071 tests (CI `test` job on `fdb859b`)

## Linked issues

Closes #627
Refs #624

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix (no new logging added)
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master` (not another feature branch, unless an explicitly requested stacked PR)

https://claude.ai/code/session_017Eki29hEib4c6YgmQqU7Cp