### PR TITLE
refactor: extract route path segments and param keys to constants

### DIFF
--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -87,10 +87,10 @@ GoRouter buildRouter(ClientManager manager) {
         builder: (context, state) => HomeserverScreen(key: ValueKey(state.uri)),
         routes: [
           GoRoute(
-            path: ':homeserver',
+            path: RouteSegments.loginServer,
             name: Routes.loginServer,
             builder: (context, state) => LoginScreen(
-              homeserver: state.pathParameters['homeserver']!,
+              homeserver: state.pathParameters[RouteParams.homeserver]!,
               capabilities: _capabilitiesFrom(state),
             ),
           ),
@@ -131,7 +131,7 @@ GoRouter buildRouter(ClientManager manager) {
             path: RoutePaths.addAccountServer,
             name: Routes.addAccountServer,
             builder: (context, state) => LoginScreen(
-              homeserver: state.pathParameters['homeserver']!,
+              homeserver: state.pathParameters[RouteParams.homeserver]!,
               capabilities: _capabilitiesFrom(state),
               isAddAccount: true,
             ),
@@ -157,10 +157,10 @@ GoRouter buildRouter(ClientManager manager) {
             builder: (context, state) => const RoomList(),
             routes: [
               GoRoute(
-                path: 'rooms/:roomId',
+                path: RouteSegments.room,
                 name: Routes.room,
                 builder: (context, state) {
-                  final roomId = state.pathParameters['roomId']!;
+                  final roomId = state.pathParameters[RouteParams.roomId]!;
                   final eventId = state.extra as String?;
                   return ChatScreen(
                     roomId: roomId,
@@ -172,10 +172,10 @@ GoRouter buildRouter(ClientManager manager) {
                 },
                 routes: [
                   GoRoute(
-                    path: 'details',
+                    path: RouteSegments.roomDetails,
                     name: Routes.roomDetails,
                     builder: (context, state) {
-                      final roomId = state.pathParameters['roomId']!;
+                      final roomId = state.pathParameters[RouteParams.roomId]!;
                       return RoomDetailsPanel(
                         roomId: roomId,
                         isFullPage: true,
@@ -184,10 +184,10 @@ GoRouter buildRouter(ClientManager manager) {
                     },
                     routes: [
                       GoRoute(
-                        path: 'permissions',
+                        path: RouteSegments.roomPermissions,
                         name: Routes.roomPermissions,
                         builder: (context, state) {
-                          final roomId = state.pathParameters['roomId']!;
+                          final roomId = state.pathParameters[RouteParams.roomId]!;
                           return RoomPermissionsScreen(
                             roomId: roomId,
                             key: ValueKey('permissions-$roomId'),
@@ -197,19 +197,19 @@ GoRouter buildRouter(ClientManager manager) {
                     ],
                   ),
                   GoRoute(
-                    path: 'call',
+                    path: RouteSegments.call,
                     name: Routes.call,
                     builder: (context, state) {
-                      final roomId = state.pathParameters['roomId']!;
+                      final roomId = state.pathParameters[RouteParams.roomId]!;
                       return AdaptiveCallScreen(roomId: roomId);
                     },
                   ),
                   GoRoute(
-                    path: 'thread/:eventId',
+                    path: RouteSegments.roomThread,
                     name: Routes.roomThread,
                     builder: (context, state) {
-                      final roomId = state.pathParameters['roomId']!;
-                      final eventId = state.pathParameters['eventId']!;
+                      final roomId = state.pathParameters[RouteParams.roomId]!;
+                      final eventId = state.pathParameters[RouteParams.eventId]!;
                       return ThreadScreen(
                         roomId: roomId,
                         threadRootEventId: eventId,
@@ -218,18 +218,18 @@ GoRouter buildRouter(ClientManager manager) {
                     },
                   ),
                   GoRoute(
-                    path: 'threads',
+                    path: RouteSegments.roomThreads,
                     name: Routes.roomThreads,
                     builder: (context, state) {
-                      final roomId = state.pathParameters['roomId']!;
+                      final roomId = state.pathParameters[RouteParams.roomId]!;
                       return ThreadListScreen(
                         roomId: roomId,
                         key: ValueKey('threads-$roomId'),
                         onOpenThread: (eventId) =>
                             context.pushNamed(Routes.roomThread,
                                 pathParameters: {
-                                  'roomId': roomId,
-                                  'eventId': eventId,
+                                  RouteParams.roomId: roomId,
+                                  RouteParams.eventId: eventId,
                                 },),
                       );
                     },
@@ -237,15 +237,15 @@ GoRouter buildRouter(ClientManager manager) {
                 ],
               ),
               GoRoute(
-                path: 'spaces',
+                path: RouteSegments.spaces,
                 name: Routes.spaces,
                 builder: (context, state) => const SizedBox.shrink(),
               ),
               GoRoute(
-                path: 'spaces/:spaceId/details',
+                path: RouteSegments.spaceDetails,
                 name: Routes.spaceDetails,
                 builder: (context, state) {
-                  final spaceId = state.pathParameters['spaceId']!;
+                  final spaceId = state.pathParameters[RouteParams.spaceId]!;
                   return SpaceDetailsPanel(
                     spaceId: spaceId,
                     isFullPage: true,
@@ -254,57 +254,57 @@ GoRouter buildRouter(ClientManager manager) {
                 },
               ),
               GoRoute(
-                path: 'inbox',
+                path: RouteSegments.inbox,
                 name: Routes.inbox,
                 builder: (context, state) => const InboxScreen(),
               ),
               GoRoute(
-                path: 'whats-new',
+                path: RouteSegments.whatsNew,
                 name: Routes.whatsNew,
                 builder: (context, state) => const WhatsNewScreen(),
               ),
               GoRoute(
-                path: 'settings',
+                path: RouteSegments.settings,
                 name: Routes.settings,
                 builder: (context, state) => const SettingsScreen(),
                 routes: [
                   GoRoute(
-                    path: 'appearance',
+                    path: RouteSegments.settingsAppearance,
                     name: Routes.settingsAppearance,
                     builder: (context, state) =>
                         const AppearanceScreen(),
                   ),
                   GoRoute(
-                    path: 'notifications',
+                    path: RouteSegments.settingsNotifications,
                     name: Routes.settingsNotifications,
                     builder: (context, state) =>
                         const NotificationSettingsScreen(),
                   ),
                   GoRoute(
-                    path: 'devices',
+                    path: RouteSegments.settingsDevices,
                     name: Routes.settingsDevices,
                     builder: (context, state) => const DevicesScreen(),
                   ),
                   GoRoute(
-                    path: 'voice-video',
+                    path: RouteSegments.settingsVoiceVideo,
                     name: Routes.settingsVoiceVideo,
                     builder: (context, state) =>
                         const VoiceVideoSettingsScreen(),
                   ),
                   GoRoute(
-                    path: 'recovery-key',
+                    path: RouteSegments.settingsRecoveryKey,
                     name: Routes.settingsRecoveryKey,
                     builder: (context, state) =>
                         const ShowRecoveryKeyScreen(),
                   ),
                   GoRoute(
-                    path: 'sticker-packs',
+                    path: RouteSegments.settingsStickerPacks,
                     name: Routes.settingsStickerPacks,
                     builder: (context, state) =>
                         const StickerPacksScreen(),
                   ),
                   GoRoute(
-                    path: 'emoji-gg-browse',
+                    path: RouteSegments.settingsEmojiGgBrowse,
                     name: Routes.settingsEmojiGgBrowse,
                     builder: (context, state) =>
                         const EmojiGgBrowseScreen(),

--- a/lib/core/routing/route_names.dart
+++ b/lib/core/routing/route_names.dart
@@ -1,3 +1,14 @@
+/// Path-parameter keys used in route definitions and `pathParameters` maps.
+///
+/// Defined once so the `:key` in a route path stays in sync with every
+/// `state.pathParameters['key']` read and `pathParameters: {'key': ...}` write.
+abstract class RouteParams {
+  static const roomId = 'roomId';
+  static const homeserver = 'homeserver';
+  static const eventId = 'eventId';
+  static const spaceId = 'spaceId';
+}
+
 /// Absolute route paths for go_router navigation and redirect checks.
 ///
 /// Use these instead of inline string literals so the path is defined once
@@ -13,7 +24,33 @@ abstract class RoutePaths {
   // ── Add-account flow ──────────────────────────────────────────
   static const addAccount = '/add-account';
   static const addAccountRegister = '/add-account/register';
-  static const addAccountServer = '/add-account/:homeserver';
+  static const addAccountServer = '/add-account/:${RouteParams.homeserver}';
+}
+
+/// Relative path segments for nested `GoRoute` definitions.
+///
+/// Nested sub-routes must use relative segments (a child `path` may not start
+/// with `/`), so these complement the absolute [RoutePaths].
+abstract class RouteSegments {
+  static const loginServer = ':${RouteParams.homeserver}';
+  static const room = 'rooms/:${RouteParams.roomId}';
+  static const roomDetails = 'details';
+  static const roomPermissions = 'permissions';
+  static const call = 'call';
+  static const roomThread = 'thread/:${RouteParams.eventId}';
+  static const roomThreads = 'threads';
+  static const spaces = 'spaces';
+  static const spaceDetails = 'spaces/:${RouteParams.spaceId}/details';
+  static const inbox = 'inbox';
+  static const whatsNew = 'whats-new';
+  static const settings = 'settings';
+  static const settingsAppearance = 'appearance';
+  static const settingsNotifications = 'notifications';
+  static const settingsDevices = 'devices';
+  static const settingsVoiceVideo = 'voice-video';
+  static const settingsRecoveryKey = 'recovery-key';
+  static const settingsStickerPacks = 'sticker-packs';
+  static const settingsEmojiGgBrowse = 'emoji-gg-browse';
 }
 
 /// Named route constants for go_router navigation.

--- a/lib/features/auth/screens/homeserver_screen.dart
+++ b/lib/features/auth/screens/homeserver_screen.dart
@@ -82,7 +82,7 @@ class _HomeserverScreenState extends State<HomeserverScreen>
     );
     context.goNamed(
       widget.isAddAccount ? Routes.addAccountServer : Routes.loginServer,
-      pathParameters: {'homeserver': text},
+      pathParameters: {RouteParams.homeserver: text},
       extra: caps,
     );
   }

--- a/lib/features/calling/screens/call_pane.dart
+++ b/lib/features/calling/screens/call_pane.dart
@@ -58,7 +58,7 @@ class CallPane extends StatelessWidget {
               icon: const Icon(Icons.arrow_back_rounded),
               onPressed: () => context.goNamed(
                 Routes.room,
-                pathParameters: {'roomId': roomId},
+                pathParameters: {RouteParams.roomId: roomId},
               ),
             ),
             title: Text(_resolveRoomName(context, callService)),

--- a/lib/features/calling/screens/call_screen.dart
+++ b/lib/features/calling/screens/call_screen.dart
@@ -66,7 +66,7 @@ class _CallScreenState extends State<CallScreen> {
           icon: const Icon(Icons.arrow_back_rounded),
           onPressed: () => context.popOrGo(
             Routes.room,
-            pathParameters: {'roomId': widget.roomId},
+            pathParameters: {RouteParams.roomId: widget.roomId},
           ),
         ),
         title: Text(widget.displayName),

--- a/lib/features/calling/services/call_navigator.dart
+++ b/lib/features/calling/services/call_navigator.dart
@@ -37,7 +37,7 @@ abstract class CallNavigator {
     if (context.mounted) {
       context.pushOrGo(
         Routes.call,
-        pathParameters: {'roomId': roomId},
+        pathParameters: {RouteParams.roomId: roomId},
       );
     }
   }
@@ -47,7 +47,7 @@ abstract class CallNavigator {
     if (id != null && context.mounted) {
       context.pushOrGo(
         Routes.call,
-        pathParameters: {'roomId': id},
+        pathParameters: {RouteParams.roomId: id},
       );
     }
   }

--- a/lib/features/calling/widgets/incoming_call_overlay.dart
+++ b/lib/features/calling/widgets/incoming_call_overlay.dart
@@ -45,7 +45,7 @@ class _IncomingCallOverlayState extends State<IncomingCallOverlay> {
         if (mounted) {
           widget.router.goNamed(
             Routes.call,
-            pathParameters: {'roomId': roomId},
+            pathParameters: {RouteParams.roomId: roomId},
           );
         }
       });
@@ -96,7 +96,7 @@ class _IncomingCallOverlayState extends State<IncomingCallOverlay> {
     if (roomId != null) {
       widget.router.goNamed(
         Routes.call,
-        pathParameters: {'roomId': roomId},
+        pathParameters: {RouteParams.roomId: roomId},
       );
     }
   }

--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -231,8 +231,8 @@ class _ChatScreenState extends State<ChatScreen>
     unawaited(context.pushNamed(
       Routes.roomThread,
       pathParameters: {
-        'roomId': widget.roomId,
-        'eventId': rootEvent.eventId,
+        RouteParams.roomId: widget.roomId,
+        RouteParams.eventId: rootEvent.eventId,
       },
     ),);
   }
@@ -255,7 +255,7 @@ class _ChatScreenState extends State<ChatScreen>
     }
     unawaited(context.pushNamed(
       Routes.roomThreads,
-      pathParameters: {'roomId': widget.roomId},
+      pathParameters: {RouteParams.roomId: widget.roomId},
     ),);
   }
 

--- a/lib/features/chat/widgets/chat_app_bar.dart
+++ b/lib/features/chat/widgets/chat_app_bar.dart
@@ -151,7 +151,7 @@ class ChatAppBar extends StatelessWidget implements PreferredSizeWidget {
                   } else {
                     context.pushOrGo(
                       Routes.roomDetails,
-                      pathParameters: {'roomId': room.id},
+                      pathParameters: {RouteParams.roomId: room.id},
                     );
                   }
               }
@@ -338,7 +338,7 @@ class _CallButtonState extends State<_CallButton> {
           if (value == 'go') {
             context.pushOrGo(
               Routes.call,
-              pathParameters: {'roomId': widget.room.id},
+              pathParameters: {RouteParams.roomId: widget.room.id},
             );
           } else if (value == 'leave') {
             unawaited(CallNavigator.endCall(context));

--- a/lib/features/chat/widgets/state_event_tile.dart
+++ b/lib/features/chat/widgets/state_event_tile.dart
@@ -78,7 +78,7 @@ class StateEventTile extends StatelessWidget {
       if (existing == null) {
         await matrix.client.joinRoom(replacement);
       }
-      router.goNamed(Routes.room, pathParameters: {'roomId': replacement});
+      router.goNamed(Routes.room, pathParameters: {RouteParams.roomId: replacement});
     } catch (e) {
       debugPrint('[Kohera] Failed to open replacement room: $e');
       scaffold.showSnackBar(

--- a/lib/features/home/screens/home_shell.dart
+++ b/lib/features/home/screens/home_shell.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/call_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/calling/widgets/voice_banner.dart';
@@ -35,7 +36,7 @@ class _HomeShellState extends State<HomeShell> {
 
   // ── Route → MatrixService sync ──────────────────────────────
 
-  String? get _routeRoomId => widget.routerState.pathParameters['roomId'];
+  String? get _routeRoomId => widget.routerState.pathParameters[RouteParams.roomId];
   String? get _routeName => widget.routerState.topRoute?.name;
 
   void _syncRoomSelection() {
@@ -55,7 +56,7 @@ class _HomeShellState extends State<HomeShell> {
   @override
   void didUpdateWidget(covariant HomeShell old) {
     super.didUpdateWidget(old);
-    final oldRoomId = old.routerState.pathParameters['roomId'];
+    final oldRoomId = old.routerState.pathParameters[RouteParams.roomId];
     final newRoomId = _routeRoomId;
 
     if (oldRoomId != newRoomId) {

--- a/lib/features/home/widgets/inbox_screen.dart
+++ b/lib/features/home/widgets/inbox_screen.dart
@@ -245,14 +245,14 @@ class _NotificationGroupTile extends StatelessWidget {
                         context.goNamed(
                           Routes.roomThread,
                           pathParameters: {
-                            'roomId': group.roomId,
-                            'eventId': singleThread,
+                            RouteParams.roomId: group.roomId,
+                            RouteParams.eventId: singleThread,
                           },
                         );
                       } else {
                         context.goNamed(
                           Routes.room,
-                          pathParameters: {'roomId': group.roomId},
+                          pathParameters: {RouteParams.roomId: group.roomId},
                         );
                       }
                     },
@@ -408,14 +408,14 @@ class _NotificationTile extends StatelessWidget {
           context.goNamed(
             Routes.roomThread,
             pathParameters: {
-              'roomId': notification.roomId,
-              'eventId': tid,
+              RouteParams.roomId: notification.roomId,
+              RouteParams.eventId: tid,
             },
           );
         } else {
           context.goNamed(
             Routes.room,
-            pathParameters: {'roomId': notification.roomId},
+            pathParameters: {RouteParams.roomId: notification.roomId},
           );
         }
       },

--- a/lib/features/notifications/services/notification_service.dart
+++ b/lib/features/notifications/services/notification_service.dart
@@ -639,7 +639,7 @@ class NotificationService {
 
   void navigateToRoom(String roomId) {
     if (router != null) {
-      router!.goNamed(Routes.room, pathParameters: {'roomId': roomId});
+      router!.goNamed(Routes.room, pathParameters: {RouteParams.roomId: roomId});
     } else {
       matrixService.selection.selectRoom(roomId);
     }

--- a/lib/features/notifications/services/web_push_service.dart
+++ b/lib/features/notifications/services/web_push_service.dart
@@ -191,7 +191,7 @@ class WebPushService {
             final roomId = obj.getProperty<JSString>('roomId'.toJS).toDart;
             if (roomId.isNotEmpty) {
               if (router != null) {
-                router!.goNamed(Routes.room, pathParameters: {'roomId': roomId});
+                router!.goNamed(Routes.room, pathParameters: {RouteParams.roomId: roomId});
               } else {
                 matrixService.selection.selectRoom(roomId);
               }

--- a/lib/features/rooms/widgets/admin_settings_section.dart
+++ b/lib/features/rooms/widgets/admin_settings_section.dart
@@ -218,7 +218,7 @@ class _AdminSettingsSectionState extends State<AdminSettingsSection> {
           trailing: const Icon(Icons.chevron_right_rounded),
           onTap: () => context.goNamed(
             Routes.roomPermissions,
-            pathParameters: {'roomId': room.id},
+            pathParameters: {RouteParams.roomId: room.id},
           ),
         ),
 

--- a/lib/features/rooms/widgets/invite_tile.dart
+++ b/lib/features/rooms/widgets/invite_tile.dart
@@ -47,7 +47,7 @@ class _InviteTileState extends State<InviteTile> {
       // Timeout is fine — the join already succeeded server-side.
     }
     if (mounted) {
-      context.goNamed(Routes.room, pathParameters: {'roomId': widget.room.id});
+      context.goNamed(Routes.room, pathParameters: {RouteParams.roomId: widget.room.id});
       setState(() => _isJoining = false);
     }
   }

--- a/lib/features/rooms/widgets/join_access_controller.dart
+++ b/lib/features/rooms/widgets/join_access_controller.dart
@@ -231,7 +231,7 @@ class _JoinAccessControllerState extends State<JoinAccessController> {
       if (mounted) {
         context.goNamed(
           Routes.room,
-          pathParameters: {'roomId': newRoomId},
+          pathParameters: {RouteParams.roomId: newRoomId},
         );
       }
     } catch (e) {

--- a/lib/features/rooms/widgets/message_search_tiles.dart
+++ b/lib/features/rooms/widgets/message_search_tiles.dart
@@ -85,7 +85,7 @@ class MessageSearchResultTile extends StatelessWidget {
           mouseCursor: SystemMouseCursors.click,
           onTap: () => context.goNamed(
             Routes.room,
-            pathParameters: {'roomId': result.roomId},
+            pathParameters: {RouteParams.roomId: result.roomId},
             extra: result.eventId,
           ),
           child: Padding(

--- a/lib/features/rooms/widgets/room_details_panel.dart
+++ b/lib/features/rooms/widgets/room_details_panel.dart
@@ -178,7 +178,7 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
             icon: const Icon(Icons.arrow_back),
             onPressed: () => context.popOrGo(
               Routes.room,
-              pathParameters: {'roomId': widget.roomId},
+              pathParameters: {RouteParams.roomId: widget.roomId},
             ),
           ),
           title: Text(room.getLocalizedDisplayname()),

--- a/lib/features/rooms/widgets/room_members_section.dart
+++ b/lib/features/rooms/widgets/room_members_section.dart
@@ -303,7 +303,7 @@ class _MemberTileState extends State<_MemberTile> {
                   selection.selectRoom(dmRoomId);
                   router.goNamed(
                     Routes.room,
-                    pathParameters: {'roomId': dmRoomId},
+                    pathParameters: {RouteParams.roomId: dmRoomId},
                   );
                 } catch (e) {
                   debugPrint('[Kohera] Start DM failed: $e');

--- a/lib/features/rooms/widgets/room_tile.dart
+++ b/lib/features/rooms/widgets/room_tile.dart
@@ -118,7 +118,7 @@ class _RoomTileState extends State<RoomTile> {
         child: InkWell(
           borderRadius: BorderRadius.circular(14),
           mouseCursor: SystemMouseCursors.click,
-          onTap: () => context.goNamed(Routes.room, pathParameters: {'roomId': room.id}),
+          onTap: () => context.goNamed(Routes.room, pathParameters: {RouteParams.roomId: room.id}),
           onSecondaryTapUp: hasMenu
               ? (details) {
                   final overlay = Overlay.of(context).context

--- a/lib/features/spaces/widgets/space_context_menu.dart
+++ b/lib/features/spaces/widgets/space_context_menu.dart
@@ -163,7 +163,7 @@ Future<void> showSpaceContextMenu(
       if (context.mounted) {
         context.goNamed(
           Routes.spaceDetails,
-          pathParameters: {'spaceId': space.id},
+          pathParameters: {RouteParams.spaceId: space.id},
         );
       }
     case SpaceContextAction.createSubspace:

--- a/test/e2e/chat_screen_test.dart
+++ b/test/e2e/chat_screen_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/call_service.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/preferences_service.dart';
@@ -134,9 +135,9 @@ void main() {
       initialLocation: '/rooms/$roomId',
       routes: [
         GoRoute(
-          path: '/rooms/:roomId',
+          path: '/${RouteSegments.room}',
           builder: (_, state) =>
-              ChatScreen(roomId: state.pathParameters['roomId']!),
+              ChatScreen(roomId: state.pathParameters[RouteParams.roomId]!),
           routes: [
             GoRoute(
               path: 'details',

--- a/test/e2e/login_flow_test.dart
+++ b/test/e2e/login_flow_test.dart
@@ -223,10 +223,10 @@ void main() {
           builder: (context, state) => const HomeserverScreen(),
           routes: [
             GoRoute(
-              path: ':homeserver',
+              path: RouteSegments.loginServer,
               name: Routes.loginServer,
               builder: (context, state) {
-                final homeserver = state.pathParameters['homeserver']!;
+                final homeserver = state.pathParameters[RouteParams.homeserver]!;
                 final capabilities = state.extra as ServerAuthCapabilities? ??
                     const ServerAuthCapabilities(supportsPassword: true);
                 return LoginScreen(

--- a/test/screens/homeserver_screen_test.dart
+++ b/test/screens/homeserver_screen_test.dart
@@ -92,10 +92,10 @@ void main() {
           builder: (context, state) => const HomeserverScreen(),
           routes: [
             GoRoute(
-              path: ':homeserver',
+              path: RouteSegments.loginServer,
               name: Routes.loginServer,
               builder: (context, state) {
-                final homeserver = state.pathParameters['homeserver']!;
+                final homeserver = state.pathParameters[RouteParams.homeserver]!;
                 final capabilities =
                     state.extra as ServerAuthCapabilities? ??
                         const ServerAuthCapabilities(supportsPassword: true);

--- a/test/widgets/invite_tile_test.dart
+++ b/test/widgets/invite_tile_test.dart
@@ -83,12 +83,12 @@ void main() {
           builder: (context, state) => const Scaffold(body: RoomList()),
           routes: [
             GoRoute(
-              path: 'rooms/:roomId',
+              path: RouteSegments.room,
               name: Routes.room,
               builder: (context, state) {
-                lastNavigatedRoom = state.pathParameters['roomId'];
+                lastNavigatedRoom = state.pathParameters[RouteParams.roomId];
                 return Scaffold(
-                  body: Text('Room ${state.pathParameters['roomId']}'),
+                  body: Text('Room ${state.pathParameters[RouteParams.roomId]}'),
                 );
               },
             ),

--- a/test/widgets/message_search_tiles_test.dart
+++ b/test/widgets/message_search_tiles_test.dart
@@ -19,12 +19,12 @@ void main() {
           builder: (context, state) => Scaffold(body: child),
           routes: [
             GoRoute(
-              path: 'rooms/:roomId',
+              path: RouteSegments.room,
               name: Routes.room,
               builder: (context, state) {
-                lastNavigatedRoom = state.pathParameters['roomId'];
+                lastNavigatedRoom = state.pathParameters[RouteParams.roomId];
                 return Scaffold(
-                  body: Text('Room ${state.pathParameters['roomId']}'),
+                  body: Text('Room ${state.pathParameters[RouteParams.roomId]}'),
                 );
               },
             ),

--- a/test/widgets/room_tile_test.dart
+++ b/test/widgets/room_tile_test.dart
@@ -105,12 +105,12 @@ void main() {
           ),
           routes: [
             GoRoute(
-              path: 'rooms/:roomId',
+              path: RouteSegments.room,
               name: Routes.room,
               builder: (context, state) {
-                lastNavigatedRoom = state.pathParameters['roomId'];
+                lastNavigatedRoom = state.pathParameters[RouteParams.roomId];
                 return Scaffold(
-                  body: Text('Room ${state.pathParameters['roomId']}'),
+                  body: Text('Room ${state.pathParameters[RouteParams.roomId]}'),
                 );
               },
             ),

--- a/test/widgets/space_context_menu_test.dart
+++ b/test/widgets/space_context_menu_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/spaces/widgets/space_context_menu.dart';
@@ -296,10 +297,10 @@ void main() {
             ),
           ),
           GoRoute(
-            path: '/spaces/:spaceId/details',
+            path: '/${RouteSegments.spaceDetails}',
             name: 'space-details',
             builder: (context, state) => Scaffold(
-              body: Text('Space details for ${state.pathParameters['spaceId']}'),
+              body: Text('Space details for ${state.pathParameters[RouteParams.spaceId]}'),
             ),
           ),
         ],


### PR DESCRIPTION
## Summary

Extracts the remaining inline route magic strings into constants: the nested `GoRoute` path **segments** (`'rooms/:roomId'`, `'details'`, `'settings'`, `':homeserver'`, …) and the path-**parameter keys** (`'roomId'`, `'homeserver'`, `'eventId'`, `'spaceId'`) that were read via `state.pathParameters['roomId']` and written via `pathParameters: {'roomId': ...}` across ~20 feature files. A typo in any one silently broke navigation; now each is defined once.

> **Stacked on #653.** This branch is based on `fix/639-add-account-null-pending`, so until that PR merges this PR's diff also shows its commits. The route-constants work is the final commit (`73613ecf`). Merge #653 first.

## Changes

- `route_names.dart`: add `RouteParams` (the 4 param keys) and `RouteSegments` (relative segments for nested routes). Each segment is **composed** from its param key (`'rooms/:${RouteParams.roomId}'`) so the key has a single source of truth; `RoutePaths.addAccountServer` reuses it too.
- `app_router.dart`: every nested `path:` literal → `RouteSegments.*`; every `state.pathParameters[...]` read and `pathParameters` write → `RouteParams.*`.
- ~20 feature files + `home_shell.dart`: route `pathParameters` keys → `RouteParams.*`.
- Navigation tests updated to use the same constants.
- Deliberately untouched (same-named but not route params): JSON keys in `session_backup.dart`, secure-storage keys, native/platform args maps, JS interop, and mockito `anyNamed(...)` matchers.

## Testing

- `flutter analyze` — no issues.
- `flutter test` — full suite, 1997 passing.

## Linked issues

Refs #639
