### PR TITLE
fix: reflect remaining unread in APNs badge on inbox mark-read

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -203,6 +203,10 @@ import UserNotifications
       case "clearBadge":
         UIApplication.shared.applicationIconBadgeNumber = 0
         result(nil)
+      case "setBadge":
+        let count = (call.arguments as? [String: Any])?["count"] as? Int ?? 0
+        UIApplication.shared.applicationIconBadgeNumber = count
+        result(nil)
       case "getAppGroupPath":
         let path = FileManager.default.containerURL(
           forSecurityApplicationGroupIdentifier: "group.io.github.quantumheart.kohera"

--- a/lib/core/utils/notification_filter.dart
+++ b/lib/core/utils/notification_filter.dart
@@ -4,6 +4,15 @@ import 'package:matrix/matrix.dart';
 
 // ── Notification-level-aware unread count ───────────────────
 
+/// Total unread notification count across all rooms.
+///
+/// Mirrors the server-computed APNs badge: the authoritative unread state
+/// shared across chat rooms, the inbox, and the OS app icon badge. Prefer
+/// this over any locally-cached subset (e.g. paged inbox notifications).
+int totalUnreadCount(Client client) => client.rooms
+    .where((r) => r.notificationCount > 0)
+    .fold<int>(0, (sum, r) => sum + r.notificationCount);
+
 /// Effective unread count filtered by the global notification level.
 /// Shared between the room list UI and the OS notification service.
 int effectiveUnreadCount(Room room, PreferencesService prefs) {

--- a/lib/features/notifications/services/apns_push_service.dart
+++ b/lib/features/notifications/services/apns_push_service.dart
@@ -213,6 +213,19 @@ class ApnsPushService {
     }
   }
 
+  static Future<void> setBadge(int count) async {
+    if (count <= 0) {
+      await clearBadge();
+      return;
+    }
+    if (!isNativeIOS) return;
+    try {
+      await _channel.invokeMethod<void>('setBadge', {'count': count});
+    } catch (e) {
+      debugPrint('[Kohera] Failed to set badge: $e');
+    }
+  }
+
   // ── Gateway resolution ───────────────────────────────────────
 
   String? get _gatewayUrl => AppConfig.instance.apnsPushGatewayUrl;

--- a/lib/features/notifications/services/inbox_controller.dart
+++ b/lib/features/notifications/services/inbox_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:kohera/core/utils/notification_filter.dart';
 import 'package:kohera/core/utils/word_boundary.dart';
 import 'package:kohera/features/notifications/services/apns_push_service.dart';
 import 'package:matrix/matrix.dart' as matrix_sdk;
@@ -290,7 +291,9 @@ class InboxController extends ChangeNotifier {
         if (g.roomId != roomId) g,
     ];
     _updateUnreadCount();
-    unawaited(ApnsPushService.clearBadge());
+    final remainingBadge =
+        (totalUnreadCount(_client) - room.notificationCount).clamp(0, 1 << 30);
+    unawaited(ApnsPushService.setBadge(remainingBadge));
     if (!_disposed) notifyListeners();
 
     final maxThreadTs = perThread.values.fold<int>(

--- a/lib/features/notifications/services/inbox_controller.dart
+++ b/lib/features/notifications/services/inbox_controller.dart
@@ -291,8 +291,8 @@ class InboxController extends ChangeNotifier {
         if (g.roomId != roomId) g,
     ];
     _updateUnreadCount();
-    final remainingBadge =
-        (totalUnreadCount(_client) - room.notificationCount).clamp(0, 1 << 30);
+    final remainingUnread = totalUnreadCount(_client) - room.notificationCount;
+    final remainingBadge = remainingUnread < 0 ? 0 : remainingUnread;
     unawaited(ApnsPushService.setBadge(remainingBadge));
     if (!_disposed) notifyListeners();
 

--- a/lib/features/notifications/services/notification_service.dart
+++ b/lib/features/notifications/services/notification_service.dart
@@ -490,9 +490,7 @@ class NotificationService {
     bool isGrouped = false,
   }) async {
     if (kIsWeb) {
-      final unreadCount = matrixService.client.rooms
-          .where((r) => r.notificationCount > 0)
-          .fold<int>(0, (sum, r) => sum + r.notificationCount);
+      final unreadCount = totalUnreadCount(matrixService.client);
       showWebNotification(
         title: title,
         body: senderName.isNotEmpty

--- a/test/utils/notification_filter_test.dart
+++ b/test/utils/notification_filter_test.dart
@@ -59,8 +59,8 @@ void main() {
       when(stillUnread.notificationCount).thenReturn(6);
       when(mockClient.rooms).thenReturn([read, stillUnread]);
 
-      final remaining =
-          (totalUnreadCount(mockClient) - read.notificationCount).clamp(0, 1 << 30);
+      final raw = totalUnreadCount(mockClient) - read.notificationCount;
+      final remaining = raw < 0 ? 0 : raw;
       expect(remaining, 6);
     });
   });

--- a/test/utils/notification_filter_test.dart
+++ b/test/utils/notification_filter_test.dart
@@ -31,6 +31,40 @@ void main() {
         .thenReturn(User(ownUserId, room: mockRoom, displayName: 'Me'));
   });
 
+  // ── totalUnreadCount ─────────────────────────────────────────
+
+  group('totalUnreadCount', () {
+    test('sums notificationCount across all rooms', () {
+      final r1 = MockRoom();
+      final r2 = MockRoom();
+      final r3 = MockRoom();
+      when(r1.notificationCount).thenReturn(3);
+      when(r2.notificationCount).thenReturn(0);
+      when(r3.notificationCount).thenReturn(7);
+      when(mockClient.rooms).thenReturn([r1, r2, r3]);
+      expect(totalUnreadCount(mockClient), 10);
+    });
+
+    test('returns 0 when no rooms have unread', () {
+      final r1 = MockRoom();
+      when(r1.notificationCount).thenReturn(0);
+      when(mockClient.rooms).thenReturn([r1]);
+      expect(totalUnreadCount(mockClient), 0);
+    });
+
+    test('reflects remaining count after one of several rooms is read', () {
+      final read = MockRoom();
+      final stillUnread = MockRoom();
+      when(read.notificationCount).thenReturn(4);
+      when(stillUnread.notificationCount).thenReturn(6);
+      when(mockClient.rooms).thenReturn([read, stillUnread]);
+
+      final remaining =
+          (totalUnreadCount(mockClient) - read.notificationCount).clamp(0, 1 << 30);
+      expect(remaining, 6);
+    });
+  });
+
   // ── effectiveUnreadCount ─────────────────────────────────────
 
   group('effectiveUnreadCount', () {


### PR DESCRIPTION
## Summary

Marking a single room as read in the Inbox cleared the iOS app icon badge unconditionally, misrepresenting unread state for other rooms until the next push arrived (#630). The badge now reflects the remaining unread count, derived from the shared server-truth (`room.notificationCount` across all rooms) rather than the inbox's locally-paged subset.

## Changes

- `core/utils/notification_filter.dart` — add `totalUnreadCount(client)`: authoritative unread total summed across all rooms.
- `notifications/services/apns_push_service.dart` — add `setBadge(int)` (routes to `clearBadge()` when `<= 0`).
- `ios/Runner/AppDelegate.swift` — handle a new `setBadge` method channel call.
- `notifications/services/inbox_controller.dart` — on `markRoomAsRead`, set the badge to `totalUnreadCount(_client) - room.notificationCount` (clamped) instead of blind-clearing. The optimistic update runs before the awaited `setReadMarker`, so the just-read room's stale count is subtracted explicitly.
- `notifications/services/notification_service.dart` — reuse `totalUnreadCount` in the web badge path (DRY).
- `test/utils/notification_filter_test.dart` — regression tests for `totalUnreadCount` and remaining-after-read.

## Testing

- `flutter analyze` — clean (5 changed files).
- `flutter test test/utils/notification_filter_test.dart test/services/inbox_controller_test.dart` — all pass.

## Notes

- `AppDelegate` uses `applicationIconBadgeNumber` (deprecated iOS 17+) to match the existing `clearBadge`; migrating both to `UNUserNotificationCenter.setBadgeCount` is left as a separate cleanup.

Closes #630

## Checklist

- [x] Code follows project conventions
- [x] Tests added/updated and passing
- [x] `flutter analyze` clean