### PR TITLE
style: fire a random light pulse along the static loader mark

### DIFF
--- a/lib/shared/widgets/kohera_loader.dart
+++ b/lib/shared/widgets/kohera_loader.dart
@@ -2,8 +2,9 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 
-/// Animated brand loader: the mycelial network grows outward from the mushroom
-/// base, each thread drawing to its node, then the whole mark fades and regrows.
+/// Animated brand loader: the mycelial mark stands static while a pulse of
+/// light fires from the base out to a node, picking a different thread each
+/// time so the network appears to signal at random.
 class KoheraLoader extends StatefulWidget {
   const KoheraLoader({this.size = 48, this.color, super.key});
 
@@ -18,12 +19,38 @@ class _KoheraLoaderState extends State<KoheraLoader>
     with SingleTickerProviderStateMixin {
   late final AnimationController _controller = AnimationController(
     vsync: this,
-    duration: const Duration(milliseconds: 2400),
+    duration: const Duration(milliseconds: 900),
   )..repeat();
+
+  final math.Random _random = math.Random();
+  int _activeLeg = 0;
+  double _lastValue = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _activeLeg = _random.nextInt(_MyceliumPulsePainter.rootCount);
+    _controller.addListener(_onTick);
+  }
+
+  void _onTick() {
+    if (_controller.value < _lastValue) {
+      _activeLeg = _nextLeg();
+    }
+    _lastValue = _controller.value;
+  }
+
+  int _nextLeg() {
+    if (_MyceliumPulsePainter.rootCount < 2) return 0;
+    final next = _random.nextInt(_MyceliumPulsePainter.rootCount - 1);
+    return next >= _activeLeg ? next + 1 : next;
+  }
 
   @override
   void dispose() {
-    _controller.dispose();
+    _controller
+      ..removeListener(_onTick)
+      ..dispose();
     super.dispose();
   }
 
@@ -37,8 +64,9 @@ class _KoheraLoaderState extends State<KoheraLoader>
         child: AnimatedBuilder(
           animation: _controller,
           builder: (_, __) => CustomPaint(
-            painter: _MyceliumGrowthPainter(
+            painter: _MyceliumPulsePainter(
               progress: _controller.value,
+              activeLeg: _activeLeg,
               color: color,
             ),
           ),
@@ -48,10 +76,15 @@ class _KoheraLoaderState extends State<KoheraLoader>
   }
 }
 
-class _MyceliumGrowthPainter extends CustomPainter {
-  _MyceliumGrowthPainter({required this.progress, required this.color});
+class _MyceliumPulsePainter extends CustomPainter {
+  _MyceliumPulsePainter({
+    required this.progress,
+    required this.activeLeg,
+    required this.color,
+  });
 
   final double progress;
+  final int activeLeg;
   final Color color;
 
   // Roots as base→mid→tip on the same 100×100 grid as the brand mark.
@@ -63,54 +96,109 @@ class _MyceliumGrowthPainter extends CustomPainter {
     [75.2, 70.0, 92.0, 90.0],
   ];
 
+  static int get rootCount => _roots.length;
+
   static const _base = Offset(50, 50);
+
+  // Light travels during the first portion of the cycle, then rests.
+  static const _travel = 0.72;
 
   @override
   void paint(Canvas canvas, Size size) {
     canvas.scale(size.width / 100.0);
 
-    final v = progress;
-    final grow = (v / 0.62).clamp(0.0, 1.0);
-    final intro = (v / 0.12).clamp(0.0, 1.0);
-    final fade = v < 0.82 ? 1.0 : (1 - (v - 0.82) / 0.18).clamp(0.0, 1.0);
-
-    // ── Cap + stem + source node (fade and scale in) ──
-    final introAlpha = (intro * fade).clamp(0.0, 1.0);
-    final introPaint = Paint()
-      ..color = color.withValues(alpha: introAlpha)
+    // ── Static mark: cap, stem, source node ──
+    final markPaint = Paint()
+      ..color = color
       ..isAntiAlias = true;
-    canvas.save();
-    final scale = 0.7 + 0.3 * intro;
-    canvas
-      ..translate(_base.dx, _base.dy)
-      ..scale(scale)
-      ..translate(-_base.dx, -_base.dy);
-    _drawCapStem(canvas, introPaint);
-    canvas.restore();
-    canvas.drawCircle(_base, 5, introPaint);
+    _drawCapStem(canvas, markPaint);
+    canvas.drawCircle(_base, 5, markPaint);
 
-    // ── Roots grow outward, nodes pop in on arrival ──
+    // ── Static threads + nodes ──
     final stroke = Paint()
-      ..color = color.withValues(alpha: fade)
+      ..color = color
       ..style = PaintingStyle.stroke
       ..strokeWidth = 3.5
       ..strokeCap = StrokeCap.round
       ..strokeJoin = StrokeJoin.round
       ..isAntiAlias = true;
     final node = Paint()
-      ..color = color.withValues(alpha: fade)
+      ..color = color
       ..isAntiAlias = true;
 
-    for (var i = 0; i < _roots.length; i++) {
-      final r = _roots[i];
+    for (final r in _roots) {
       final mid = Offset(r[0], r[1]);
       final tip = Offset(r[2], r[3]);
-      final f = ((grow - i * 0.10) / 0.55).clamp(0.0, 1.0);
-      if (f <= 0) continue;
-      _drawPartialRoot(canvas, mid, tip, f, stroke);
-      final pop = ((f - 0.8) / 0.2).clamp(0.0, 1.0);
-      if (pop > 0) canvas.drawCircle(tip, 4.5 * pop, node);
+      canvas.drawPath(
+        Path()
+          ..moveTo(_base.dx, _base.dy)
+          ..lineTo(mid.dx, mid.dy)
+          ..lineTo(tip.dx, tip.dy),
+        stroke,
+      );
+      canvas.drawCircle(tip, 4.5, node);
     }
+
+    // ── Pulse of light firing along the active thread ──
+    _drawPulse(canvas);
+  }
+
+  void _drawPulse(Canvas canvas) {
+    final t = (progress / _travel).clamp(0.0, 1.0);
+    if (t <= 0 || t >= 1) return;
+
+    final r = _roots[activeLeg];
+    final mid = Offset(r[0], r[1]);
+    final tip = Offset(r[2], r[3]);
+    final head = _pointAlong(mid, tip, t);
+
+    // Quick fire-in, sustained, fade-out as it lands.
+    final intensity = (t < 0.15 ? t / 0.15 : (1 - (t - 0.15) / 0.85))
+        .clamp(0.0, 1.0);
+    final light = Color.lerp(color, Colors.white, 0.7)!;
+
+    // Glow trail behind the head.
+    final glow = Paint()
+      ..color = light.withValues(alpha: 0.55 * intensity)
+      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 4)
+      ..isAntiAlias = true;
+    for (var i = 1; i <= 4; i++) {
+      final tt = (t - i * 0.06).clamp(0.0, 1.0);
+      if (tt <= 0) break;
+      final p = _pointAlong(mid, tip, tt);
+      canvas.drawCircle(p, 3.5 - i * 0.5, glow);
+    }
+
+    // Bright core.
+    canvas.drawCircle(
+      head,
+      4,
+      Paint()
+        ..color = light.withValues(alpha: intensity)
+        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 2)
+        ..isAntiAlias = true,
+    );
+
+    // Node flash as the light arrives.
+    final arrival = ((t - 0.82) / 0.18).clamp(0.0, 1.0);
+    if (arrival > 0) {
+      canvas.drawCircle(
+        tip,
+        4.5 + 4 * arrival,
+        Paint()
+          ..color = light.withValues(alpha: (1 - arrival) * 0.9)
+          ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 3)
+          ..isAntiAlias = true,
+      );
+    }
+  }
+
+  Offset _pointAlong(Offset mid, Offset tip, double t) {
+    final l1 = (mid - _base).distance;
+    final l2 = (tip - mid).distance;
+    final d = t * (l1 + l2);
+    if (d <= l1) return Offset.lerp(_base, mid, l1 == 0 ? 0 : d / l1)!;
+    return Offset.lerp(mid, tip, l2 == 0 ? 0 : (d - l1) / l2)!;
   }
 
   void _drawCapStem(Canvas canvas, Paint paint) {
@@ -133,24 +221,9 @@ class _MyceliumGrowthPainter extends CustomPainter {
     );
   }
 
-  void _drawPartialRoot(
-      Canvas canvas, Offset mid, Offset tip, double f, Paint stroke,) {
-    final l1 = (mid - _base).distance;
-    final l2 = (tip - mid).distance;
-    final target = f * (l1 + l2);
-    final path = Path()..moveTo(_base.dx, _base.dy);
-    if (target <= l1) {
-      final p = Offset.lerp(_base, mid, target / l1)!;
-      path.lineTo(p.dx, p.dy);
-    } else {
-      path.lineTo(mid.dx, mid.dy);
-      final p = Offset.lerp(mid, tip, ((target - l1) / l2).clamp(0.0, 1.0))!;
-      path.lineTo(p.dx, p.dy);
-    }
-    canvas.drawPath(path, stroke);
-  }
-
   @override
-  bool shouldRepaint(_MyceliumGrowthPainter oldDelegate) =>
-      oldDelegate.progress != progress || oldDelegate.color != color;
+  bool shouldRepaint(_MyceliumPulsePainter oldDelegate) =>
+      oldDelegate.progress != progress ||
+      oldDelegate.activeLeg != activeLeg ||
+      oldDelegate.color != color;
 }


### PR DESCRIPTION
## Summary

Polishes the `KoheraLoader` animation. The mushroom mark and its mycelial threads now stay static, and a pulse of light fires from the base out to a node along one thread at a time — picking a different thread each cycle so the network appears to signal at random.

## Changes

- Removed the fade/scale-in intro and the whole-mark regrow cycle; the cap, stem, source node, threads, and tip nodes now render fully every frame.
- Replaced the per-thread growth animation with a static draw of all five threads and their nodes.
- Added a light pulse that travels base→tip along the active thread, with a quick fire-in, a blurred glowing trail, a bright white-tinted core, a node flash on arrival, and a short rest before the next firing.
- The active thread is reselected each animation cycle and never repeats back-to-back, so firing reads as random.

## Testing

- `flutter analyze lib/shared/widgets/kohera_loader.dart` — no issues.
- `flutter test` across the seven loader-referencing suites — all 68 tests pass. The public `KoheraLoader({size, color})` API is unchanged, so existing `find.byType(KoheraLoader)` assertions still hold.

## Checklist

- [x] Code follows the project conventions
- [x] Tests pass locally
- [x] No new analyzer warnings
