### PR TITLE
feat(#620): enable dehydrated devices (MSC3814)

### DIFF
--- a/docs/e2ee-flow.md
+++ b/docs/e2ee-flow.md
@@ -477,6 +477,40 @@ SDK Database (IndexedDB on web, SQLite on native)
 
 ---
 
+## Dehydrated Devices (MSC3814)
+
+The client is built with `enableDehydratedDevices: true`
+(`lib/core/services/client_factory_shared.dart`). A dehydrated device is a
+server-stored, offline olm account that other users keep sending room keys to
+while none of your real devices are online. On a later login it is rehydrated:
+its queued to-device room keys are fetched and imported, then a fresh
+dehydrated device replaces it.
+
+The SDK drives this automatically — `Client.dehydratedDeviceSetup()` is invoked
+from inside the bootstrap state machine, so it runs both during first-time E2EE
+setup (the `BootstrapDriver` flow) and during headless restore
+(`restoreCryptoIdentity`, used by `tryAutoUnlockBackup`). Kohera adds no
+explicit call.
+
+Key facts:
+
+- The dehydrated device's pickle key is stored in SSSS (4S) under the secret
+  name `org.matrix.msc3814` — there is no new user-visible secret.
+- Rehydration requires SSSS to be **open**. It therefore rides on whatever
+  unlocks SSSS: the on-device stored recovery key (silent), a typed recovery
+  key, or device verification. Dehydrated devices do **not** remove the unlock
+  step — they make the post-unlock result more complete by also recovering
+  messages sent while no device was online, which online key backup alone can
+  miss.
+- Graceful degradation is built into the SDK: on a homeserver without MSC3814,
+  `getDehydratedDevice()` returns 400 and `dehydratedDeviceSetup()` logs and
+  returns, so setup/restore complete normally via the recovery-key flow.
+
+**Source:** `lib/core/services/client_factory_shared.dart`;
+SDK `matrix/lib/msc_extensions/msc_3814_dehydrated_devices/`; issue #620.
+
+---
+
 ## Call Signaling Metadata
 
 1:1 voice/video calls in Kohera use MatrixRTC (MSC3401) `m.call.member` state events for signaling. State events are **not** E2EE — they are written in clear at the Matrix state layer so the homeserver and push gateway can route VoIP pushes on event type without decrypting anything.

--- a/docs/e2ee-flow.md
+++ b/docs/e2ee-flow.md
@@ -505,6 +505,20 @@ Key facts:
 - Graceful degradation is built into the SDK: on a homeserver without MSC3814,
   `getDehydratedDevice()` returns 400 and `dehydratedDeviceSetup()` logs and
   returns, so setup/restore complete normally via the recovery-key flow.
+- The dehydrated device is filtered out of Settings → Devices
+  (`DevicesScreen._loadDevices` excludes the id from `getDehydratedDevice()`),
+  so users never see — or accidentally delete — the server-side device.
+
+Known limitation — the verification-only unlock path does not rehydrate.
+`dehydratedDeviceSetup()` requires an **unlocked** `OpenSSSS`
+(`OpenSSSS.getStored` needs the 4S private key), which only the setup,
+typed-recovery-key, and stored-key (`restoreCryptoIdentity`) paths produce. A
+fresh login unlocked purely by verifying another device gossips the cached
+secrets but never unlocks an `OpenSSSS`, so it skips dehydration. Those logins
+still recover history via online key backup and key gossip from the verified
+device; they only miss the narrow set of messages sent while no device was
+online and never backed up. Closing this would require an SDK entry point that
+rehydrates from cached secrets.
 
 **Source:** `lib/core/services/client_factory_shared.dart`;
 SDK `matrix/lib/msc_extensions/msc_3814_dehydrated_devices/`; issue #620.

--- a/lib/core/services/client_factory_shared.dart
+++ b/lib/core/services/client_factory_shared.dart
@@ -26,6 +26,7 @@ Client buildClient(
       KeyVerificationMethod.emoji,
       KeyVerificationMethod.numbers,
     },
+    enableDehydratedDevices: true,
     nativeImplementations: nativeImplementations,
   );
   client.roomPreviewLastEvents.removeAll(callPreviewTypes);

--- a/lib/features/settings/screens/devices_screen.dart
+++ b/lib/features/settings/screens/devices_screen.dart
@@ -9,6 +9,7 @@ import 'package:kohera/features/e2ee/widgets/key_verification_dialog.dart';
 import 'package:kohera/features/settings/widgets/device_list_item.dart';
 import 'package:kohera/shared/widgets/section_header.dart';
 import 'package:matrix/matrix.dart';
+import 'package:matrix/msc_extensions/msc_3814_dehydrated_devices/api.dart';
 import 'package:provider/provider.dart';
 
 class DevicesScreen extends StatefulWidget {
@@ -49,10 +50,16 @@ class _DevicesScreenState extends State<DevicesScreen> {
     });
     try {
       final matrix = context.read<MatrixService>();
-      final devices = await matrix.client.getDevices();
+      final client = matrix.client;
+      final devicesFuture = client.getDevices();
+      final dehydratedIdFuture = _dehydratedDeviceId(client);
+      final devices = await devicesFuture;
+      final dehydratedId = await dehydratedIdFuture;
       if (!mounted) return;
       setState(() {
-        _devices = devices;
+        _devices = devices == null || dehydratedId == null
+            ? devices
+            : devices.where((d) => d.deviceId != dehydratedId).toList();
         _loading = false;
       });
     } catch (e) {
@@ -62,6 +69,15 @@ class _DevicesScreenState extends State<DevicesScreen> {
         _error = 'Failed to load devices';
         _loading = false;
       });
+    }
+  }
+
+  Future<String?> _dehydratedDeviceId(Client client) async {
+    try {
+      final device = await client.getDehydratedDevice();
+      return device.deviceId;
+    } catch (_) {
+      return null;
     }
   }
 

--- a/test/screens/devices_screen_test.dart
+++ b/test/screens/devices_screen_test.dart
@@ -72,23 +72,25 @@ void main() {
 
     testWidgets('shows current device and other devices', (tester) async {
       final now = DateTime.now().millisecondsSinceEpoch;
-      when(mockClient.getDevices()).thenAnswer((_) async => [
-            Device(
-              deviceId: 'THISDEVICE',
-              displayName: 'Kohera Flutter',
-              lastSeenTs: now,
-            ),
-            Device(
-              deviceId: 'OTHER1',
-              displayName: 'Element Android',
-              lastSeenTs: now - 3600000,
-            ),
-            Device(
-              deviceId: 'OTHER2',
-              displayName: 'Element Web',
-              lastSeenTs: now - 7200000,
-            ),
-          ],);
+      when(mockClient.getDevices()).thenAnswer(
+        (_) async => [
+          Device(
+            deviceId: 'THISDEVICE',
+            displayName: 'Kohera Flutter',
+            lastSeenTs: now,
+          ),
+          Device(
+            deviceId: 'OTHER1',
+            displayName: 'Element Android',
+            lastSeenTs: now - 3600000,
+          ),
+          Device(
+            deviceId: 'OTHER2',
+            displayName: 'Element Web',
+            lastSeenTs: now - 7200000,
+          ),
+        ],
+      );
 
       await tester.pumpWidget(buildTestWidget());
       await tester.pumpAndSettle();
@@ -101,13 +103,54 @@ void main() {
       expect(find.text('Remove all other devices'), findsOneWidget);
     });
 
+    testWidgets('hides the dehydrated device from the list', (tester) async {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      when(mockClient.getDevices()).thenAnswer(
+        (_) async => [
+          Device(
+            deviceId: 'THISDEVICE',
+            displayName: 'Kohera Flutter',
+            lastSeenTs: now,
+          ),
+          Device(
+            deviceId: 'OTHER1',
+            displayName: 'Element Android',
+            lastSeenTs: now - 3600000,
+          ),
+          Device(
+            deviceId: 'FAMdehydrated',
+            displayName: 'Dehydrated Device',
+          ),
+        ],
+      );
+      when(
+        mockClient.request(
+          any,
+          argThat(contains('dehydrated_device')),
+          data: anyNamed('data'),
+          contentType: anyNamed('contentType'),
+          query: anyNamed('query'),
+        ),
+      ).thenAnswer(
+        (_) async => {'device_id': 'FAMdehydrated'},
+      );
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Element Android'), findsOneWidget);
+      expect(find.text('Dehydrated Device'), findsNothing);
+    });
+
     testWidgets('shows empty state when no other devices', (tester) async {
-      when(mockClient.getDevices()).thenAnswer((_) async => [
-            Device(
-              deviceId: 'THISDEVICE',
-              displayName: 'Kohera Flutter',
-            ),
-          ],);
+      when(mockClient.getDevices()).thenAnswer(
+        (_) async => [
+          Device(
+            deviceId: 'THISDEVICE',
+            displayName: 'Kohera Flutter',
+          ),
+        ],
+      );
 
       await tester.pumpWidget(buildTestWidget());
       await tester.pumpAndSettle();
@@ -118,9 +161,11 @@ void main() {
 
     testWidgets('shows backup warning when backup needed', (tester) async {
       when(mockChatBackup.chatBackupNeeded).thenReturn(true);
-      when(mockClient.getDevices()).thenAnswer((_) async => [
-            Device(deviceId: 'THISDEVICE', displayName: 'Kohera Flutter'),
-          ],);
+      when(mockClient.getDevices()).thenAnswer(
+        (_) async => [
+          Device(deviceId: 'THISDEVICE', displayName: 'Kohera Flutter'),
+        ],
+      );
 
       await tester.pumpWidget(buildTestWidget());
       await tester.pumpAndSettle();
@@ -133,12 +178,14 @@ void main() {
 
     testWidgets('rename device shows dialog and calls updateDevice',
         (tester) async {
-      when(mockClient.getDevices()).thenAnswer((_) async => [
-            Device(
-              deviceId: 'THISDEVICE',
-              displayName: 'Kohera Flutter',
-            ),
-          ],);
+      when(mockClient.getDevices()).thenAnswer(
+        (_) async => [
+          Device(
+            deviceId: 'THISDEVICE',
+            displayName: 'Kohera Flutter',
+          ),
+        ],
+      );
       when(mockClient.updateDevice(any, displayName: anyNamed('displayName')))
           .thenAnswer((_) async {});
 
@@ -162,14 +209,16 @@ void main() {
 
     testWidgets('remove device shows confirmation dialog', (tester) async {
       final now = DateTime.now().millisecondsSinceEpoch;
-      when(mockClient.getDevices()).thenAnswer((_) async => [
-            Device(deviceId: 'THISDEVICE', displayName: 'Kohera Flutter'),
-            Device(
-              deviceId: 'OTHER1',
-              displayName: 'Old Phone',
-              lastSeenTs: now,
-            ),
-          ],);
+      when(mockClient.getDevices()).thenAnswer(
+        (_) async => [
+          Device(deviceId: 'THISDEVICE', displayName: 'Kohera Flutter'),
+          Device(
+            deviceId: 'OTHER1',
+            displayName: 'Old Phone',
+            lastSeenTs: now,
+          ),
+        ],
+      );
 
       await tester.pumpWidget(buildTestWidget());
       await tester.pumpAndSettle();
@@ -181,9 +230,11 @@ void main() {
       } else {
         // PopupMenuButton renders as an IconButton with an overflow icon.
         // Find it by widget type within the DeviceListItem for 'Old Phone'.
-        await tester.tap(find.byWidgetPredicate(
-          (widget) => widget is PopupMenuButton,
-        ),);
+        await tester.tap(
+          find.byWidgetPredicate(
+            (widget) => widget is PopupMenuButton,
+          ),
+        );
       }
       await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Summary

Enables MSC3814 dehydrated devices. A dehydrated device is a server-stored, offline olm account that other users keep sending room keys to while none of your real devices are online. On a later login it is rehydrated — its queued to-device room keys are fetched and imported — then replaced with a fresh dehydrated device.

The SDK (matrix 6.2.0) drives the crypto from inside the bootstrap state machine, so `dehydratedDeviceSetup()` runs during first-time E2EE setup, typed-recovery-key unlock, and headless restore (`restoreCryptoIdentity`) with no explicit call. One-time and fallback keys are uploaded with the device (olm_manager) so senders can session to it. The pickle key lives in 4S under `org.matrix.msc3814` — no new user-visible secret.

## Changes

- `client_factory_shared.dart` — `enableDehydratedDevices: true`.
- `devices_screen.dart` — filter the dehydrated device out of Settings → Devices (it is a real server-side device; users could otherwise see it and delete/block it, breaking recovery). Best-effort `getDehydratedDevice()` lookup, no-op on servers without MSC3814.
- `docs/e2ee-flow.md` — new "Dehydrated Devices (MSC3814)" section.
- Tests: devices screen hides the dehydrated device.

## Scope correction vs the issue

The issue framed this as "a fresh login decrypts history with **zero** user interaction." That overstates it. Rehydration reads the pickle key from 4S, so it needs secret storage **open**. A brand-new device with no locally-stored recovery key must still unlock once (stored key = silent; otherwise typed recovery key or device verification). What dehydrated devices add: recovery of messages sent while no device was online (which online key backup can miss), plus fuller coverage on the existing headless stored-key path.

## Known limitation (documented, not fixed)

The **verification-only** unlock path does not rehydrate. `dehydratedDeviceSetup()` requires an unlocked `OpenSSSS` (`OpenSSSS.getStored` needs the 4S private key), which the verify-with-another-device flow never produces — it only gossips cached secrets. Those logins still recover history via online key backup + key gossip; they only miss the narrow set of messages sent while no device was online and never backed up. Closing this would require an SDK entry point that rehydrates from cached secrets (upstream change), so it is documented rather than worked around with a risky reimplementation of SDK crypto.

## Testing

- `flutter analyze` — no issues.
- Full suite green (after a clean mock regen).
- The end-to-end MSC3814 round-trip is homeserver-dependent and cannot run in CI without a live MSC3814-enabled homeserver; the SDK invocation path and the devices filter are verified by unit/widget tests and code review. Manual verification: set up E2EE on a Synapse with dehydrated devices enabled, confirm the dehydrated device does **not** appear in Settings → Devices, log in on a second device, confirm history (including messages sent while offline) decrypts.

Closes #620
Refs #626