### PR TITLE
fix(#639): redirect add-account routes when no pending service

### DIFF
--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -107,6 +107,8 @@ GoRouter buildRouter(ClientManager manager) {
       GoRoute(
         path: '/add-account',
         name: Routes.addAccount,
+        redirect: (context, state) =>
+            addAccountRedirect(manager.pendingService),
         builder: (context, state) {
           final manager = context.read<ClientManager>();
           return _AddAccountGuard(
@@ -405,6 +407,17 @@ class AccountSwitchRedirector {
     return location.startsWith('/rooms/') ? '/' : null;
   }
 }
+
+/// Redirect target for the add-account routes.
+///
+/// The add-account route builders eagerly dereference
+/// [ClientManager.pendingService] to seed a scoped [MatrixService] provider, so
+/// the route is only safe to build once a pending service exists. When
+/// [pendingService] is null (e.g. a deep link or back navigation that bypasses
+/// the settings entry point), the routes must redirect home instead of letting
+/// the `!` dereference crash the screen.
+String? addAccountRedirect(MatrixService? pendingService) =>
+    pendingService == null ? '/' : null;
 
 class _AddAccountGuard extends StatefulWidget {
   const _AddAccountGuard({required this.manager, required this.child});

--- a/test/core/add_account_redirect_test.dart
+++ b/test/core/add_account_redirect_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/routing/app_router.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:matrix/matrix.dart';
+import 'package:matrix/src/utils/cached_stream_controller.dart';
+import 'package:mockito/mockito.dart';
+
+import '../services/matrix_service_test.mocks.dart';
+
+MatrixService _makeService(String name) {
+  final mockClient = MockClient();
+  when(mockClient.rooms).thenReturn([]);
+  when(mockClient.userID).thenReturn('@$name:example.com');
+  when(mockClient.dispose()).thenAnswer((_) async {});
+  when(mockClient.onSync).thenReturn(CachedStreamController<SyncUpdate>());
+  when(mockClient.onPresenceChanged)
+      .thenReturn(CachedStreamController<CachedPresence>());
+  return MatrixService(client: mockClient, clientName: name);
+}
+
+void main() {
+  group('addAccountRedirect', () {
+    test('redirects home when there is no pending service', () {
+      expect(addAccountRedirect(null), '/');
+    });
+
+    test('does not redirect when a pending service exists', () {
+      expect(addAccountRedirect(_makeService('pending')), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The add-account route builders dereference `ClientManager.pendingService!` to seed a scoped `MatrixService` provider, so reaching an add-account route without a pending service crashed the whole screen with "Null check operator used on a null value". This adds a route-level guard that redirects home when no pending service exists.

## Changes

- Add a `redirect` on the parent `/add-account` route that returns `/` when `pendingService` is null. go_router evaluates parent-route redirects for every sub-route in the matched stack, so this guards the login, register, and server add-account routes before any builder dereferences `pendingService!`.
- Extract the decision into a small pure function `addAccountRedirect(MatrixService?)` in `lib/core/routing/app_router.dart`, matching the existing `AccountSwitchRedirector` pattern.
- Add `test/core/add_account_redirect_test.dart` covering the null and non-null cases.

## Testing

- [ ] `flutter analyze` is clean
- [ ] `flutter test` passes (run `dart run build_runner build --delete-conflicting-outputs` first if mocks changed)

Note: the Flutter toolchain is not installed in the environment this branch was prepared in, so analyze/test were not run locally — CI will exercise them.

## Linked issues

Closes #639

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master` (not another feature branch, unless an explicitly requested stacked PR)
