### PR TITLE
feat: apply the mushroom theme throughout the app

### DIFF
--- a/lib/features/auth/screens/homeserver_screen.dart
+++ b/lib/features/auth/screens/homeserver_screen.dart
@@ -8,6 +8,7 @@ import 'package:kohera/core/services/matrix_service.dart' show MatrixService;
 import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/features/auth/widgets/app_logo_header.dart';
 import 'package:kohera/features/auth/widgets/homeserver_controller.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:provider/provider.dart';
 
 class HomeserverScreen extends StatefulWidget {
@@ -118,7 +119,7 @@ class _HomeserverScreenState extends State<HomeserverScreen>
           if (!_fadeCtrl.isCompleted)
             FadeTransition(
               opacity: ReverseAnimation(_fadeAnim),
-              child: const Center(child: CircularProgressIndicator()),
+              child: const Center(child: KoheraLoader()),
             ),
           Center(
             child: FadeTransition(

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -8,6 +8,7 @@ import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/client_manager.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/features/auth/widgets/login_controller.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:provider/provider.dart';
 
 class LoginScreen extends StatefulWidget {
@@ -138,7 +139,7 @@ class _LoginScreenState extends State<LoginScreen>
                   // ── SSO waiting state ──
                   if (isSsoInProgress) ...[
                     const SizedBox(height: 16),
-                    const CircularProgressIndicator(),
+                    const KoheraLoader(),
                     const SizedBox(height: 16),
                     Text(
                       'Complete sign-in in your browser,\n'

--- a/lib/features/auth/widgets/app_logo_header.dart
+++ b/lib/features/auth/widgets/app_logo_header.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
+
+import 'package:kohera/shared/widgets/kohera_mark.dart';
 
 class AppLogoHeader extends StatelessWidget {
   const AppLogoHeader({required this.subtitle, super.key});
@@ -21,12 +22,7 @@ class AppLogoHeader extends StatelessWidget {
             borderRadius: BorderRadius.circular(20),
           ),
           child: Center(
-            child: SvgPicture.asset(
-              'assets/icons/kohera_mark.svg',
-              width: 42,
-              height: 42,
-              colorFilter: ColorFilter.mode(cs.onPrimaryContainer, BlendMode.srcIn),
-            ),
+            child: KoheraMark(size: 42, color: cs.onPrimaryContainer),
           ),
         ),
         const SizedBox(height: 20),

--- a/lib/features/auth/widgets/registration_views.dart
+++ b/lib/features/auth/widgets/registration_views.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:kohera/features/auth/widgets/registration_controller.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 // coverage:ignore-start
@@ -43,7 +44,7 @@ Widget _buildRecaptchaView(
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        const CircularProgressIndicator(),
+        const KoheraLoader(),
         const SizedBox(height: 16),
         Text(
           'Complete the verification in your browser,\n'

--- a/lib/features/calling/widgets/screen_source_picker.dart
+++ b/lib/features/calling/widgets/screen_source_picker.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_webrtc/flutter_webrtc.dart' as rtc;
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 
 // coverage:ignore-start
 
@@ -103,7 +104,7 @@ class _ScreenSourcePickerState extends State<_ScreenSourcePicker> {
               const SizedBox(height: 8),
               Expanded(
                 child: _loading
-                    ? const Center(child: CircularProgressIndicator())
+                    ? const Center(child: KoheraLoader())
                     : TabBarView(
                         physics: const NeverScrollableScrollPhysics(),
                         children: [

--- a/lib/features/chat/screens/thread_list_screen.dart
+++ b/lib/features/chat/screens/thread_list_screen.dart
@@ -5,6 +5,7 @@ import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/features/chat/services/thread_roots_service.dart';
 import 'package:kohera/features/chat/services/thread_summary.dart';
 import 'package:kohera/features/chat/widgets/thread_list_tile.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:provider/provider.dart';
 
 class ThreadListScreen extends StatefulWidget {
@@ -89,7 +90,7 @@ class _ThreadListScreenState extends State<ThreadListScreen> {
     final summaries = _summaries;
     final Widget body;
     if (_loading && summaries == null) {
-      body = const Center(child: CircularProgressIndicator());
+      body = const Center(child: KoheraLoader());
     } else if (_error != null && (summaries == null || summaries.isEmpty)) {
       body = _buildError(context);
     } else if (summaries == null || summaries.isEmpty) {

--- a/lib/features/chat/screens/thread_screen.dart
+++ b/lib/features/chat/screens/thread_screen.dart
@@ -10,6 +10,7 @@ import 'package:kohera/features/chat/services/thread_roots_service.dart';
 import 'package:kohera/features/chat/widgets/compose_bar_section.dart';
 import 'package:kohera/features/chat/widgets/file_send_handler.dart';
 import 'package:kohera/features/chat/widgets/message_list_view.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 
@@ -193,7 +194,7 @@ class _ThreadScreenState extends State<ThreadScreen> {
     if (_loadingRoot) {
       return Scaffold(
         appBar: AppBar(title: const Text('Thread')),
-        body: const Center(child: CircularProgressIndicator()),
+        body: const Center(child: KoheraLoader()),
       );
     }
 

--- a/lib/features/chat/widgets/message_list_view.dart
+++ b/lib/features/chat/widgets/message_list_view.dart
@@ -11,6 +11,7 @@ import 'package:kohera/features/chat/widgets/read_receipts.dart';
 import 'package:kohera/features/chat/widgets/state_event_tile.dart';
 import 'package:kohera/features/chat/widgets/sticker_message_item.dart';
 import 'package:kohera/features/chat/widgets/unread_divider.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
@@ -487,7 +488,7 @@ class MessageListViewState extends State<MessageListView> {
   @override
   Widget build(BuildContext context) {
     if (_timeline == null) {
-      return const Center(child: CircularProgressIndicator());
+      return const Center(child: KoheraLoader());
     }
 
     final events = _visibleEvents;

--- a/lib/features/chat/widgets/openmoji_picker.dart
+++ b/lib/features/chat/widgets/openmoji_picker.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:kohera/core/utils/openmoji.dart';
 import 'package:kohera/core/utils/openmoji_catalog.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:kohera/shared/widgets/openmoji_image.dart';
 
 // ── OpenMojiPicker ───────────────────────────────────────────
@@ -84,7 +85,7 @@ class _OpenMojiPickerState extends State<OpenMojiPicker> {
     final cs = Theme.of(context).colorScheme;
     final categories = _categories;
     if (categories == null) {
-      return const Center(child: CircularProgressIndicator());
+      return const Center(child: KoheraLoader());
     }
 
     return Stack(

--- a/lib/features/chat/widgets/search_results_body.dart
+++ b/lib/features/chat/widgets/search_results_body.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:kohera/features/chat/services/chat_search_controller.dart';
 import 'package:kohera/features/chat/widgets/search_result_tile.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:matrix/matrix.dart';
 
 /// Displays search results for in-room message search.
@@ -61,7 +62,7 @@ class SearchResultsBody extends StatelessWidget {
 
     // Loading first batch.
     if (search.isLoading && search.results.isEmpty) {
-      return const Center(child: CircularProgressIndicator());
+      return const Center(child: KoheraLoader());
     }
 
     // Empty results.

--- a/lib/features/e2ee/screens/e2ee_setup_screen.dart
+++ b/lib/features/e2ee/screens/e2ee_setup_screen.dart
@@ -8,6 +8,7 @@ import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart';
 import 'package:kohera/features/e2ee/widgets/bootstrap_controller.dart';
 import 'package:kohera/features/e2ee/widgets/key_verification_inline.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -203,7 +204,7 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
 
     if (backupNeeded == null) {
       return const Scaffold(
-        body: Center(child: CircularProgressIndicator()),
+        body: Center(child: KoheraLoader()),
       );
     }
 
@@ -469,7 +470,7 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const CircularProgressIndicator(),
+          const KoheraLoader(),
           const SizedBox(height: 16),
           Text(_controller?.loadingMessage ?? 'Preparing...'),
         ],
@@ -657,7 +658,7 @@ class _E2eeSetupScreenState extends State<E2eeSetupScreen> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const CircularProgressIndicator(),
+            const KoheraLoader(),
             const SizedBox(height: 16),
             const Text('Starting verification...'),
             const SizedBox(height: 16),

--- a/lib/features/e2ee/screens/show_recovery_key_screen.dart
+++ b/lib/features/e2ee/screens/show_recovery_key_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -57,7 +58,7 @@ class _ShowRecoveryKeyScreenState extends State<ShowRecoveryKeyScreen> {
                 future: _keyFuture,
                 builder: (context, snapshot) {
                   if (snapshot.connectionState != ConnectionState.done) {
-                    return const Center(child: CircularProgressIndicator());
+                    return const Center(child: KoheraLoader());
                   }
                   final key = snapshot.data;
                   if (key == null || key.isEmpty) {

--- a/lib/features/e2ee/widgets/key_verification_content.dart
+++ b/lib/features/e2ee/widgets/key_verification_content.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:matrix/encryption.dart';
 
 // ── Key verification content ────────────────────────────────────
@@ -124,7 +125,7 @@ class KeyVerificationContent extends StatelessWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        const CircularProgressIndicator(),
+        const KoheraLoader(),
         const SizedBox(height: 16),
         Text(message),
       ],

--- a/lib/features/home/widgets/inbox_screen.dart
+++ b/lib/features/home/widgets/inbox_screen.dart
@@ -11,6 +11,7 @@ import 'package:kohera/features/home/widgets/mobile_space_drawer.dart';
 import 'package:kohera/features/notifications/models/notification_constants.dart';
 import 'package:kohera/features/notifications/services/inbox_controller.dart';
 import 'package:kohera/features/rooms/widgets/invite_tile.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:kohera/shared/widgets/room_avatar.dart';
 import 'package:matrix/matrix.dart' as matrix_sdk;
 import 'package:provider/provider.dart';
@@ -108,7 +109,7 @@ class _InboxScreenState extends State<InboxScreen> {
             child: controller.filter == InboxFilter.invitations
                 ? _InvitationsView(cs: cs, tt: tt)
                 : controller.isLoading && controller.grouped.isEmpty
-                    ? const Center(child: CircularProgressIndicator())
+                    ? const Center(child: KoheraLoader())
                     : controller.error != null && controller.grouped.isEmpty
                         ? Center(
                             child: Column(

--- a/lib/features/home/widgets/wide_layout.dart
+++ b/lib/features/home/widgets/wide_layout.dart
@@ -8,6 +8,7 @@ import 'package:kohera/features/chat/screens/chat_screen.dart';
 import 'package:kohera/features/rooms/widgets/room_details_panel.dart';
 import 'package:kohera/features/rooms/widgets/room_list.dart';
 import 'package:kohera/features/spaces/widgets/space_rail.dart';
+import 'package:kohera/shared/widgets/kohera_mark.dart';
 import 'package:provider/provider.dart';
 
 // coverage:ignore-start
@@ -173,8 +174,10 @@ class _WideLayoutState extends State<WideLayout> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(Icons.chat_bubble_outline_rounded,
-              size: 56, color: cs.onSurfaceVariant.withValues(alpha: 0.3),),
+          KoheraMark(
+            size: 72,
+            color: cs.onSurfaceVariant.withValues(alpha: 0.3),
+          ),
           const SizedBox(height: 16),
           Text(
             'Select a conversation',

--- a/lib/features/settings/screens/devices_screen.dart
+++ b/lib/features/settings/screens/devices_screen.dart
@@ -7,6 +7,7 @@ import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/features/e2ee/widgets/key_verification_dialog.dart';
 import 'package:kohera/features/settings/widgets/device_list_item.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:kohera/shared/widgets/section_header.dart';
 import 'package:matrix/matrix.dart';
 import 'package:matrix/msc_extensions/msc_3814_dehydrated_devices/api.dart';
@@ -349,7 +350,7 @@ class _DevicesScreenState extends State<DevicesScreen> {
 
   Widget _buildBody() {
     if (_loading) {
-      return const Center(child: CircularProgressIndicator());
+      return const Center(child: KoheraLoader());
     }
     if (_error != null) {
       return _buildError();

--- a/lib/features/settings/screens/emoji_gg_browse_screen.dart
+++ b/lib/features/settings/screens/emoji_gg_browse_screen.dart
@@ -6,6 +6,7 @@ import 'package:kohera/core/routing/nav_helper.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/emoji_gg_service.dart';
 import 'package:kohera/core/services/sticker_pack_service.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:provider/provider.dart';
 
 class EmojiGgBrowseScreen extends StatefulWidget {
@@ -170,7 +171,7 @@ class _EmojiGgBrowseScreenState extends State<EmojiGgBrowseScreen> {
 
   Widget _buildBody(ColorScheme cs) {
     if (_packs == null && !_loadError) {
-      return const Center(child: CircularProgressIndicator());
+      return const Center(child: KoheraLoader());
     }
 
     if (_loadError) {

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -12,6 +12,7 @@ import 'package:kohera/core/services/sticker_pack_service.dart';
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart';
 import 'package:kohera/features/settings/widgets/account_switcher.dart';
 import 'package:kohera/features/settings/widgets/profile_avatar_card.dart';
+import 'package:kohera/shared/widgets/kohera_mark.dart';
 import 'package:kohera/shared/widgets/section_header.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -205,6 +206,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               children: [
                 _SettingsTile(
                   icon: Icons.info_outline_rounded,
+                  leading: const KoheraMark(size: 24),
                   title: 'Kohera',
                   subtitle: prefs.currentVersion != null
                       ? "v${prefs.currentVersion} · What's new"
@@ -326,18 +328,20 @@ class _SettingsTile extends StatelessWidget {
     required this.title,
     required this.subtitle,
     required this.onTap,
+    this.leading,
   });
 
   final IconData icon;
   final String title;
   final String subtitle;
   final VoidCallback onTap;
+  final Widget? leading;
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     return ListTile(
-      leading: Icon(icon, color: cs.onSurfaceVariant),
+      leading: leading ?? Icon(icon, color: cs.onSurfaceVariant),
       title: Text(title),
       subtitle: Text(subtitle),
       trailing: Icon(Icons.chevron_right, color: cs.onSurfaceVariant),

--- a/lib/features/whats_new/screens/whats_new_screen.dart
+++ b/lib/features/whats_new/screens/whats_new_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:kohera/core/services/github_releases_service.dart';
 import 'package:kohera/features/whats_new/widgets/release_notes_markdown.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -142,8 +143,7 @@ class _LoadingView extends StatelessWidget {
   const _LoadingView();
 
   @override
-  Widget build(BuildContext context) =>
-      const CircularProgressIndicator.adaptive();
+  Widget build(BuildContext context) => const KoheraLoader();
 }
 
 class _ErrorView extends StatelessWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,6 +26,7 @@ import 'package:kohera/features/chat/services/opengraph_service.dart';
 import 'package:kohera/features/e2ee/widgets/verification_request_listener.dart';
 import 'package:kohera/features/notifications/services/inbox_controller.dart';
 import 'package:kohera/features/notifications/widgets/notification_lifecycle_observer.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:provider/provider.dart';
 
@@ -56,6 +57,8 @@ class _KoheraAppState extends State<KoheraApp> {
   }
 
   Future<void> _init() async {
+    // Keep the branded splash up long enough for its growth animation to play.
+    final minSplash = Future<void>.delayed(const Duration(seconds: 3));
     try {
       MediaKit.ensureInitialized();
 
@@ -73,6 +76,7 @@ class _KoheraAppState extends State<KoheraApp> {
         );
       }
 
+      await minSplash;
       if (!mounted) return;
       clientManager.addListener(_onActiveServiceChanged);
       setState(() {
@@ -139,7 +143,9 @@ class _KoheraAppState extends State<KoheraApp> {
                       ),
                     ],
                   )
-                : const CircularProgressIndicator.adaptive(),
+                // Brand seed colour — this splash renders before the Kohera
+                // theme is applied, so the default scheme would be wrong.
+                : const KoheraLoader(size: 96, color: Color(0xFF1976D2)),
           ),
         ),
       );

--- a/lib/shared/widgets/full_image_view.dart
+++ b/lib/shared/widgets/full_image_view.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:kohera/core/utils/media_auth.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:kohera/shared/widgets/media_viewer_shell.dart';
 import 'package:matrix/matrix.dart';
 
@@ -67,7 +68,7 @@ class _FullImageContentState extends State<_FullImageContent> {
     final cs = Theme.of(context).colorScheme;
 
     if (_loading) {
-      return const Center(child: CircularProgressIndicator());
+      return const Center(child: KoheraLoader());
     }
 
     final image = _imageBytes != null

--- a/lib/shared/widgets/kohera_loader.dart
+++ b/lib/shared/widgets/kohera_loader.dart
@@ -1,0 +1,156 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+/// Animated brand loader: the mycelial network grows outward from the mushroom
+/// base, each thread drawing to its node, then the whole mark fades and regrows.
+class KoheraLoader extends StatefulWidget {
+  const KoheraLoader({this.size = 48, this.color, super.key});
+
+  final double size;
+  final Color? color;
+
+  @override
+  State<KoheraLoader> createState() => _KoheraLoaderState();
+}
+
+class _KoheraLoaderState extends State<KoheraLoader>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 2400),
+  )..repeat();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final color = widget.color ?? Theme.of(context).colorScheme.primary;
+    return SizedBox(
+      width: widget.size,
+      height: widget.size,
+      child: RepaintBoundary(
+        child: AnimatedBuilder(
+          animation: _controller,
+          builder: (_, __) => CustomPaint(
+            painter: _MyceliumGrowthPainter(
+              progress: _controller.value,
+              color: color,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MyceliumGrowthPainter extends CustomPainter {
+  _MyceliumGrowthPainter({required this.progress, required this.color});
+
+  final double progress;
+  final Color color;
+
+  // Roots as base→mid→tip on the same 100×100 grid as the brand mark.
+  static const _roots = <List<double>>[
+    [26.0, 71.0, 10.0, 92.0],
+    [39.2, 68.0, 32.0, 86.0],
+    [52.4, 72.0, 54.0, 94.0],
+    [65.6, 67.0, 76.0, 84.0],
+    [75.2, 70.0, 92.0, 90.0],
+  ];
+
+  static const _base = Offset(50, 50);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    canvas.scale(size.width / 100.0);
+
+    final v = progress;
+    final grow = (v / 0.62).clamp(0.0, 1.0);
+    final intro = (v / 0.12).clamp(0.0, 1.0);
+    final fade = v < 0.82 ? 1.0 : (1 - (v - 0.82) / 0.18).clamp(0.0, 1.0);
+
+    // ── Cap + stem + source node (fade and scale in) ──
+    final introAlpha = (intro * fade).clamp(0.0, 1.0);
+    final introPaint = Paint()
+      ..color = color.withValues(alpha: introAlpha)
+      ..isAntiAlias = true;
+    canvas.save();
+    final scale = 0.7 + 0.3 * intro;
+    canvas
+      ..translate(_base.dx, _base.dy)
+      ..scale(scale)
+      ..translate(-_base.dx, -_base.dy);
+    _drawCapStem(canvas, introPaint);
+    canvas.restore();
+    canvas.drawCircle(_base, 5, introPaint);
+
+    // ── Roots grow outward, nodes pop in on arrival ──
+    final stroke = Paint()
+      ..color = color.withValues(alpha: fade)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 3.5
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round
+      ..isAntiAlias = true;
+    final node = Paint()
+      ..color = color.withValues(alpha: fade)
+      ..isAntiAlias = true;
+
+    for (var i = 0; i < _roots.length; i++) {
+      final r = _roots[i];
+      final mid = Offset(r[0], r[1]);
+      final tip = Offset(r[2], r[3]);
+      final f = ((grow - i * 0.10) / 0.55).clamp(0.0, 1.0);
+      if (f <= 0) continue;
+      _drawPartialRoot(canvas, mid, tip, f, stroke);
+      final pop = ((f - 0.8) / 0.2).clamp(0.0, 1.0);
+      if (pop > 0) canvas.drawCircle(tip, 4.5 * pop, node);
+    }
+  }
+
+  void _drawCapStem(Canvas canvas, Paint paint) {
+    canvas.drawPath(
+      Path()..addArc(const Rect.fromLTWH(20, 6, 60, 40), math.pi, math.pi)..close(),
+      paint,
+    );
+    canvas.drawPath(
+      Path()
+        ..moveTo(42.5, 26)
+        ..lineTo(57.5, 26)
+        ..lineTo(58.5, 50)
+        ..lineTo(41.5, 50)
+        ..close(),
+      paint,
+    );
+    canvas.drawOval(
+      Rect.fromCenter(center: _base, width: 17, height: 17 * 0.7),
+      paint,
+    );
+  }
+
+  void _drawPartialRoot(
+      Canvas canvas, Offset mid, Offset tip, double f, Paint stroke,) {
+    final l1 = (mid - _base).distance;
+    final l2 = (tip - mid).distance;
+    final target = f * (l1 + l2);
+    final path = Path()..moveTo(_base.dx, _base.dy);
+    if (target <= l1) {
+      final p = Offset.lerp(_base, mid, target / l1)!;
+      path.lineTo(p.dx, p.dy);
+    } else {
+      path.lineTo(mid.dx, mid.dy);
+      final p = Offset.lerp(mid, tip, ((target - l1) / l2).clamp(0.0, 1.0))!;
+      path.lineTo(p.dx, p.dy);
+    }
+    canvas.drawPath(path, stroke);
+  }
+
+  @override
+  bool shouldRepaint(_MyceliumGrowthPainter oldDelegate) =>
+      oldDelegate.progress != progress || oldDelegate.color != color;
+}

--- a/lib/shared/widgets/kohera_mark.dart
+++ b/lib/shared/widgets/kohera_mark.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+class KoheraMark extends StatelessWidget {
+  const KoheraMark({required this.size, this.color, super.key});
+
+  final double size;
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    final tint = color ?? Theme.of(context).colorScheme.onSurfaceVariant;
+    return SvgPicture.asset(
+      'assets/icons/kohera_mark.svg',
+      width: size,
+      height: size,
+      colorFilter: ColorFilter.mode(tint, BlendMode.srcIn),
+    );
+  }
+}

--- a/test/e2e/chat_screen_test.dart
+++ b/test/e2e/chat_screen_test.dart
@@ -12,6 +12,7 @@ import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/chat/screens/chat_screen.dart';
 import 'package:kohera/features/chat/services/media_playback_service.dart';
 import 'package:kohera/features/chat/widgets/sticker_picker_overlay.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:matrix/matrix.dart';
 import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:mockito/annotations.dart';
@@ -289,7 +290,7 @@ void main() {
       await tester.pumpWidget(buildChatApp());
       await tester.pump();
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(KoheraLoader), findsOneWidget);
     });
   });
 

--- a/test/e2e/settings_screen_test.dart
+++ b/test/e2e/settings_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/core/services/sticker_pack_service.dart';
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart';
 import 'package:kohera/features/settings/screens/settings_screen.dart';
+import 'package:kohera/shared/widgets/kohera_mark.dart';
 import 'package:matrix/matrix.dart';
 import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:mockito/annotations.dart';
@@ -259,7 +260,7 @@ void main() {
       expect(find.text('ABOUT'), findsOneWidget);
       expect(find.text('Kohera'), findsOneWidget);
       expect(find.textContaining("What's new"), findsOneWidget);
-      expect(find.byIcon(Icons.info_outline_rounded), findsOneWidget);
+      expect(find.byType(KoheraMark), findsOneWidget);
     });
   });
 

--- a/test/features/whats_new/whats_new_test.dart
+++ b/test/features/whats_new/whats_new_test.dart
@@ -9,6 +9,7 @@ import 'package:http/testing.dart';
 import 'package:kohera/core/services/github_releases_service.dart';
 import 'package:kohera/features/whats_new/screens/whats_new_screen.dart';
 import 'package:kohera/features/whats_new/widgets/release_notes_markdown.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:provider/provider.dart';
 
 const _sampleMarkdown = '''
@@ -162,7 +163,7 @@ void main() {
       await tester.pumpWidget(_screenHarness(svc));
       await tester.pump();
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(KoheraLoader), findsOneWidget);
       expect(find.text("What's new"), findsOneWidget);
 
       completer.complete(http.Response('{}', 500));

--- a/test/screens/chat_search_test.dart
+++ b/test/screens/chat_search_test.dart
@@ -8,6 +8,7 @@ import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/core/services/sticker_pack_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/chat/screens/chat_screen.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:matrix/matrix.dart';
 import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:mockito/annotations.dart';
@@ -209,7 +210,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 600));
       await tester.pump(); // Trigger the search.
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(KoheraLoader), findsOneWidget);
 
       // Complete the future to avoid pending timers.
       completer.complete((

--- a/test/screens/devices_screen_test.dart
+++ b/test/screens/devices_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart';
 import 'package:kohera/core/services/sub_services/uia_service.dart';
 import 'package:kohera/features/settings/screens/devices_screen.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:matrix/matrix.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -57,7 +58,7 @@ void main() {
 
       await tester.pumpWidget(buildTestWidget());
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(KoheraLoader), findsOneWidget);
     });
 
     testWidgets('shows error state on failure', (tester) async {

--- a/test/screens/homeserver_screen_test.dart
+++ b/test/screens/homeserver_screen_test.dart
@@ -12,6 +12,7 @@ import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/features/auth/screens/homeserver_screen.dart';
 import 'package:kohera/features/auth/screens/login_screen.dart';
 import 'package:kohera/features/auth/screens/registration_screen.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:matrix/matrix.dart';
 import 'package:matrix/src/utils/cached_stream_controller.dart';
 import 'package:mockito/mockito.dart';
@@ -137,11 +138,11 @@ void main() {
       await tester.pumpWidget(buildTestWidget());
       await tester.pump();
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(KoheraLoader), findsOneWidget);
 
       await tester.pumpAndSettle();
 
-      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.byType(KoheraLoader), findsNothing);
     });
 
     testWidgets('shows subtitle and Continue button', (tester) async {

--- a/test/widgets/inbox_screen_test.dart
+++ b/test/widgets/inbox_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
 import 'package:kohera/features/home/widgets/inbox_screen.dart';
 import 'package:kohera/features/notifications/services/inbox_controller.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:matrix/matrix.dart' as matrix_sdk;
 import 'package:matrix/matrix.dart' show Client, GetNotificationsResponse, MatrixEvent, Membership, Room, SyncUpdate, User;
 import 'package:matrix/src/utils/cached_stream_controller.dart';
@@ -132,7 +133,7 @@ void main() {
       ),).called(greaterThanOrEqualTo(1));
     });
 
-    testWidgets('loading state shows CircularProgressIndicator',
+    testWidgets('loading state shows KoheraLoader',
         (tester) async {
       // Use a completer to hold the fetch indefinitely
       final completer = Completer<GetNotificationsResponse>();
@@ -146,7 +147,7 @@ void main() {
       // Pump once to let initState's fetch trigger isLoading
       await tester.pump();
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(KoheraLoader), findsOneWidget);
 
       // Complete to avoid pending timers
       completer.complete(_makeResponse([]));

--- a/test/widgets/key_verification_dialog_test.dart
+++ b/test/widgets/key_verification_dialog_test.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/features/e2ee/widgets/key_verification_dialog.dart';
+import 'package:kohera/shared/widgets/kohera_loader.dart';
 import 'package:matrix/encryption.dart';
 import 'package:matrix/matrix.dart';
 
@@ -149,7 +150,7 @@ void main() {
       );
       await openDialog(tester, verification: verification);
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(KoheraLoader), findsOneWidget);
       expect(find.text('Waiting for the other device to accept...'),
           findsOneWidget,);
     });

--- a/web/index.html
+++ b/web/index.html
@@ -74,64 +74,80 @@
         background-color: #1C1B1F;
       }
 
-      .loader circle {
-        stroke: rgba(255, 255, 255, .12);
-      }
-
-      .loader circle:last-child {
-        stroke: #90CAF9;
+      .loader {
+        color: #90CAF9;
       }
     }
 
     .loader {
-      width: 36px;
-      height: 36px;
-      animation: rotate 1.4s linear infinite;
+      width: 72px;
+      height: 72px;
+      color: #1976D2;
     }
 
-    .loader circle {
-      fill: none;
-      stroke: rgba(0, 0, 0, .12);
-      stroke-width: 3.5;
+    .loader .bloom {
+      transform-box: fill-box;
+      transform-origin: 50% 100%;
+      animation: bloom 2.4s ease-in-out infinite both;
     }
 
-    .loader circle:last-child {
-      stroke: #1976D2;
-      stroke-dasharray: 80, 200;
-      stroke-dashoffset: 0;
-      stroke-linecap: round;
-      animation: sweep 1.4s ease-in-out infinite;
+    .loader .root {
+      stroke-dasharray: 120;
+      animation: draw 2.4s ease-in-out infinite both;
     }
 
-    @keyframes rotate {
-      to {
-        transform: rotate(360deg);
-      }
+    .loader .node {
+      transform-box: fill-box;
+      transform-origin: center;
+      animation: pop 2.4s ease-in-out infinite both;
     }
 
-    @keyframes sweep {
-      0% {
-        stroke-dasharray: 1, 200;
-        stroke-dashoffset: 0;
-      }
+    .loader .s2 { animation-delay: .08s; }
+    .loader .s3 { animation-delay: .16s; }
+    .loader .s4 { animation-delay: .24s; }
+    .loader .s5 { animation-delay: .32s; }
 
-      50% {
-        stroke-dasharray: 80, 200;
-        stroke-dashoffset: -35;
-      }
+    @keyframes bloom {
+      0%   { opacity: 0; transform: scale(.65); }
+      12%  { opacity: 1; transform: scale(1); }
+      70%  { opacity: 1; }
+      82%, 100% { opacity: 0; }
+    }
 
-      100% {
-        stroke-dasharray: 1, 200;
-        stroke-dashoffset: -125;
-      }
+    @keyframes draw {
+      0%   { stroke-dashoffset: 120; opacity: 1; }
+      24%  { stroke-dashoffset: 0; }
+      70%  { opacity: 1; }
+      82%, 100% { stroke-dashoffset: 0; opacity: 0; }
+    }
+
+    @keyframes pop {
+      0%, 18% { opacity: 0; transform: scale(.2); }
+      28%     { opacity: 1; transform: scale(1); }
+      70%     { opacity: 1; }
+      82%, 100% { opacity: 0; }
     }
   </style>
 </head>
 
 <body>
-  <svg id="loading" class="loader" viewBox="0 0 44 44">
-    <circle cx="22" cy="22" r="20" />
-    <circle cx="22" cy="22" r="20" />
+  <svg id="loading" class="loader" viewBox="0 0 100 100" fill="currentColor">
+    <g class="bloom">
+      <path d="M 20 26 A 30 20 0 0 1 80 26 Z" />
+      <polygon points="42.5,26 57.5,26 58.5,50 41.5,50" />
+      <ellipse cx="50" cy="50" rx="8.5" ry="5.95" />
+      <circle cx="50" cy="50" r="5" />
+    </g>
+    <path class="root s1" d="M 50 50 L 26 71 L 10 92" fill="none" stroke="currentColor" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" />
+    <circle class="node s1" cx="10" cy="92" r="4.5" />
+    <path class="root s2" d="M 50 50 L 39.2 68 L 32 86" fill="none" stroke="currentColor" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" />
+    <circle class="node s2" cx="32" cy="86" r="4.5" />
+    <path class="root s3" d="M 50 50 L 52.4 72 L 54 94" fill="none" stroke="currentColor" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" />
+    <circle class="node s3" cx="54" cy="94" r="4.5" />
+    <path class="root s4" d="M 50 50 L 65.6 67 L 76 84" fill="none" stroke="currentColor" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" />
+    <circle class="node s4" cx="76" cy="84" r="4.5" />
+    <path class="root s5" d="M 50 50 L 75.2 70 L 92 90" fill="none" stroke="currentColor" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" />
+    <circle class="node s5" cx="92" cy="90" r="4.5" />
   </svg>
   <script src="flutter_bootstrap.js" async></script>
   <script>


### PR DESCRIPTION
## Summary

Extends the new mushroom/mycelial brand mark (shipped as the app icon in #655) into the app itself: a shared static mark in key surfaces, and an animated "mycelial growth" loader for prominent loading states — including a matching web first-frame loader.

## Changes

**Shared widgets**
- `KoheraMark` — renders the monochrome mushroom SVG tinted to any colour (single source, theme-aware)
- `KoheraLoader` — animates the mark as a growing mycelial network for loading states

**Static mark placements**
- Auth header logo now uses `KoheraMark` (replaces the inline `SvgPicture`)
- Faded mark in the wide-layout "Select a conversation" empty pane
- Mark as the leading icon on the settings About tile

**Loaders**
- Replaced the 19 prominent full-screen / dialog / empty-state spinners with the animated `KoheraLoader`; the ~50 small inline spinners stay as `CircularProgressIndicator` (legibility + list performance)
- App-launch splash held for a minimum of 3s so the growth animation plays
- Web `index.html` first-frame spinner replaced with a matching CSS/SVG mycelial growth animation

## Testing

- [x] `flutter analyze` clean (whole project)
- Verified on the iOS simulator: splash growth animation plays on launch; app launches and navigates cleanly after the loader sweep
- Not visually verified: the web loader (no browser in dev env) and a few login/verification-gated prominent loaders — all use the same verified widget

## Screenshots / recordings

Splash growth animation and the static-mark placements verified on the iOS simulator during development.

## Linked issues

_None._

## Checklist

- [x] Conventional Commits subjects, no `Word:` lines or inline issue refs in bodies
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix — n/a, no logging added
- [x] No stray comments (only `// ── Section ──` markers)
- [ ] Tests added or updated — n/a (presentational widgets / asset wiring)
- [x] Targets `master`