### PR TITLE
fix(security): encrypt iOS key-mirror payloads at rest

### DIFF
--- a/ios/KoheraNotificationService/MegolmDecryptor.swift
+++ b/ios/KoheraNotificationService/MegolmDecryptor.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 import SQLite3
 
@@ -50,6 +51,11 @@ struct MegolmDecryptor {
     // ── Session lookup ───────────────────────────────────────────
 
     private static func lookupSession(sessionId: String, clientName: String) -> String? {
+        guard let dbKey = loadDbKey(clientName: clientName) else {
+            NSLog("[KoheraNSE] No key-mirror encryption key available")
+            return nil
+        }
+
         guard let containerURL = FileManager.default.containerURL(
             forSecurityApplicationGroupIdentifier: appGroupId
         ) else {
@@ -85,16 +91,44 @@ struct MegolmDecryptor {
         }
 
         guard let cValue = sqlite3_column_text(stmt, 0) else { return nil }
-        let jsonString = String(cString: cValue)
+        let storedValue = String(cString: cValue)
 
-        guard let jsonData = jsonString.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+        guard let jsonData = decryptValue(base64: storedValue, key: dbKey) else {
+            NSLog("[KoheraNSE] Failed to decrypt session payload")
+            return nil
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
               let pickle = json["pickle"] as? String else {
             NSLog("[KoheraNSE] Failed to parse session JSON")
             return nil
         }
 
         return pickle
+    }
+
+    // ── Payload encryption (AES-256-GCM, key shared via Keychain) ─
+
+    private static func loadDbKey(clientName: String) -> SymmetricKey? {
+        guard let encoded = SharedKeychainReader.read(
+                  key: "kohera_\(clientName)_key_mirror_db_key"
+              ),
+              let data = Data(base64Encoded: encoded),
+              data.count == 32 else {
+            return nil
+        }
+        return SymmetricKey(data: data)
+    }
+
+    private static func decryptValue(base64: String, key: SymmetricKey) -> Data? {
+        guard let combined = Data(base64Encoded: base64) else { return nil }
+        do {
+            let box = try AES.GCM.SealedBox(combined: combined)
+            return try AES.GCM.open(box, using: key)
+        } catch {
+            NSLog("[KoheraNSE] AES-GCM open failed: %@", error.localizedDescription)
+            return nil
+        }
     }
 
     // ── Body extraction ──────────────────────────────────────────

--- a/lib/features/notifications/services/key_mirror_crypto.dart
+++ b/lib/features/notifications/services/key_mirror_crypto.dart
@@ -1,0 +1,49 @@
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:pointycastle/export.dart';
+
+/// AES-256-GCM used to protect the iOS key-mirror payloads at rest.
+///
+/// [encrypt] returns `nonce || ciphertext || tag`, matching CryptoKit's
+/// combined `AES.GCM.SealedBox` representation so the Notification Service
+/// Extension can decrypt with `AES.GCM.open`.
+class KeyMirrorCrypto {
+  static const int keyLength = 32;
+  static const int _nonceLength = 12;
+  static const int _macBits = 128;
+
+  static final Random _random = Random.secure();
+
+  static Uint8List randomBytes(int length) {
+    final bytes = Uint8List(length);
+    for (var i = 0; i < length; i++) {
+      bytes[i] = _random.nextInt(256);
+    }
+    return bytes;
+  }
+
+  static Uint8List generateKey() => randomBytes(keyLength);
+
+  static Uint8List encrypt(Uint8List key, Uint8List plaintext) {
+    final nonce = randomBytes(_nonceLength);
+    final cipher = GCMBlockCipher(AESEngine())
+      ..init(
+        true,
+        AEADParameters(KeyParameter(key), _macBits, nonce, Uint8List(0)),
+      );
+    final sealed = cipher.process(plaintext);
+    return Uint8List.fromList([...nonce, ...sealed]);
+  }
+
+  static Uint8List decrypt(Uint8List key, Uint8List combined) {
+    final nonce = Uint8List.sublistView(combined, 0, _nonceLength);
+    final sealed = Uint8List.sublistView(combined, _nonceLength);
+    final cipher = GCMBlockCipher(AESEngine())
+      ..init(
+        false,
+        AEADParameters(KeyParameter(key), _macBits, nonce, Uint8List(0)),
+      );
+    return cipher.process(sealed);
+  }
+}

--- a/lib/features/notifications/services/megolm_key_mirror.dart
+++ b/lib/features/notifications/services/megolm_key_mirror.dart
@@ -1,29 +1,46 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:kohera/features/notifications/services/apns_push_service.dart';
+import 'package:kohera/features/notifications/services/key_mirror_crypto.dart';
 import 'package:matrix/matrix.dart';
 import 'package:path/path.dart' as p;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sqflite/sqflite.dart' as sqflite;
 
 class MegolmKeyMirror {
-  MegolmKeyMirror({required this.client, required this.clientName});
+  MegolmKeyMirror({
+    required this.client,
+    required this.clientName,
+    FlutterSecureStorage? storage,
+  }) : _storage = storage ??
+            const FlutterSecureStorage(
+              iOptions: IOSOptions(
+                groupId: 'group.io.github.quantumheart.kohera',
+                accessibility: KeychainAccessibility.first_unlock,
+              ),
+            );
 
   final Client client;
   final String clientName;
+  final FlutterSecureStorage _storage;
 
   final Set<String> _subscribedRooms = <String>{};
   final List<StreamSubscription<dynamic>> _subs = [];
   String? _appGroupPath;
+  Uint8List? _dbKey;
   bool _started = false;
 
   String get _mirrorDbName => 'kohera_${clientName}_keys.db';
   String get _legacyDbName => 'kohera_$clientName.db';
   String get _backfillFlagKey => 'kohera_key_mirror_backfilled_$clientName';
+  String get _encryptionFlagKey => 'kohera_key_mirror_encrypted_$clientName';
+  String get _dbKeyStorageKey => 'kohera_${clientName}_key_mirror_db_key';
 
   Future<void> start() async {
     if (_started || !Platform.isIOS) return;
@@ -35,6 +52,13 @@ class MegolmKeyMirror {
       return;
     }
 
+    _dbKey = await _loadOrCreateDbKey();
+    if (_dbKey == null) {
+      debugPrint('[Kohera] Key mirror: no encryption key, skipping');
+      return;
+    }
+
+    await _upgradeToEncryptedFormatIfNeeded();
     await _migrateLegacyDbIfNeeded();
     await _backfillIfNeeded();
     _hookExistingRooms();
@@ -59,6 +83,48 @@ class MegolmKeyMirror {
     }
   }
 
+  Future<Uint8List?> _loadOrCreateDbKey() async {
+    try {
+      final existing = await _storage.read(key: _dbKeyStorageKey);
+      if (existing != null) {
+        final decoded = base64Decode(existing);
+        if (decoded.length == KeyMirrorCrypto.keyLength) {
+          return Uint8List.fromList(decoded);
+        }
+        debugPrint('[Kohera] Key mirror: stored key malformed, regenerating');
+      }
+      final key = KeyMirrorCrypto.generateKey();
+      await _storage.write(key: _dbKeyStorageKey, value: base64Encode(key));
+      return key;
+    } catch (e) {
+      debugPrint('[Kohera] Key mirror: failed to load encryption key: $e');
+      return null;
+    }
+  }
+
+  Future<void> _upgradeToEncryptedFormatIfNeeded() async {
+    final prefs = await SharedPreferences.getInstance();
+    if (prefs.getBool(_encryptionFlagKey) ?? false) return;
+
+    _deleteDbFiles(p.join(_appGroupPath!, _mirrorDbName));
+    await prefs.setBool(_backfillFlagKey, false);
+    await prefs.setBool(_encryptionFlagKey, true);
+    debugPrint('[Kohera] Key mirror: reset mirror for encrypted format');
+  }
+
+  void _deleteDbFiles(String basePath) {
+    for (final suffix in const ['', '-wal', '-shm', '-journal']) {
+      final f = File('$basePath$suffix');
+      if (f.existsSync()) {
+        try {
+          f.deleteSync();
+        } catch (e) {
+          debugPrint('[Kohera] Key mirror: failed to delete $f: $e');
+        }
+      }
+    }
+  }
+
   Future<void> _migrateLegacyDbIfNeeded() async {
     final legacyPath = p.join(_appGroupPath!, _legacyDbName);
     final legacyFile = File(legacyPath);
@@ -78,16 +144,7 @@ class MegolmKeyMirror {
       await legacy?.close();
     }
 
-    for (final suffix in const ['', '-wal', '-shm', '-journal']) {
-      final f = File('$legacyPath$suffix');
-      if (f.existsSync()) {
-        try {
-          await f.delete();
-        } catch (e) {
-          debugPrint('[Kohera] Key mirror: failed to delete $f: $e');
-        }
-      }
-    }
+    _deleteDbFiles(legacyPath);
   }
 
   Future<void> _backfillIfNeeded() async {
@@ -179,7 +236,7 @@ class MegolmKeyMirror {
       for (final row in rows) {
         batch.insert(
           'box_inbound_group_session',
-          row,
+          {'k': row['k'], 'v': _encryptValue(row['v']! as String)},
           conflictAlgorithm: sqflite.ConflictAlgorithm.replace,
         );
       }
@@ -188,6 +245,14 @@ class MegolmKeyMirror {
     } finally {
       await db?.close();
     }
+  }
+
+  String _encryptValue(String plaintext) {
+    final sealed = KeyMirrorCrypto.encrypt(
+      _dbKey!,
+      Uint8List.fromList(utf8.encode(plaintext)),
+    );
+    return base64Encode(sealed);
   }
 
   Future<void> _checkpoint(sqflite.Database db) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1222,7 +1222,7 @@ packages:
     source: hosted
     version: "2.1.8"
   pointycastle:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: pointycastle
       sha256: "92aa3841d083cc4b0f4709b5c74fd6409a3e6ba833ffc7dc6a8fee096366acf5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   path: ^1.9.1
   path_provider: ^2.1.5
   permission_handler: ^11.4.0
+  pointycastle: ^4.0.0
   provider: ^6.1.2
   pub_semver: ^2.1.4
   record: ^6.2.0

--- a/test/features/notifications/key_mirror_crypto_test.dart
+++ b/test/features/notifications/key_mirror_crypto_test.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/features/notifications/services/key_mirror_crypto.dart';
+
+void main() {
+  group('KeyMirrorCrypto', () {
+    test('generateKey returns 32 random bytes', () {
+      final a = KeyMirrorCrypto.generateKey();
+      final b = KeyMirrorCrypto.generateKey();
+      expect(a.length, KeyMirrorCrypto.keyLength);
+      expect(a, isNot(equals(b)));
+    });
+
+    test('round-trips a payload', () {
+      final key = KeyMirrorCrypto.generateKey();
+      final plaintext =
+          Uint8List.fromList(utf8.encode('{"pickle":"secret-session"}'));
+
+      final sealed = KeyMirrorCrypto.encrypt(key, plaintext);
+      final opened = KeyMirrorCrypto.decrypt(key, sealed);
+
+      expect(opened, equals(plaintext));
+    });
+
+    test('output is nonce(12) + ciphertext + tag(16), CryptoKit-combined', () {
+      final key = KeyMirrorCrypto.generateKey();
+      final plaintext = Uint8List.fromList(utf8.encode('hello'));
+
+      final sealed = KeyMirrorCrypto.encrypt(key, plaintext);
+
+      // 12-byte nonce + ciphertext (== plaintext length for GCM) + 16-byte tag.
+      expect(sealed.length, 12 + plaintext.length + 16);
+    });
+
+    test('uses a fresh nonce per encryption', () {
+      final key = KeyMirrorCrypto.generateKey();
+      final plaintext = Uint8List.fromList(utf8.encode('same input'));
+
+      final first = KeyMirrorCrypto.encrypt(key, plaintext);
+      final second = KeyMirrorCrypto.encrypt(key, plaintext);
+
+      expect(first, isNot(equals(second)));
+    });
+
+    test('rejects decryption with the wrong key', () {
+      final plaintext = Uint8List.fromList(utf8.encode('top secret'));
+      final sealed = KeyMirrorCrypto.encrypt(
+        KeyMirrorCrypto.generateKey(),
+        plaintext,
+      );
+
+      expect(
+        () => KeyMirrorCrypto.decrypt(KeyMirrorCrypto.generateKey(), sealed),
+        throwsA(anything),
+      );
+    });
+
+    test('rejects a tampered ciphertext', () {
+      final key = KeyMirrorCrypto.generateKey();
+      final sealed = KeyMirrorCrypto.encrypt(
+        key,
+        Uint8List.fromList(utf8.encode('integrity')),
+      );
+      sealed[sealed.length - 1] ^= 0xFF;
+
+      expect(
+        () => KeyMirrorCrypto.decrypt(key, sealed),
+        throwsA(anything),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The iOS Notification Service Extension (NSE) key mirror stored each inbound Megolm session — including the olm `pickle` — as plaintext JSON in the App Group container, and the NSE's pickle key was derived from the public user id, leaving the key material effectively unprotected at rest. This encrypts every mirrored payload with AES-256-GCM under a random key shared between the app and the extension via the existing Keychain access group.

## Changes

- Add `lib/features/notifications/services/key_mirror_crypto.dart`: AES-256-GCM (pointycastle) producing `nonce(12) ‖ ciphertext ‖ tag(16)`, matching CryptoKit's combined `AES.GCM.SealedBox` layout.
- `megolm_key_mirror.dart`: generate/load a random 256-bit key in the shared Keychain (`flutter_secure_storage`, same `groupId` + `first_unlock` as the access token) under `kohera_<clientName>_key_mirror_db_key`; encrypt every payload before writing; wipe and rebuild any existing plaintext mirror on first launch so there are no mixed-format rows.
- `ios/KoheraNotificationService/MegolmDecryptor.swift`: read the key from the Keychain via `SharedKeychainReader` and `AES.GCM.open` each payload before parsing the pickle.
- Promote `pointycastle` to a direct dependency (version unchanged, 4.0.0).
- Add `test/features/notifications/key_mirror_crypto_test.dart`: round-trip, exact byte layout, fresh-nonce-per-call, wrong-key and tampered-ciphertext rejection.

The NSE's `derivePickleKey(from: userId)` is intentionally left unchanged — it is the Matrix SDK's own pickle key and cannot be changed here; the new AES-GCM layer is what protects the material at rest.

## Testing

- [ ] `flutter analyze` is clean
- [ ] `flutter test` passes
- [ ] On-device: encrypted-push notifications still decrypt after upgrading from a build with an existing plaintext mirror

> Note: the Flutter SDK and Xcode are not available in the environment where this was authored, so neither the Dart suite nor the iOS NSE build were run locally. The Keychain key-sharing reuses the exact pattern already proven by the access-token flow; the new/untested surface is the pointycastle ↔ CryptoKit AES-GCM interop, verified by byte-layout reasoning and unit tests but not yet on a device. Device testing will be done as follow-up.

## Linked issues

Refs #

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master`

https://claude.ai/code/session_01XNi8XuNJ8kA2e4urXobTgb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNi8XuNJ8kA2e4urXobTgb)_