### PR TITLE
feat(#621): persist E2EE skip state and make backup banner dismissable

### DIFF
--- a/docs/e2ee-flow.md
+++ b/docs/e2ee-flow.md
@@ -458,7 +458,9 @@ FlutterSecureStorage (localStorage on web, Keychain/Keystore on native)
 ├── kohera_{clientName}_homeserver     ← session credential
 ├── kohera_{clientName}_device_id      ← session credential
 ├── kohera_session_backup_{clientName} ← JSON: tokens + olmAccount pickle
-└── ssss_recovery_key_{userId}          ← recovery key (if "Save to device" checked)
+├── ssss_recovery_key_{userId}          ← recovery key (if "Save to device" checked)
+├── e2ee_setup_skipped_{userId}         ← skip/done flag; stops router re-forcing on restart
+└── e2ee_banner_dismissed_{userId}      ← KeyBackupBanner dismissed (persists until backup disabled/logout)
 
 In-Memory (UiaService)
 └── _cachedPassword             ← login password (30s TTL)

--- a/lib/core/services/matrix_service.dart
+++ b/lib/core/services/matrix_service.dart
@@ -125,11 +125,9 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
   bool _foregroundSyncStarted = false;
   bool _lifecycleObserverRegistered = false;
 
-  bool _hasSkippedSetup = false;
-  bool get hasSkippedSetup => _hasSkippedSetup;
+  bool get hasSkippedSetup => chatBackup.setupSkipped;
   void skipSetup() {
-    _hasSkippedSetup = true;
-    notifyListeners();
+    unawaited(chatBackup.markSetupSkipped());
   }
 
   @override
@@ -250,6 +248,7 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
   Future<void> logout() async {
     await auth.logout();
     await chatBackup.deleteStoredRecoveryKey();
+    await chatBackup.deleteDismissalState();
   }
 
   // ── Soft Logout ──────────────────────────────────────────────
@@ -267,6 +266,7 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
       if (auth.isPermanentAuthFailure(cause)) {
         await auth.logout();
         await chatBackup.deleteStoredRecoveryKey();
+        await chatBackup.deleteDismissalState();
       } else {
         debugPrint('[Kohera] Transient refresh failure, keeping session '
             'for next sync/refresh retry');
@@ -280,6 +280,7 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
     if (auth.isLoggedIn) {
       uia.listenForUia();
       _listenForLoginState();
+      unawaited(chatBackup.loadDismissalState());
       unawaited(callPushRuleManager.ensureRule());
       unawaited(
         keyMirror.start().catchError((Object e) {
@@ -300,7 +301,6 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
       uia.cancelUiaSub();
       selection.resetSelection();
       chatBackup.resetChatBackupState();
-      _hasSkippedSetup = false;
       _foregroundSyncStarted = false;
       if (_lifecycleObserverRegistered) {
         WidgetsBinding.instance.removeObserver(this);
@@ -319,6 +319,7 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
         debugPrint('[Kohera] Server-side logout detected');
         await auth.handleServerLogout();
         await chatBackup.deleteStoredRecoveryKey();
+        await chatBackup.deleteDismissalState();
       }
     });
   }

--- a/lib/core/services/sub_services/chat_backup_service.dart
+++ b/lib/core/services/sub_services/chat_backup_service.dart
@@ -32,6 +32,50 @@ class ChatBackupService extends ChangeNotifier {
   String? _chatBackupError;
   String? get chatBackupError => _chatBackupError;
 
+  // ── Setup Dismissal State ─────────────────────────────────────
+  bool _setupSkipped = false;
+  bool get setupSkipped => _setupSkipped;
+
+  bool _bannerDismissed = false;
+  bool get bannerDismissed => _bannerDismissed;
+
+  Future<void> loadDismissalState() async {
+    final userId = _client.userID;
+    if (userId == null) return;
+    final results = await Future.wait([
+      _storage.read(key: 'e2ee_setup_skipped_$userId'),
+      _storage.read(key: 'e2ee_banner_dismissed_$userId'),
+    ]);
+    _setupSkipped = results[0] == 'true';
+    _bannerDismissed = results[1] == 'true';
+    notifyListeners();
+  }
+
+  Future<void> markSetupSkipped() async {
+    _setupSkipped = true;
+    notifyListeners();
+    final userId = _client.userID;
+    if (userId == null) return;
+    await _storage.write(key: 'e2ee_setup_skipped_$userId', value: 'true');
+  }
+
+  Future<void> dismissBanner() async {
+    _bannerDismissed = true;
+    notifyListeners();
+    final userId = _client.userID;
+    if (userId == null) return;
+    await _storage.write(key: 'e2ee_banner_dismissed_$userId', value: 'true');
+  }
+
+  Future<void> deleteDismissalState() async {
+    final userId = _client.userID;
+    if (userId == null) return;
+    await Future.wait([
+      _storage.delete(key: 'e2ee_setup_skipped_$userId'),
+      _storage.delete(key: 'e2ee_banner_dismissed_$userId'),
+    ]);
+  }
+
   Future<void> checkChatBackupStatus() async {
     try {
       final hasBackupVersion = await _backupVersion.hasVersion();
@@ -69,6 +113,7 @@ class ChatBackupService extends ChangeNotifier {
       }
       _backupVersion.invalidateCache();
       await deleteStoredRecoveryKey();
+      _bannerDismissed = false;
       _chatBackupNeeded = true;
     } catch (e) {
       debugPrint('[Kohera] disableChatBackup error: $e');
@@ -81,6 +126,8 @@ class ChatBackupService extends ChangeNotifier {
 
   void resetChatBackupState() {
     _chatBackupNeeded = null;
+    _setupSkipped = false;
+    _bannerDismissed = false;
   }
 
   // ── Key Restoration ──────────────────────────────────────────

--- a/lib/features/e2ee/widgets/key_backup_banner.dart
+++ b/lib/features/e2ee/widgets/key_backup_banner.dart
@@ -11,12 +11,15 @@ class KeyBackupBanner extends StatelessWidget {
     final needed = context.select<ChatBackupService, bool?>(
       (s) => s.chatBackupNeeded,
     );
+    final dismissed = context.select<ChatBackupService, bool>(
+      (s) => s.bannerDismissed,
+    );
 
     return AnimatedSize(
       duration: const Duration(milliseconds: 200),
       curve: Curves.easeInOut,
       alignment: Alignment.topCenter,
-      child: needed == true
+      child: needed == true && !dismissed
           ? const _KeyBackupBannerContent()
           : const SizedBox.shrink(),
     );
@@ -87,6 +90,14 @@ class _KeyBackupBannerContent extends StatelessWidget {
                   foregroundColor: cs.onTertiaryContainer,
                 ),
                 child: const Text('Set up'),
+              ),
+              IconButton(
+                onPressed: () =>
+                    context.read<ChatBackupService>().dismissBanner(),
+                icon: const Icon(Icons.close, size: 18),
+                color: cs.onTertiaryContainer,
+                tooltip: 'Dismiss',
+                visualDensity: VisualDensity.compact,
               ),
             ],
           ),

--- a/test/services/chat_backup_service_test.dart
+++ b/test/services/chat_backup_service_test.dart
@@ -282,7 +282,88 @@ void main() {
     });
   });
 
+  group('setup dismissal state', () {
+    const userId = '@user:example.com';
+
+    test('loadDismissalState reads both flags from storage', () async {
+      when(mockClient.userID).thenReturn(userId);
+      when(mockStorage.read(key: 'e2ee_setup_skipped_$userId'))
+          .thenAnswer((_) async => 'true');
+      when(mockStorage.read(key: 'e2ee_banner_dismissed_$userId'))
+          .thenAnswer((_) async => null);
+
+      await service.loadDismissalState();
+
+      expect(service.setupSkipped, isTrue);
+      expect(service.bannerDismissed, isFalse);
+    });
+
+    test('markSetupSkipped sets flag immediately and persists', () async {
+      when(mockClient.userID).thenReturn(userId);
+
+      await service.markSetupSkipped();
+
+      expect(service.setupSkipped, isTrue);
+      verify(
+        mockStorage.write(
+          key: 'e2ee_setup_skipped_$userId',
+          value: 'true',
+        ),
+      ).called(1);
+    });
+
+    test('dismissBanner sets flag immediately and persists', () async {
+      when(mockClient.userID).thenReturn(userId);
+
+      await service.dismissBanner();
+
+      expect(service.bannerDismissed, isTrue);
+      verify(
+        mockStorage.write(
+          key: 'e2ee_banner_dismissed_$userId',
+          value: 'true',
+        ),
+      ).called(1);
+    });
+
+    test('deleteDismissalState removes both keys', () async {
+      when(mockClient.userID).thenReturn(userId);
+
+      await service.deleteDismissalState();
+
+      verify(mockStorage.delete(key: 'e2ee_setup_skipped_$userId')).called(1);
+      verify(mockStorage.delete(key: 'e2ee_banner_dismissed_$userId'))
+          .called(1);
+    });
+
+    test('disableChatBackup re-shows a previously dismissed banner', () async {
+      when(mockClient.userID).thenReturn(userId);
+      await service.dismissBanner();
+      expect(service.bannerDismissed, isTrue);
+
+      when(mockKeyManager.getRoomKeysBackupInfo())
+          .thenAnswer((_) async => fakeBackupInfo());
+      when(mockClient.deleteRoomKeysVersion(any)).thenAnswer((_) async {});
+
+      await service.disableChatBackup();
+
+      expect(service.bannerDismissed, isFalse);
+    });
+  });
+
   group('resetChatBackupState', () {
+    test('resets dismissal flags along with chatBackupNeeded', () async {
+      when(mockClient.userID).thenReturn('@user:example.com');
+      await service.markSetupSkipped();
+      await service.dismissBanner();
+
+      service.resetChatBackupState();
+
+      expect(service.setupSkipped, isFalse);
+      expect(service.bannerDismissed, isFalse);
+      expect(service.chatBackupNeeded, isNull);
+    });
+
     test('resets chatBackupNeeded to null', () async {
       when(mockCrossSigning.enabled).thenReturn(true);
       when(mockKeyManager.enabled).thenReturn(true);

--- a/test/widgets/key_backup_banner_test.dart
+++ b/test/widgets/key_backup_banner_test.dart
@@ -89,6 +89,37 @@ void main() {
       expect(find.text('Protect your messages'), findsNothing);
     });
 
+    testWidgets('hidden when needed but already dismissed', (tester) async {
+      when(mockChatBackup.chatBackupNeeded).thenReturn(true);
+      when(mockChatBackup.bannerDismissed).thenReturn(true);
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Protect your messages'), findsNothing);
+    });
+
+    testWidgets('dismiss button hides the banner', (tester) async {
+      final fake = _FakeChatBackupService(chatBackupNeeded: true);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(splashFactory: InkRipple.splashFactory),
+          home: ChangeNotifierProvider<ChatBackupService>.value(
+            value: fake,
+            child: const Scaffold(body: KeyBackupBanner()),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Protect your messages'), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Protect your messages'), findsNothing);
+      expect(fake.bannerDismissed, isTrue);
+    });
+
     testWidgets('appears when backup status changes to needed',
         (tester) async {
       final fake = _FakeChatBackupService(chatBackupNeeded: false);
@@ -116,14 +147,27 @@ void main() {
 class _FakeChatBackupService extends ChangeNotifier
     implements ChatBackupService {
   bool? _chatBackupNeeded;
+  bool _bannerDismissed;
 
-  _FakeChatBackupService({required bool? chatBackupNeeded})
-      : _chatBackupNeeded = chatBackupNeeded;
+  _FakeChatBackupService({
+    required bool? chatBackupNeeded,
+    bool bannerDismissed = false,
+  })  : _chatBackupNeeded = chatBackupNeeded,
+        _bannerDismissed = bannerDismissed;
 
   @override
   bool? get chatBackupNeeded => _chatBackupNeeded;
   set chatBackupNeeded(bool? value) {
     _chatBackupNeeded = value;
+    notifyListeners();
+  }
+
+  @override
+  bool get bannerDismissed => _bannerDismissed;
+
+  @override
+  Future<void> dismissBanner() async {
+    _bannerDismissed = true;
     notifyListeners();
   }
 

--- a/test/widgets/key_backup_banner_test.mocks.dart
+++ b/test/widgets/key_backup_banner_test.mocks.dart
@@ -45,11 +45,65 @@ class MockChatBackupService extends _i1.Mock implements _i2.ChatBackupService {
       ) as bool);
 
   @override
+  bool get setupSkipped => (super.noSuchMethod(
+        Invocation.getter(#setupSkipped),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
+  bool get bannerDismissed => (super.noSuchMethod(
+        Invocation.getter(#bannerDismissed),
+        returnValue: false,
+        returnValueForMissingStub: false,
+      ) as bool);
+
+  @override
   bool get hasListeners => (super.noSuchMethod(
         Invocation.getter(#hasListeners),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
+  @override
+  _i3.Future<void> loadDismissalState() => (super.noSuchMethod(
+        Invocation.method(
+          #loadDismissalState,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+
+  @override
+  _i3.Future<void> markSetupSkipped() => (super.noSuchMethod(
+        Invocation.method(
+          #markSetupSkipped,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+
+  @override
+  _i3.Future<void> dismissBanner() => (super.noSuchMethod(
+        Invocation.method(
+          #dismissBanner,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
+
+  @override
+  _i3.Future<void> deleteDismissalState() => (super.noSuchMethod(
+        Invocation.method(
+          #deleteDismissalState,
+          [],
+        ),
+        returnValue: _i3.Future<void>.value(),
+        returnValueForMissingStub: _i3.Future<void>.value(),
+      ) as _i3.Future<void>);
 
   @override
   _i3.Future<void> checkChatBackupStatus() => (super.noSuchMethod(


### PR DESCRIPTION
## Summary

Stops re-forcing users into `/e2ee-setup` on every cold restart. The skip/done decision lived only in memory on `MatrixService`, so it reset on every launch — when post-sync auto-unlock could not silently succeed, the router re-forced the setup screen and showed an undismissable banner, even for users who had already finished or deliberately skipped setup. This was the largest source of felt "forcing" in the E2EE onboarding (see epic #626).

Now the decision persists per-user in secure storage, the hard router redirect stops after the first skip, and the banner is dismissable with persisted dismissal.

## Changes

- **`ChatBackupService`** owns `setupSkipped` and `bannerDismissed`, backed by `e2ee_setup_skipped_{userId}` / `e2ee_banner_dismissed_{userId}` secure-storage keys. `loadDismissalState`/`markSetupSkipped`/`dismissBanner`/`deleteDismissalState` manage them; `resetChatBackupState` clears them in-memory; `disableChatBackup` re-shows a previously dismissed banner.
- **`MatrixService`** delegates `hasSkippedSetup`/`skipSetup` to `chatBackup`, loads dismissal state on session activation, and clears persisted state on every logout path (logout, soft-logout permanent failure, server-side logout).
- **`KeyBackupBanner`** gates on `bannerDismissed` and gains a close button.
- **`docs/e2ee-flow.md`** storage map updated with the two new keys.

## Testing

- `flutter analyze` — no issues.
- Full suite — 2052 tests pass.
- New tests: banner dismiss-button and dismissed-hidden cases; `ChatBackupService` persistence (load/mark/dismiss/delete, re-show on disable, reset clears flags).

Closes #621
Refs #626