### PR TITLE
fix(#639): own add-account pending service in a single shell

### DIFF
--- a/lib/core/routing/account_switch_redirector.dart
+++ b/lib/core/routing/account_switch_redirector.dart
@@ -12,13 +12,13 @@ import 'package:kohera/core/services/matrix_service.dart';
 /// `_dependents.isEmpty` assertion. Redirecting `/rooms/...` to `/` tears the
 /// chat subtree down cleanly before the swap reconciles.
 class AccountSwitchRedirector {
-  AccountSwitchRedirector(this._active);
+  AccountSwitchRedirector(this._activeService);
 
-  MatrixService _active;
+  MatrixService _activeService;
 
-  String? redirectFor(MatrixService current, String location) {
-    if (identical(current, _active)) return null;
-    _active = current;
+  String? redirectFor(MatrixService currentService, String location) {
+    if (identical(currentService, _activeService)) return null;
+    _activeService = currentService;
     return location.startsWith(RoutePaths.roomPrefix) ? RoutePaths.home : null;
   }
 }

--- a/lib/core/routing/account_switch_redirector.dart
+++ b/lib/core/routing/account_switch_redirector.dart
@@ -1,0 +1,24 @@
+import 'package:kohera/core/routing/route_names.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+
+/// Detects active-account switches and falls back to the room list when a
+/// room route is still mounted.
+///
+/// Switching accounts swaps the per-account providers ([MatrixService] and
+/// friends) for different instances while the keyed `ChatScreen` subtree is
+/// still mounted and depends on them via `context.watch`. Reconciling the
+/// keyed subtree onto the swapped providers deactivates an `InheritedElement`
+/// before its dependent is released, tripping the framework's
+/// `_dependents.isEmpty` assertion. Redirecting `/rooms/...` to `/` tears the
+/// chat subtree down cleanly before the swap reconciles.
+class AccountSwitchRedirector {
+  AccountSwitchRedirector(this._active);
+
+  MatrixService _active;
+
+  String? redirectFor(MatrixService current, String location) {
+    if (identical(current, _active)) return null;
+    _active = current;
+    return location.startsWith(RoutePaths.roomPrefix) ? RoutePaths.home : null;
+  }
+}

--- a/lib/core/routing/active_matrix_listenable.dart
+++ b/lib/core/routing/active_matrix_listenable.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/foundation.dart';
+import 'package:kohera/core/services/client_manager.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+
+/// A [Listenable] that forwards notifications from the currently active
+/// [MatrixService] (and its [ChatBackupService]), re-binding automatically
+/// when the active account changes. Lets the router use a stable
+/// `refreshListenable` across account switches.
+class ActiveMatrixListenable extends ChangeNotifier {
+  ActiveMatrixListenable(this._manager) {
+    _manager.addListener(_onManagerChanged);
+    _attach(_manager.activeService);
+  }
+
+  final ClientManager _manager;
+  MatrixService? _attached;
+
+  void _onManagerChanged() {
+    final next = _manager.activeService;
+    if (!identical(next, _attached)) {
+      _detach();
+      _attach(next);
+    }
+    notifyListeners();
+  }
+
+  void _attach(MatrixService service) {
+    service.addListener(notifyListeners);
+    service.chatBackup.addListener(notifyListeners);
+    _attached = service;
+  }
+
+  void _detach() {
+    final prev = _attached;
+    if (prev == null) return;
+    prev.removeListener(notifyListeners);
+    prev.chatBackup.removeListener(notifyListeners);
+    _attached = null;
+  }
+
+  @override
+  void dispose() {
+    _manager.removeListener(_onManagerChanged);
+    _detach();
+    super.dispose();
+  }
+}

--- a/lib/core/routing/active_matrix_listenable.dart
+++ b/lib/core/routing/active_matrix_listenable.dart
@@ -13,13 +13,13 @@ class ActiveMatrixListenable extends ChangeNotifier {
   }
 
   final ClientManager _manager;
-  MatrixService? _attached;
+  MatrixService? _attachedService;
 
   void _onManagerChanged() {
-    final next = _manager.activeService;
-    if (!identical(next, _attached)) {
+    final nextService = _manager.activeService;
+    if (!identical(nextService, _attachedService)) {
       _detach();
-      _attach(next);
+      _attach(nextService);
     }
     notifyListeners();
   }
@@ -27,15 +27,15 @@ class ActiveMatrixListenable extends ChangeNotifier {
   void _attach(MatrixService service) {
     service.addListener(notifyListeners);
     service.chatBackup.addListener(notifyListeners);
-    _attached = service;
+    _attachedService = service;
   }
 
   void _detach() {
-    final prev = _attached;
-    if (prev == null) return;
-    prev.removeListener(notifyListeners);
-    prev.chatBackup.removeListener(notifyListeners);
-    _attached = null;
+    final previousService = _attachedService;
+    if (previousService == null) return;
+    previousService.removeListener(notifyListeners);
+    previousService.chatBackup.removeListener(notifyListeners);
+    _attachedService = null;
   }
 
   @override

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -112,7 +112,7 @@ GoRouter buildRouter(ClientManager manager) {
       // shell never builds with a null one.
       ShellRoute(
         builder: (context, state, child) =>
-            AddAccountShell(manager: manager, child: child),
+            AddAccountShell(manager: manager, routerChild: child),
         routes: [
           GoRoute(
             path: RoutePaths.addAccount,

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -42,21 +42,29 @@ GoRouter buildRouter(ClientManager manager) {
   final switchRedirector = AccountSwitchRedirector(manager.activeService);
   return GoRouter(
     refreshListenable: refreshListenable,
-    initialLocation: '/',
+    initialLocation: RoutePaths.home,
     redirect: (context, state) {
       final matrixService = manager.activeService;
       final loggedIn = matrixService.isLoggedIn;
       final loc = state.matchedLocation;
-      final onAuthRoute =
-          loc.startsWith('/login') || loc.startsWith('/register');
-      final onSetupRoute = loc == '/e2ee-setup';
-      final onAddAccountRoute = loc.startsWith('/add-account');
+      final onAuthRoute = loc.startsWith(RoutePaths.login) ||
+          loc.startsWith(RoutePaths.register);
+      final onSetupRoute = loc == RoutePaths.e2eeSetup;
+      final onAddAccountRoute = loc.startsWith(RoutePaths.addAccount);
 
       final switchRedirect = switchRedirector.redirectFor(matrixService, loc);
       if (switchRedirect != null) return switchRedirect;
 
-      if (!loggedIn && !onAuthRoute) return '/login';
-      if (loggedIn && onAuthRoute && !onAddAccountRoute) return '/';
+      // The add-account flow drives login against a pending service. If there
+      // is none (genuine stray entry, or the moment after a successful commit
+      // clears it), there is nothing to add — leave the flow before any
+      // builder dereferences it.
+      if (onAddAccountRoute && manager.pendingService == null) {
+        return RoutePaths.home;
+      }
+
+      if (!loggedIn && !onAuthRoute) return RoutePaths.login;
+      if (loggedIn && onAuthRoute && !onAddAccountRoute) return RoutePaths.home;
 
       if (loggedIn &&
           !onSetupRoute &&
@@ -64,7 +72,7 @@ GoRouter buildRouter(ClientManager manager) {
           !onAddAccountRoute &&
           matrixService.chatBackup.chatBackupNeeded == true &&
           !matrixService.hasSkippedSetup) {
-        return '/e2ee-setup';
+        return RoutePaths.e2eeSetup;
       }
 
       return null;
@@ -72,97 +80,66 @@ GoRouter buildRouter(ClientManager manager) {
     routes: [
       // ── Auth routes ──────────────────────────────────────────
       GoRoute(
-        path: '/login',
+        path: RoutePaths.login,
         name: Routes.login,
         builder: (context, state) => HomeserverScreen(key: ValueKey(state.uri)),
         routes: [
           GoRoute(
             path: ':homeserver',
             name: Routes.loginServer,
-            builder: (context, state) {
-              final homeserver = state.pathParameters['homeserver']!;
-              final capabilities =
-                  state.extra as ServerAuthCapabilities? ??
-                      const ServerAuthCapabilities(supportsPassword: true);
-              return LoginScreen(
-                homeserver: homeserver,
-                capabilities: capabilities,
-              );
-            },
+            builder: (context, state) => LoginScreen(
+              homeserver: state.pathParameters['homeserver']!,
+              capabilities: _capabilitiesFrom(state),
+            ),
           ),
         ],
       ),
       GoRoute(
-        path: '/register',
+        path: RoutePaths.register,
         name: Routes.register,
-        builder: (context, state) {
-          final homeserver = state.extra as String? ??
-              context.read<PreferencesService>().defaultHomeserver ??
-              AppConfig.instance.defaultHomeserver;
-          return RegistrationScreen(initialHomeserver: homeserver);
-        },
+        builder: (context, state) =>
+            RegistrationScreen(initialHomeserver: _homeserverFrom(context, state)),
       ),
 
-      // ── Add-account login flow (outside shell) ──────────────
-      GoRoute(
-        path: '/add-account',
-        name: Routes.addAccount,
-        builder: (context, state) {
-          final manager = context.read<ClientManager>();
-          return _AddAccountGuard(
-            manager: manager,
-            child: ChangeNotifierProvider<MatrixService>.value(
-              value: manager.pendingService!,
-              child: const HomeserverScreen(isAddAccount: true),
-            ),
-          );
-        },
+      // ── Add-account login flow (outside the main app shell) ──
+      //
+      // A single shell owns the pending service for the whole flow: it
+      // provides the shadowed [MatrixService] once and cancels the pending
+      // service exactly when the flow is left (the shell is disposed). The
+      // top-level redirect handles entry without a pending service, so the
+      // shell never builds with a null one.
+      ShellRoute(
+        builder: (context, state, child) =>
+            _AddAccountShell(manager: manager, child: child),
         routes: [
           GoRoute(
-            path: 'register',
-            name: Routes.addAccountRegister,
-            builder: (context, state) {
-              final homeserver = state.extra as String? ??
-                  context.read<PreferencesService>().defaultHomeserver ??
-                  AppConfig.instance.defaultHomeserver;
-              final manager = context.read<ClientManager>();
-              return _AddAccountGuard(
-                manager: manager,
-                child: ChangeNotifierProvider<MatrixService>.value(
-                  value: manager.pendingService!,
-                  child: RegistrationScreen(initialHomeserver: homeserver),
-                ),
-              );
-            },
+            path: RoutePaths.addAccount,
+            name: Routes.addAccount,
+            builder: (context, state) =>
+                const HomeserverScreen(isAddAccount: true),
           ),
           GoRoute(
-            path: ':homeserver',
+            path: RoutePaths.addAccountRegister,
+            name: Routes.addAccountRegister,
+            builder: (context, state) => RegistrationScreen(
+              initialHomeserver: _homeserverFrom(context, state),
+            ),
+          ),
+          GoRoute(
+            path: RoutePaths.addAccountServer,
             name: Routes.addAccountServer,
-            builder: (context, state) {
-              final homeserver = state.pathParameters['homeserver']!;
-              final capabilities =
-                  state.extra as ServerAuthCapabilities? ??
-                      const ServerAuthCapabilities(supportsPassword: true);
-              final manager = context.read<ClientManager>();
-              return _AddAccountGuard(
-                manager: manager,
-                child: ChangeNotifierProvider<MatrixService>.value(
-                  value: manager.pendingService!,
-                  child: LoginScreen(
-                    homeserver: homeserver,
-                    capabilities: capabilities,
-                    isAddAccount: true,
-                  ),
-                ),
-              );
-            },
+            builder: (context, state) => LoginScreen(
+              homeserver: state.pathParameters['homeserver']!,
+              capabilities: _capabilitiesFrom(state),
+              isAddAccount: true,
+            ),
           ),
         ],
       ),
 
       // ── E2EE setup (full-page, outside shell) ────────────────
       GoRoute(
-        path: '/e2ee-setup',
+        path: RoutePaths.e2eeSetup,
         name: Routes.e2eeSetup,
         builder: (context, state) => const E2eeSetupScreen(),
       ),
@@ -173,7 +150,7 @@ GoRouter buildRouter(ClientManager manager) {
             HomeShell(routerChild: child, routerState: state),
         routes: [
           GoRoute(
-            path: '/',
+            path: RoutePaths.home,
             name: Routes.home,
             builder: (context, state) => const RoomList(),
             routes: [
@@ -406,17 +383,41 @@ class AccountSwitchRedirector {
   }
 }
 
-class _AddAccountGuard extends StatefulWidget {
-  const _AddAccountGuard({required this.manager, required this.child});
+/// Reads the homeserver for a registration route from the navigation extra,
+/// falling back to the user's preferred default and then the app default.
+String _homeserverFrom(BuildContext context, GoRouterState state) =>
+    state.extra as String? ??
+    context.read<PreferencesService>().defaultHomeserver ??
+    AppConfig.instance.defaultHomeserver;
+
+/// Reads the server capabilities for a login route from the navigation extra,
+/// falling back to password-only auth before a .well-known lookup completes.
+ServerAuthCapabilities _capabilitiesFrom(GoRouterState state) =>
+    state.extra as ServerAuthCapabilities? ??
+    const ServerAuthCapabilities(supportsPassword: true);
+
+/// Owns the pending-service lifecycle for the entire add-account flow.
+///
+/// As a [ShellRoute] host this widget persists across the entry, server, and
+/// register sub-routes and is disposed only when the flow is left, so it is
+/// the single place that:
+///   * provides the pending [MatrixService] to the shadowed subtree, and
+///   * cancels the pending service on exit (a no-op once committed).
+///
+/// Intra-flow navigation (including Back) no longer tears down the pending
+/// service, and the top-level redirect guarantees a pending service exists
+/// before this builds.
+class _AddAccountShell extends StatefulWidget {
+  const _AddAccountShell({required this.manager, required this.child});
 
   final ClientManager manager;
   final Widget child;
 
   @override
-  State<_AddAccountGuard> createState() => _AddAccountGuardState();
+  State<_AddAccountShell> createState() => _AddAccountShellState();
 }
 
-class _AddAccountGuardState extends State<_AddAccountGuard> {
+class _AddAccountShellState extends State<_AddAccountShell> {
   @override
   void dispose() {
     widget.manager.cancelPendingService();
@@ -424,7 +425,14 @@ class _AddAccountGuardState extends State<_AddAccountGuard> {
   }
 
   @override
-  Widget build(BuildContext context) => widget.child;
+  Widget build(BuildContext context) {
+    final pending = widget.manager.pendingService;
+    if (pending == null) return const SizedBox.shrink();
+    return ChangeNotifierProvider<MatrixService>.value(
+      value: pending,
+      child: widget.child,
+    );
+  }
 }
 
 class _AdaptiveCallScreen extends StatelessWidget {

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kohera/core/models/server_auth_capabilities.dart';
+import 'package:kohera/core/routing/account_switch_redirector.dart';
+import 'package:kohera/core/routing/active_matrix_listenable.dart';
 import 'package:kohera/core/routing/route_names.dart';
+import 'package:kohera/core/routing/widgets/add_account_shell.dart';
 import 'package:kohera/core/services/app_config.dart';
 import 'package:kohera/core/services/client_manager.dart';
 import 'package:kohera/core/services/matrix_service.dart';
@@ -9,8 +12,7 @@ import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/features/auth/screens/homeserver_screen.dart';
 import 'package:kohera/features/auth/screens/login_screen.dart';
 import 'package:kohera/features/auth/screens/registration_screen.dart';
-import 'package:kohera/features/calling/screens/call_pane.dart';
-import 'package:kohera/features/calling/screens/call_screen.dart';
+import 'package:kohera/features/calling/screens/adaptive_call_screen.dart';
 import 'package:kohera/features/chat/screens/chat_screen.dart';
 import 'package:kohera/features/chat/screens/thread_list_screen.dart';
 import 'package:kohera/features/chat/screens/thread_screen.dart';
@@ -38,7 +40,7 @@ import 'package:provider/provider.dart';
 /// [manager] so that account switches don't require recreating the router
 /// (which would reset the navigation stack and cause a visible flash).
 GoRouter buildRouter(ClientManager manager) {
-  final refreshListenable = _ActiveMatrixListenable(manager);
+  final refreshListenable = ActiveMatrixListenable(manager);
   final switchRedirector = AccountSwitchRedirector(manager.activeService);
   return GoRouter(
     refreshListenable: refreshListenable,
@@ -110,7 +112,7 @@ GoRouter buildRouter(ClientManager manager) {
       // shell never builds with a null one.
       ShellRoute(
         builder: (context, state, child) =>
-            _AddAccountShell(manager: manager, child: child),
+            AddAccountShell(manager: manager, child: child),
         routes: [
           GoRoute(
             path: RoutePaths.addAccount,
@@ -199,7 +201,7 @@ GoRouter buildRouter(ClientManager manager) {
                     name: Routes.call,
                     builder: (context, state) {
                       final roomId = state.pathParameters['roomId']!;
-                      return _AdaptiveCallScreen(roomId: roomId);
+                      return AdaptiveCallScreen(roomId: roomId);
                     },
                   ),
                   GoRoute(
@@ -317,72 +319,6 @@ GoRouter buildRouter(ClientManager manager) {
   );
 }
 
-/// A [Listenable] that forwards notifications from the currently active
-/// [MatrixService] (and its [ChatBackupService]), re-binding automatically
-/// when the active account changes. Lets the router use a stable
-/// `refreshListenable` across account switches.
-class _ActiveMatrixListenable extends ChangeNotifier {
-  _ActiveMatrixListenable(this._manager) {
-    _manager.addListener(_onManagerChanged);
-    _attach(_manager.activeService);
-  }
-
-  final ClientManager _manager;
-  MatrixService? _attached;
-
-  void _onManagerChanged() {
-    final next = _manager.activeService;
-    if (!identical(next, _attached)) {
-      _detach();
-      _attach(next);
-    }
-    notifyListeners();
-  }
-
-  void _attach(MatrixService service) {
-    service.addListener(notifyListeners);
-    service.chatBackup.addListener(notifyListeners);
-    _attached = service;
-  }
-
-  void _detach() {
-    final prev = _attached;
-    if (prev == null) return;
-    prev.removeListener(notifyListeners);
-    prev.chatBackup.removeListener(notifyListeners);
-    _attached = null;
-  }
-
-  @override
-  void dispose() {
-    _manager.removeListener(_onManagerChanged);
-    _detach();
-    super.dispose();
-  }
-}
-
-/// Detects active-account switches and falls back to the room list when a
-/// room route is still mounted.
-///
-/// Switching accounts swaps the per-account providers ([MatrixService] and
-/// friends) for different instances while the keyed `ChatScreen` subtree is
-/// still mounted and depends on them via `context.watch`. Reconciling the
-/// keyed subtree onto the swapped providers deactivates an `InheritedElement`
-/// before its dependent is released, tripping the framework's
-/// `_dependents.isEmpty` assertion. Redirecting `/rooms/...` to `/` tears the
-/// chat subtree down cleanly before the swap reconciles.
-class AccountSwitchRedirector {
-  AccountSwitchRedirector(this._active);
-
-  MatrixService _active;
-
-  String? redirectFor(MatrixService current, String location) {
-    if (identical(current, _active)) return null;
-    _active = current;
-    return location.startsWith('/rooms/') ? '/' : null;
-  }
-}
-
 /// Reads the homeserver for a registration route from the navigation extra,
 /// falling back to the user's preferred default and then the app default.
 String _homeserverFrom(BuildContext context, GoRouterState state) =>
@@ -395,61 +331,3 @@ String _homeserverFrom(BuildContext context, GoRouterState state) =>
 ServerAuthCapabilities _capabilitiesFrom(GoRouterState state) =>
     state.extra as ServerAuthCapabilities? ??
     const ServerAuthCapabilities(supportsPassword: true);
-
-/// Owns the pending-service lifecycle for the entire add-account flow.
-///
-/// As a [ShellRoute] host this widget persists across the entry, server, and
-/// register sub-routes and is disposed only when the flow is left, so it is
-/// the single place that:
-///   * provides the pending [MatrixService] to the shadowed subtree, and
-///   * cancels the pending service on exit (a no-op once committed).
-///
-/// Intra-flow navigation (including Back) no longer tears down the pending
-/// service, and the top-level redirect guarantees a pending service exists
-/// before this builds.
-class _AddAccountShell extends StatefulWidget {
-  const _AddAccountShell({required this.manager, required this.child});
-
-  final ClientManager manager;
-  final Widget child;
-
-  @override
-  State<_AddAccountShell> createState() => _AddAccountShellState();
-}
-
-class _AddAccountShellState extends State<_AddAccountShell> {
-  @override
-  void dispose() {
-    widget.manager.cancelPendingService();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final pending = widget.manager.pendingService;
-    if (pending == null) return const SizedBox.shrink();
-    return ChangeNotifierProvider<MatrixService>.value(
-      value: pending,
-      child: widget.child,
-    );
-  }
-}
-
-class _AdaptiveCallScreen extends StatelessWidget {
-  const _AdaptiveCallScreen({required this.roomId});
-
-  final String roomId;
-
-  @override
-  Widget build(BuildContext context) {
-    final isWide =
-        MediaQuery.sizeOf(context).width >= HomeShell.wideBreakpoint;
-    if (isWide) return const CallPane();
-    final room =
-        context.read<MatrixService>().client.getRoomById(roomId);
-    return CallScreen(
-      roomId: roomId,
-      displayName: room?.getLocalizedDisplayname() ?? 'Call',
-    );
-  }
-}

--- a/lib/core/routing/route_names.dart
+++ b/lib/core/routing/route_names.dart
@@ -1,3 +1,20 @@
+/// Absolute route paths for go_router navigation and redirect checks.
+///
+/// Use these instead of inline string literals so the path is defined once
+/// and `context.go(...)` calls stay in sync with the route table.
+abstract class RoutePaths {
+  static const home = '/';
+  static const login = '/login';
+  static const register = '/register';
+  static const e2eeSetup = '/e2ee-setup';
+  static const settingsRecoveryKey = '/settings/recovery-key';
+
+  // ── Add-account flow ──────────────────────────────────────────
+  static const addAccount = '/add-account';
+  static const addAccountRegister = '/add-account/register';
+  static const addAccountServer = '/add-account/:homeserver';
+}
+
 /// Named route constants for go_router navigation.
 abstract class Routes {
   static const login = 'login';

--- a/lib/core/routing/route_names.dart
+++ b/lib/core/routing/route_names.dart
@@ -4,6 +4,7 @@
 /// and `context.go(...)` calls stay in sync with the route table.
 abstract class RoutePaths {
   static const home = '/';
+  static const roomPrefix = '/rooms/';
   static const login = '/login';
   static const register = '/register';
   static const e2eeSetup = '/e2ee-setup';

--- a/lib/core/routing/widgets/add_account_shell.dart
+++ b/lib/core/routing/widgets/add_account_shell.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:kohera/core/services/client_manager.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:provider/provider.dart';
+
+/// Owns the pending-service lifecycle for the entire add-account flow.
+///
+/// As a [ShellRoute] host this widget persists across the entry, server, and
+/// register sub-routes and is disposed only when the flow is left, so it is
+/// the single place that:
+///   * provides the pending [MatrixService] to the shadowed subtree, and
+///   * cancels the pending service on exit (a no-op once committed).
+///
+/// Intra-flow navigation (including Back) no longer tears down the pending
+/// service, and the top-level redirect guarantees a pending service exists
+/// before this builds.
+class AddAccountShell extends StatefulWidget {
+  const AddAccountShell({
+    required this.manager,
+    required this.child,
+    super.key,
+  });
+
+  final ClientManager manager;
+  final Widget child;
+
+  @override
+  State<AddAccountShell> createState() => _AddAccountShellState();
+}
+
+class _AddAccountShellState extends State<AddAccountShell> {
+  @override
+  void dispose() {
+    widget.manager.cancelPendingService();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final pending = widget.manager.pendingService;
+    if (pending == null) return const SizedBox.shrink();
+    return ChangeNotifierProvider<MatrixService>.value(
+      value: pending,
+      child: widget.child,
+    );
+  }
+}

--- a/lib/core/routing/widgets/add_account_shell.dart
+++ b/lib/core/routing/widgets/add_account_shell.dart
@@ -17,12 +17,12 @@ import 'package:provider/provider.dart';
 class AddAccountShell extends StatefulWidget {
   const AddAccountShell({
     required this.manager,
-    required this.child,
+    required this.routerChild,
     super.key,
   });
 
   final ClientManager manager;
-  final Widget child;
+  final Widget routerChild;
 
   @override
   State<AddAccountShell> createState() => _AddAccountShellState();
@@ -41,7 +41,7 @@ class _AddAccountShellState extends State<AddAccountShell> {
     if (pending == null) return const SizedBox.shrink();
     return ChangeNotifierProvider<MatrixService>.value(
       value: pending,
-      child: widget.child,
+      child: widget.routerChild,
     );
   }
 }

--- a/lib/features/auth/screens/homeserver_screen.dart
+++ b/lib/features/auth/screens/homeserver_screen.dart
@@ -108,7 +108,7 @@ class _HomeserverScreenState extends State<HomeserverScreen>
               forceMaterialTransparency: true,
               leading: IconButton(
                 icon: const Icon(Icons.close),
-                onPressed: () => context.go('/'),
+                onPressed: () => context.go(RoutePaths.home),
               ),
             )
           : null,

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kohera/core/models/server_auth_capabilities.dart';
+import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/client_manager.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/features/auth/widgets/login_controller.dart';
@@ -69,7 +70,7 @@ class _LoginScreenState extends State<LoginScreen>
     if (_controller.state == LoginState.done) {
       // The router's redirect will automatically send us to '/'
       // once MatrixService.isLoggedIn becomes true.
-      context.go('/');
+      context.go(RoutePaths.home);
       return;
     }
     setState(() {});

--- a/lib/features/auth/screens/registration_screen.dart
+++ b/lib/features/auth/screens/registration_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/app_config.dart';
 import 'package:kohera/core/services/client_manager.dart';
 import 'package:kohera/core/services/matrix_service.dart';
@@ -85,7 +86,7 @@ class _RegistrationScreenState extends State<RegistrationScreen>
     if (_controller.state == RegistrationState.done) {
       // Registration complete — the router's redirect will send us
       // to '/' once MatrixService.isLoggedIn becomes true.
-      context.go('/');
+      context.go(RoutePaths.home);
       return;
     }
     setState(() {});

--- a/lib/features/calling/screens/adaptive_call_screen.dart
+++ b/lib/features/calling/screens/adaptive_call_screen.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/features/calling/screens/call_pane.dart';
+import 'package:kohera/features/calling/screens/call_screen.dart';
+import 'package:kohera/features/home/screens/home_shell.dart';
+import 'package:provider/provider.dart';
+
+/// Shows the embedded [CallPane] on wide layouts and the full-page
+/// [CallScreen] on narrow ones.
+class AdaptiveCallScreen extends StatelessWidget {
+  const AdaptiveCallScreen({required this.roomId, super.key});
+
+  final String roomId;
+
+  @override
+  Widget build(BuildContext context) {
+    final isWide = MediaQuery.sizeOf(context).width >= HomeShell.wideBreakpoint;
+    if (isWide) return const CallPane();
+    final room = context.read<MatrixService>().client.getRoomById(roomId);
+    return CallScreen(
+      roomId: roomId,
+      displayName: room?.getLocalizedDisplayname() ?? 'Call',
+    );
+  }
+}

--- a/lib/features/e2ee/screens/e2ee_setup_screen.dart
+++ b/lib/features/e2ee/screens/e2ee_setup_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart';
 import 'package:kohera/features/e2ee/widgets/bootstrap_controller.dart';
@@ -167,7 +168,7 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
   Future<void> _finishSetup() async {
     final shouldClearClipboard = _controller?.keyCopied ?? false;
     _matrixService.skipSetup();
-    if (mounted) context.go('/');
+    if (mounted) context.go(RoutePaths.home);
     if (shouldClearClipboard) {
       unawaited(Clipboard.setData(const ClipboardData(text: '')));
     }
@@ -175,7 +176,7 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
 
   void _skip() {
     _matrixService.skipSetup();
-    context.go('/');
+    context.go(RoutePaths.home);
   }
 
   // ── Build ─────────────────────────────────────────────────────
@@ -226,7 +227,7 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
                 leading: BackButton(
                   onPressed: () {
                     if (_localStep != null) {
-                      context.go('/');
+                      context.go(RoutePaths.home);
                     } else {
                       setState(() => _localStep = _ScreenStep.skipConfirm);
                     }
@@ -342,7 +343,7 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
                 onPressed: () async {
                   await _matrixService.chatBackup.disableChatBackup();
                   _matrixService.skipSetup();
-                  if (mounted) context.go('/');
+                  if (mounted) context.go(RoutePaths.home);
                 },
                 style: FilledButton.styleFrom(
                   backgroundColor: Theme.of(context).colorScheme.error,
@@ -398,7 +399,7 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             TextButton(
-              onPressed: () => context.go('/'),
+              onPressed: () => context.go(RoutePaths.home),
               child: const Text('Close'),
             ),
             FilledButton(
@@ -735,7 +736,7 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
           ),
           const SizedBox(height: 32),
           OutlinedButton(
-            onPressed: () => context.go('/settings/recovery-key'),
+            onPressed: () => context.go(RoutePaths.settingsRecoveryKey),
             child: const Text('Show recovery key'),
           ),
           const SizedBox(height: 8),

--- a/lib/features/e2ee/screens/show_recovery_key_screen.dart
+++ b/lib/features/e2ee/screens/show_recovery_key_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -171,7 +172,7 @@ class _ShowRecoveryKeyScreenState extends State<ShowRecoveryKeyScreen> {
           ),
           const SizedBox(height: 24),
           FilledButton(
-            onPressed: () => context.go('/e2ee-setup'),
+            onPressed: () => context.go(RoutePaths.e2eeSetup),
             child: const Text('Set up chat backup'),
           ),
           const SizedBox(height: 8),

--- a/lib/features/e2ee/widgets/key_backup_banner.dart
+++ b/lib/features/e2ee/widgets/key_backup_banner.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart';
 import 'package:provider/provider.dart';
 
@@ -37,7 +38,7 @@ class _KeyBackupBannerContent extends StatelessWidget {
         label: 'Key backup not set up. Tap to configure.',
         button: true,
         child: InkWell(
-          onTap: () => context.go('/e2ee-setup'),
+          onTap: () => context.go(RoutePaths.e2eeSetup),
           child: Container(
           constraints: const BoxConstraints(minHeight: 48),
           padding: const EdgeInsets.only(left: 12, right: 4),
@@ -82,7 +83,7 @@ class _KeyBackupBannerContent extends StatelessWidget {
                 ),
               ),
               TextButton(
-                onPressed: () => context.go('/e2ee-setup'),
+                onPressed: () => context.go(RoutePaths.e2eeSetup),
                 style: TextButton.styleFrom(
                   foregroundColor: cs.onTertiaryContainer,
                 ),

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -183,7 +183,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                               : 'Not set up',
                   onTap: matrix.chatBackup.chatBackupLoading
                       ? () {}
-                      : () => context.go('/e2ee-setup'),
+                      : () => context.go(RoutePaths.e2eeSetup),
                 ),
                 const Divider(height: 1, indent: 56),
                 _SettingsTile(
@@ -248,7 +248,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   Future<void> _addAccount(BuildContext context, ClientManager manager) async {
     await manager.createLoginService();
-    if (context.mounted) context.go('/add-account');
+    if (context.mounted) context.go(RoutePaths.addAccount);
   }
 
   void _confirmLogout(BuildContext context) {
@@ -296,7 +296,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             TextButton(
               onPressed: () {
                 Navigator.pop(ctx);
-                context.go('/e2ee-setup');
+                context.go(RoutePaths.e2eeSetup);
               },
               child: const Text('Set up backup first'),
             ),

--- a/test/core/account_switch_redirector_test.dart
+++ b/test/core/account_switch_redirector_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:kohera/core/routing/app_router.dart';
+import 'package:kohera/core/routing/account_switch_redirector.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:matrix/matrix.dart';
 import 'package:matrix/src/utils/cached_stream_controller.dart';


### PR DESCRIPTION
## Summary

Reaching any add-account route (`/add-account`, `/add-account/register`, `/add-account/:homeserver`) while `ClientManager.pendingService` was null crashed the screen with `Null check operator used on a null value` (`app_router.dart:132`). The builders dereferenced `pendingService!`, and each route's `_AddAccountGuard.dispose()` cancelled the pending service — so the value went null while a route was still mounted via two paths:

- **Commit:** a successful login/registration calls `commitPendingService()`, which nulls `pendingService` and notifies the router synchronously, rebuilding the still-current route against null.
- **Back navigation:** popping a sub-route disposed its guard, cancelling the pending service mid-flow.

A simple redirect-to-home was insufficient because it re-broke the #263 add-account flow (Back ejected the user to home).

## Changes

- Replace the three per-route `_AddAccountGuard`s with a single `_AddAccountShell` (`ShellRoute` host) that owns the whole flow: it provides the shadowed `MatrixService` once and cancels the pending service **only when the flow is left** (shell disposed). Intra-flow navigation, including Back, no longer tears it down.
- Guard entry in the top-level `redirect`: any add-account route with no pending service redirects home, so no builder ever dereferences a null `pendingService` (the `!` is gone). This also covers the post-commit window cleanly.
- Extract route path literals into `RoutePaths` constants and reuse them across the router and all `context.go(...)` call sites.
- Fold duplicated homeserver / capabilities resolution into `_homeserverFrom` / `_capabilitiesFrom` helpers.

## Testing

- `flutter analyze` — no issues.
- `flutter test test/core/account_switch_redirector_test.dart` — passes.

Flows verified by trace: entry, forward nav, intra-flow Back, commit-success (login + registration), abandon, and stray deep-link entry.

## Linked issues

Closes #639
