### PR TITLE
feat(#637): render Cloudflare Turnstile widget under recaptcha stage

### DIFF
--- a/lib/features/auth/services/recaptcha_server_native.dart
+++ b/lib/features/auth/services/recaptcha_server_native.dart
@@ -18,6 +18,11 @@ class RecaptchaServer {
 
   final String siteKey;
 
+  /// Cloudflare Turnstile site keys are `0x`-prefixed; Google reCAPTCHA keys
+  /// are not. The backend serves a Turnstile key under the `m.login.recaptcha`
+  /// stage (adapter path), so the widget is chosen from the key shape.
+  bool get _isTurnstile => siteKey.startsWith('0x');
+
   HttpServer? _server;
   final Completer<String> _tokenCompleter = Completer<String>();
   Timer? _timeout;
@@ -105,14 +110,19 @@ class RecaptchaServer {
     });
   }
 
-  String _buildHtmlPage() => '''
+  String _buildHtmlPage() {
+    final scriptSrc = _isTurnstile
+        ? 'https://challenges.cloudflare.com/turnstile/v0/api.js'
+        : 'https://www.google.com/recaptcha/api.js';
+    final widgetClass = _isTurnstile ? 'cf-turnstile' : 'g-recaptcha';
+    return '''
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Verify you are human</title>
-  <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+  <script src="$scriptSrc" async defer></script>
   <style>
     body {
       font-family: sans-serif;
@@ -132,7 +142,7 @@ class RecaptchaServer {
     <h2>Verify you are human</h2>
     <form id="captchaForm" method="POST" action="/token">
       <input type="hidden" id="tokenField" name="g-recaptcha-response" value="">
-      <div class="g-recaptcha"
+      <div class="$widgetClass"
            data-sitekey="${_escapeHtmlAttr(siteKey)}"
            data-callback="onCaptchaComplete"></div>
     </form>
@@ -146,6 +156,7 @@ class RecaptchaServer {
 </body>
 </html>
 ''';
+  }
 
   String _buildSuccessPage() => '''
 <!DOCTYPE html>

--- a/lib/features/auth/services/recaptcha_server_web.dart
+++ b/lib/features/auth/services/recaptcha_server_web.dart
@@ -18,6 +18,11 @@ class RecaptchaServer {
 
   final String siteKey;
 
+  /// Cloudflare Turnstile site keys are `0x`-prefixed; Google reCAPTCHA keys
+  /// are not. The backend serves a Turnstile key under the `m.login.recaptcha`
+  /// stage (adapter path), so the widget is chosen from the key shape.
+  bool get _isTurnstile => siteKey.startsWith('0x');
+
   final Completer<String> _tokenCompleter = Completer<String>();
   Timer? _timeout;
   web.Window? _popup;
@@ -88,14 +93,19 @@ class RecaptchaServer {
     }
   }
 
-  String _buildHtmlPage() => '''
+  String _buildHtmlPage() {
+    final scriptSrc = _isTurnstile
+        ? 'https://challenges.cloudflare.com/turnstile/v0/api.js'
+        : 'https://www.google.com/recaptcha/api.js';
+    final widgetClass = _isTurnstile ? 'cf-turnstile' : 'g-recaptcha';
+    return '''
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Verify you are human</title>
-  <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+  <script src="$scriptSrc" async defer></script>
   <style>
     body {
       font-family: sans-serif;
@@ -113,7 +123,7 @@ class RecaptchaServer {
 <body>
   <div>
     <h2>Verify you are human</h2>
-    <div class="g-recaptcha"
+    <div class="$widgetClass"
          data-sitekey="${_escapeHtmlAttr(siteKey)}"
          data-callback="onCaptchaComplete"></div>
   </div>
@@ -126,6 +136,7 @@ class RecaptchaServer {
 </body>
 </html>
 ''';
+  }
 
   void dispose() {
     _timeout?.cancel();

--- a/test/services/recaptcha_server_test.dart
+++ b/test/services/recaptcha_server_test.dart
@@ -26,6 +26,32 @@ void main() {
         final html = String.fromCharCodes(body);
         expect(html, contains('data-sitekey="testkey"'));
         expect(html, contains('g-recaptcha'));
+        expect(html, contains('google.com/recaptcha'));
+      } finally {
+        client.close();
+        unawaited(server.tokenFuture.catchError((_) => ''));
+        server.dispose();
+      }
+    });
+
+    test('renders Turnstile widget for a 0x-prefixed site key', () async {
+      final server = RecaptchaServer(siteKey: '0x4AAAAAtestkey');
+      final url = await server.start();
+
+      final client = HttpClient();
+      try {
+        final request = await client.getUrl(Uri.parse(url));
+        final response = await request.close();
+
+        final body = await response.fold<List<int>>(
+          [],
+          (acc, chunk) => acc..addAll(chunk),
+        );
+        final html = String.fromCharCodes(body);
+        expect(html, contains('data-sitekey="0x4AAAAAtestkey"'));
+        expect(html, contains('cf-turnstile'));
+        expect(html, contains('challenges.cloudflare.com/turnstile'));
+        expect(html, isNot(contains('google.com/recaptcha')));
       } finally {
         client.close();
         unawaited(server.tokenFuture.catchError((_) => ''));


### PR DESCRIPTION
## Summary

Implements the **client slice** of #637 to match the deployed backend, which took the **adapter path**: it serves a Cloudflare Turnstile site key (`0x`-prefixed) under the existing `m.login.recaptcha` UIA stage and repoints siteverify. No new UIA stage is introduced — the client just renders the right widget for the key it's given.

## Changes

- **`recaptcha_server_native.dart` / `_web.dart`** — `RecaptchaServer` now selects the widget from the site-key shape (`_isTurnstile = siteKey.startsWith('0x')`):
  - Turnstile key → `challenges.cloudflare.com/turnstile/v0/api.js` + `cf-turnstile` widget
  - otherwise → Google `recaptcha/api.js` + `g-recaptcha` widget
  - The `data-callback`, hidden token field, `POST /token` capture, and `m.login.recaptcha` submission are **unchanged** — both widgets deliver the token through the same path.
- **`recaptcha_server_test.dart`** — added a case asserting a `0x` key renders the Turnstile script/widget and not the Google one.

## Why this shape

Turnstile site keys are `0x`-prefixed; reCAPTCHA keys are not. That makes the key a reliable discriminator, so the **real reCAPTCHA path keeps working** until full cutover (issue requirement) with no server signalling needed.

The Turnstile **secret stays server-side** — the client only ever handles the public site key and the solution token.

## Testing

- `flutter analyze` — clean
- `flutter test test/services/recaptcha_server_test.dart` — all pass (incl. new Turnstile-render case)
- Verified live: `POST /register` on the configured homeserver returns `m.login.recaptcha` with public_key `0x4AAAAAA…` (a Turnstile key), which this widget now renders correctly.

## Note

Supersedes the earlier `io.kohera.turnstile` module-path approach on this branch (reverted) — the backend chose the adapter path, so a dedicated stage isn't needed.

Refs #637