### PR TITLE
fix(sync): pause Matrix sync when app backgrounds to avoid 0xdead10cc

### DIFF
--- a/lib/core/services/matrix_service.dart
+++ b/lib/core/services/matrix_service.dart
@@ -156,12 +156,15 @@ class MatrixService extends ChangeNotifier with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     switch (state) {
       case AppLifecycleState.resumed:
+        sync.resume();
         _startForegroundSync();
         presence.setOnline();
       case AppLifecycleState.paused:
       case AppLifecycleState.hidden:
+        unawaited(sync.pause());
         presence.setAway();
       case AppLifecycleState.detached:
+        unawaited(sync.pause());
         presence.setOffline();
       case AppLifecycleState.inactive:
         break;

--- a/lib/core/services/sub_services/sync_service.dart
+++ b/lib/core/services/sub_services/sync_service.dart
@@ -63,6 +63,17 @@ class SyncService extends ChangeNotifier {
     }
   }
 
+  Future<void> pause() async {
+    if (!_syncing) return;
+    _client.backgroundSync = false;
+    await _client.abortSync();
+  }
+
+  void resume() {
+    if (_disposed || !_syncing) return;
+    _client.backgroundSync = true;
+  }
+
   void cancelSyncSub() {
     unawaited(_syncSub?.cancel());
     _syncSub = null;


### PR DESCRIPTION
## Summary

Fixes an iOS `RUNNINGBOARD 0xdead10cc` termination (seen in a TestFlight crash when switching apps): the process was suspended while a Matrix SDK SQLite write transaction still held a file lock on a data-protected store, because the app lifecycle handler never quiesced the sync loop on background.

## Changes

- `lib/core/services/sub_services/sync_service.dart`: add `pause()` / `resume()`. `pause()` sets `client.backgroundSync = false` and `await`s `client.abortSync()` so the in-flight `/sync` is cancelled and the SQLite lock is released; `resume()` re-enables the loop. Both guard on `_syncing` so they are no-ops when not syncing.
- `lib/core/services/matrix_service.dart`: drive them from `didChangeAppLifecycleState` — `pause()` on `paused`/`hidden`/`detached`, `resume()` on `resumed`. `inactive` is left untouched (transient state such as the app switcher / notification shade).

## Root cause

`audio`/`voip`/`remote-notification` background modes keep the process executing briefly after an app switch. During that window the SDK kept looping `/sync` and writing to SQLite — the persistent main store (`client_factory_native.dart`) and the App Group megolm key-mirror DB (`megolm_key_mirror.dart`). With nothing pausing it on background, a write transaction held a file lock when iOS suspended the process, so RunningBoard killed it with `0xdead10cc`. The crash threads corroborate: `flutter_vodozemac` (E2EE) threads blocked on mutex locks and a Flutter platform-channel decode in flight — i.e. encrypted-event processing was active at suspend time.

## Notifications / messages are unaffected

- Background notifications are delivered by the separate Notification Service Extension (`ios/KoheraNotificationService/NotificationService.swift`) via APNs push + network event fetch + megolm decryption — independent of `client.backgroundSync`.
- Background refresh in the push handlers uses `client.oneShotSync()` (`apns_push_service.dart`, `ios_voip_push_service.dart`), which runs even when `backgroundSync` is false and is not blocked by `pause()`.
- On `resumed`, `resume()` triggers an incremental catch-up `/sync` from the stored since-token, so nothing received while backgrounded is dropped.

## Testing

- [ ] `flutter analyze` is clean
- [ ] `flutter test` passes

No Flutter SDK is available in the environment these changes were authored in, so `flutter analyze` / `flutter test` were not run locally — please rely on CI. The new `backgroundSync` setter and `abortSync()` calls match the SDK API already exposed in the generated mocks (`test/**/*.mocks.dart`), and no `@GenerateNiceMocks` annotations changed, so mocks do not need regeneration.

## Linked issues

<!-- Add the tracking issue/epic refs if applicable. -->

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [ ] Tests added or updated to cover the change
- [x] Targets `master`

https://claude.ai/code/session_01VVyYgmJagCkfXEoWc2fnn2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVyYgmJagCkfXEoWc2fnn2)_