### PR TITLE
fix(security): validate URL schemes before launching links

### DIFF
--- a/lib/core/utils/safe_url_launcher.dart
+++ b/lib/core/utils/safe_url_launcher.dart
@@ -1,0 +1,31 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+typedef UrlLauncher = Future<bool> Function(Uri uri, {LaunchMode mode});
+
+/// Schemes safe to hand to the platform from untrusted content. Anything else
+/// (`file:`, `javascript:`, `data:`, custom app schemes, ...) is rejected so a
+/// crafted message link cannot open local resources or spoof its destination.
+const Set<String> kAllowedUrlSchemes = {'http', 'https', 'mailto', 'matrix'};
+
+/// Whether [uri] uses a scheme we are willing to launch.
+bool isAllowedUrl(Uri uri) =>
+    kAllowedUrlSchemes.contains(uri.scheme.toLowerCase());
+
+/// Parses [rawUrl] and launches it externally, but only when it uses an allowed
+/// scheme. Returns `true` when a launch was attempted, `false` when the URL was
+/// null, unparseable, or blocked.
+Future<bool> safeLaunchUrl(
+  String? rawUrl, {
+  UrlLauncher launcher = launchUrl,
+}) async {
+  if (rawUrl == null) return false;
+  final uri = Uri.tryParse(rawUrl);
+  if (uri == null || !isAllowedUrl(uri)) {
+    debugPrint('[Kohera] Blocked launch of disallowed URL: $rawUrl');
+    return false;
+  }
+  return launcher(uri, mode: LaunchMode.externalApplication);
+}

--- a/lib/features/chat/widgets/inline_image_preview.dart
+++ b/lib/features/chat/widgets/inline_image_preview.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:kohera/core/utils/safe_url_launcher.dart';
 
 class InlineImagePreview extends StatelessWidget {
   const InlineImagePreview({
@@ -21,10 +21,7 @@ class InlineImagePreview extends StatelessWidget {
       padding: const EdgeInsets.only(top: 6),
       child: GestureDetector(
         onTap: () {
-          final uri = Uri.tryParse(url);
-          if (uri != null) {
-            unawaited(launchUrl(uri, mode: LaunchMode.externalApplication));
-          }
+          unawaited(safeLaunchUrl(url));
         },
         child: ClipRRect(
           borderRadius: BorderRadius.circular(10),

--- a/lib/features/chat/widgets/link_preview_card.dart
+++ b/lib/features/chat/widgets/link_preview_card.dart
@@ -3,9 +3,9 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/utils/media_auth.dart';
+import 'package:kohera/core/utils/safe_url_launcher.dart';
 import 'package:kohera/features/chat/services/opengraph_service.dart';
 import 'package:provider/provider.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 /// Displays an OpenGraph preview card for a URL found in a chat message.
 class LinkPreviewCard extends StatefulWidget {
@@ -111,10 +111,7 @@ class _LinkPreviewCardState extends State<LinkPreviewCard>
             child: InkWell(
               borderRadius: BorderRadius.circular(8),
               onTap: () {
-                final uri = Uri.tryParse(data.url);
-                if (uri != null) {
-                  unawaited(launchUrl(uri, mode: LaunchMode.externalApplication));
-                }
+                unawaited(safeLaunchUrl(data.url));
               },
               child: Container(
                 decoration: BoxDecoration(

--- a/lib/features/chat/widgets/linkable_span_builder.dart
+++ b/lib/features/chat/widgets/linkable_span_builder.dart
@@ -4,10 +4,10 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:html/dom.dart' as dom;
 import 'package:kohera/core/utils/emoji_spans.dart';
+import 'package:kohera/core/utils/safe_url_launcher.dart';
 import 'package:kohera/features/chat/widgets/linkable_text.dart';
 import 'package:kohera/features/chat/widgets/mention_pill.dart';
 import 'package:matrix/matrix.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 typedef RecognizerFactory = TapGestureRecognizer Function(VoidCallback onTap);
 
@@ -57,10 +57,7 @@ class LinkableSpanBuilder {
           decorationColor: linkColor,
         ),
         recognizer: createRecognizer(() {
-          final uri = Uri.tryParse(cleanedUrl);
-          if (uri != null) {
-            unawaited(launchUrl(uri, mode: LaunchMode.externalApplication));
-          }
+          unawaited(safeLaunchUrl(cleanedUrl));
         }),
       ),);
 
@@ -105,10 +102,7 @@ class LinkableSpanBuilder {
         text: text,
         style: aStyle,
         recognizer: createRecognizer(() {
-          final uri = Uri.tryParse(href);
-          if (uri != null) {
-            unawaited(launchUrl(uri, mode: LaunchMode.externalApplication));
-          }
+          unawaited(safeLaunchUrl(href));
         }),
       ),);
       return;

--- a/lib/features/chat/widgets/linkable_text.dart
+++ b/lib/features/chat/widgets/linkable_text.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:kohera/core/utils/emoji_spans.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:kohera/core/utils/safe_url_launcher.dart';
 
 /// A text widget that detects URLs and renders them as tappable, styled links.
 class LinkableText extends StatelessWidget {
@@ -79,10 +79,7 @@ class LinkableText extends StatelessWidget {
         ),
         recognizer: TapGestureRecognizer()
           ..onTap = () {
-            final uri = Uri.tryParse(cleanedUrl);
-            if (uri != null) {
-              unawaited(launchUrl(uri, mode: LaunchMode.externalApplication));
-            }
+            unawaited(safeLaunchUrl(cleanedUrl));
           },
       ),);
 

--- a/lib/features/whats_new/widgets/release_notes_markdown.dart
+++ b/lib/features/whats_new/widgets/release_notes_markdown.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'package:kohera/core/utils/safe_url_launcher.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 typedef LinkLauncher = Future<bool> Function(Uri uri);
@@ -36,7 +37,7 @@ class ReleaseNotesMarkdown extends StatelessWidget {
       onTapLink: (text, href, title) {
         if (href == null) return;
         final uri = Uri.tryParse(href);
-        if (uri == null) return;
+        if (uri == null || !isAllowedUrl(uri)) return;
         final launcher = linkLauncher ??
             (u) => launchUrl(u, mode: LaunchMode.externalApplication);
         unawaited(launcher(uri));

--- a/test/core/utils/safe_url_launcher_test.dart
+++ b/test/core/utils/safe_url_launcher_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/utils/safe_url_launcher.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+void main() {
+  group('isAllowedUrl', () {
+    test('allows web, mail, and matrix schemes', () {
+      expect(isAllowedUrl(Uri.parse('https://example.com')), isTrue);
+      expect(isAllowedUrl(Uri.parse('http://example.com')), isTrue);
+      expect(isAllowedUrl(Uri.parse('HTTPS://example.com')), isTrue);
+      expect(isAllowedUrl(Uri.parse('mailto:user@example.com')), isTrue);
+      expect(isAllowedUrl(Uri.parse('matrix:r/room:server')), isTrue);
+    });
+
+    test('rejects dangerous and unknown schemes', () {
+      expect(isAllowedUrl(Uri.parse('file:///etc/passwd')), isFalse);
+      expect(isAllowedUrl(Uri.parse('javascript:alert(1)')), isFalse);
+      expect(isAllowedUrl(Uri.parse('data:text/html,<script>')), isFalse);
+      expect(isAllowedUrl(Uri.parse('tel:+15551234')), isFalse);
+      expect(isAllowedUrl(Uri.parse('intent://evil#Intent;end')), isFalse);
+      expect(isAllowedUrl(Uri.parse('custom-app://do-something')), isFalse);
+    });
+  });
+
+  group('safeLaunchUrl', () {
+    test('launches an allowed URL via the injected launcher', () async {
+      Uri? launched;
+      final result = await safeLaunchUrl(
+        'https://example.com/page',
+        launcher: (uri, {mode = LaunchMode.platformDefault}) async {
+          launched = uri;
+          return true;
+        },
+      );
+
+      expect(result, isTrue);
+      expect(launched, Uri.parse('https://example.com/page'));
+    });
+
+    test('blocks a file: URL and never calls the launcher', () async {
+      var called = false;
+      final result = await safeLaunchUrl(
+        'file:///etc/passwd',
+        launcher: (uri, {mode = LaunchMode.platformDefault}) async {
+          called = true;
+          return true;
+        },
+      );
+
+      expect(result, isFalse);
+      expect(called, isFalse);
+    });
+
+    test('blocks a javascript: URL and never calls the launcher', () async {
+      var called = false;
+      final result = await safeLaunchUrl(
+        'javascript:alert(document.cookie)',
+        launcher: (uri, {mode = LaunchMode.platformDefault}) async {
+          called = true;
+          return true;
+        },
+      );
+
+      expect(result, isFalse);
+      expect(called, isFalse);
+    });
+
+    test('returns false for null input', () async {
+      expect(await safeLaunchUrl(null), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Untrusted content (chat message HTML, plain-text links, link previews, and release notes) passed link `href`s straight to `launchUrl` with no scheme check, letting a crafted message link open `file:`, `javascript:`, `data:`, or arbitrary app-scheme handlers while displaying benign link text. This adds a single validated launch path that only permits safe schemes.

## Changes

- Add `lib/core/utils/safe_url_launcher.dart`: `safeLaunchUrl()` parses a URL and launches it externally only when its scheme is in an allowlist (`http`, `https`, `mailto`, `matrix`); blocked URLs are logged and dropped. Exposes `isAllowedUrl()` and an injectable launcher for testing.
- Route every untrusted-content launch site through it:
  - `features/chat/widgets/linkable_span_builder.dart` — HTML `<a href>` from senders (the primary issue) and plain-text URLs
  - `features/chat/widgets/linkable_text.dart` — detected plain-text URLs
  - `features/chat/widgets/inline_image_preview.dart` — inline image tap-through
  - `features/chat/widgets/link_preview_card.dart` — OpenGraph preview card tap
  - `features/whats_new/widgets/release_notes_markdown.dart` — guards its existing test seam with `isAllowedUrl` before launching
- Add `test/core/utils/safe_url_launcher_test.dart` covering allowed schemes, rejected dangerous/unknown schemes, and that the launcher is never invoked for a blocked URL.

App-constructed and hardcoded URLs (SSO/recaptcha flow, GitHub/help links) are intentionally left as-is — they are not sender-controlled.

## Testing

- [ ] `flutter analyze` is clean
- [ ] `flutter test` passes

> Note: the Flutter SDK is not available in the environment where this change was authored, so `flutter analyze` / `flutter test` were not run locally and are left unchecked for CI to verify. The change was reviewed by inspection (no dangling imports, valid const default, correct function-subtype assignability).

## Linked issues

Refs #

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master`

https://claude.ai/code/session_01XNi8XuNJ8kA2e4urXobTgb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNi8XuNJ8kA2e4urXobTgb)_