### PR TITLE
fix: preserve inbox pagination on sync-driven refresh

### DIFF
--- a/lib/features/home/widgets/inbox_screen.dart
+++ b/lib/features/home/widgets/inbox_screen.dart
@@ -154,7 +154,7 @@ class _InboxScreenState extends State<InboxScreen> {
                                 ),
                               )
                             : RefreshIndicator(
-                                onRefresh: controller.fetch,
+                                onRefresh: controller.refresh,
                                 child: ListView.builder(
                                   padding: const EdgeInsets.symmetric(
                                       horizontal: 8, vertical: 4,),

--- a/lib/features/notifications/services/inbox_controller.dart
+++ b/lib/features/notifications/services/inbox_controller.dart
@@ -75,6 +75,7 @@ class InboxController extends ChangeNotifier {
 
   int _fetchGeneration = 0;
   int _cachedUnreadCount = 0;
+  int _loadedPages = 1;
 
   final Map<String, Map<String, Object?>> _decryptedContent = {};
 
@@ -110,17 +111,42 @@ class InboxController extends ChangeNotifier {
 
   // ── Fetch ──────────────────────────────────────────────────
 
-  Future<void> fetch() async {
+  /// Loads the first page, resetting any accumulated pagination.
+  Future<void> fetch() => _load(pages: 1);
+
+  /// Re-fetches the pages the user has already loaded.
+  ///
+  /// Used by the sync-driven background refresh so an incoming event or
+  /// receipt does not discard pages already paged in with [loadMore] and
+  /// collapse the list back to the first 30 notifications.
+  Future<void> refresh() => _load(pages: _loadedPages < 1 ? 1 : _loadedPages);
+
+  Future<void> _load({required int pages}) async {
     final gen = ++_fetchGeneration;
     _isLoading = true;
     _error = null;
     if (!_disposed) notifyListeners();
 
     try {
-      final response = await _client.getNotifications(limit: 30);
+      final all = <matrix_sdk.Notification>[];
+      String? token;
+      var fetched = 0;
+      for (var page = 0; page < pages; page++) {
+        final response = await _client.getNotifications(
+          limit: 30,
+          from: page == 0 ? null : token,
+        );
+        if (_disposed || gen != _fetchGeneration) return;
+        all.addAll(response.notifications);
+        fetched++;
+        token = response.nextToken;
+        if (token == null) break;
+      }
+      final grouped = await _groupByRoom(all);
       if (_disposed || gen != _fetchGeneration) return;
-      _nextToken = response.nextToken;
-      _grouped = await _groupByRoom(response.notifications);
+      _nextToken = token;
+      _loadedPages = fetched < 1 ? 1 : fetched;
+      _grouped = grouped;
       _updateUnreadCount();
     } catch (e) {
       if (_disposed || gen != _fetchGeneration) return;
@@ -154,15 +180,19 @@ class InboxController extends ChangeNotifier {
         from: _nextToken,
       );
       if (_disposed || gen != _fetchGeneration) return;
-      _nextToken = response.nextToken;
 
-      // Merge new notifications into existing groups
+      // Merge new notifications into existing groups. Duplicates straddling
+      // a token boundary are deduped by event id in _groupByRoom.
       final all = <matrix_sdk.Notification>[];
       for (final group in _grouped) {
         all.addAll(group.notifications);
       }
       all.addAll(response.notifications);
-      _grouped = await _groupByRoom(all);
+      final grouped = await _groupByRoom(all);
+      if (_disposed || gen != _fetchGeneration) return;
+      _nextToken = response.nextToken;
+      _loadedPages++;
+      _grouped = grouped;
       _updateUnreadCount();
     } catch (e) {
       if (_disposed || gen != _fetchGeneration) return;
@@ -190,6 +220,7 @@ class InboxController extends ChangeNotifier {
     }
     _grouped = [];
     _nextToken = null;
+    _loadedPages = 1;
     _updateUnreadCount();
     if (!_disposed) notifyListeners();
     unawaited(fetch().catchError((Object e) => debugPrint('[Kohera] Inbox fetch error: $e')));
@@ -231,7 +262,7 @@ class InboxController extends ChangeNotifier {
     _debounce = Timer(_debounceDelay, () {
       if (_disposed || _tokenExpired) return;
       if (_isLoading || _markingAsRead) return;
-      unawaited(fetch());
+      unawaited(refresh());
     });
   }
 
@@ -322,7 +353,7 @@ class InboxController extends ChangeNotifier {
         return;
       }
       debugPrint('[Kohera] Inbox markRoomAsRead error: $e');
-      await fetch();
+      await refresh();
     } finally {
       _markingAsRead = false;
     }
@@ -339,6 +370,7 @@ class InboxController extends ChangeNotifier {
     _grouped = [];
     _decryptedContent.clear();
     _nextToken = null;
+    _loadedPages = 1;
     _isLoading = false;
     _error = null;
     _updateUnreadCount();
@@ -412,9 +444,11 @@ class InboxController extends ChangeNotifier {
       List<matrix_sdk.Notification> notifications,) async {
     final map = <String, List<matrix_sdk.Notification>>{};
     final order = <String>[];
+    final seen = <String>{};
 
     for (final n in notifications) {
       if (n.read) continue;
+      if (!seen.add(n.event.eventId)) continue;
       final room = _client.getRoomById(n.roomId);
       if (room == null || room.membership != Membership.join) continue;
       await _tryDecrypt(n);

--- a/lib/features/notifications/services/inbox_controller.dart
+++ b/lib/features/notifications/services/inbox_controller.dart
@@ -75,7 +75,6 @@ class InboxController extends ChangeNotifier {
 
   int _fetchGeneration = 0;
   int _cachedUnreadCount = 0;
-  int _loadedPages = 1;
 
   final Map<String, Map<String, Object?>> _decryptedContent = {};
 
@@ -111,42 +110,60 @@ class InboxController extends ChangeNotifier {
 
   // ── Fetch ──────────────────────────────────────────────────
 
-  /// Loads the first page, resetting any accumulated pagination.
-  Future<void> fetch() => _load(pages: 1);
+  List<matrix_sdk.Notification> get _flatNotifications => [
+        for (final group in _grouped) ...group.notifications,
+      ];
 
-  /// Re-fetches the pages the user has already loaded.
-  ///
-  /// Used by the sync-driven background refresh so an incoming event or
-  /// receipt does not discard pages already paged in with [loadMore] and
-  /// collapse the list back to the first 30 notifications.
-  Future<void> refresh() => _load(pages: _loadedPages < 1 ? 1 : _loadedPages);
+  Future<void> fetch() => _withLoad((gen) async {
+        final response = await _client.getNotifications(limit: 30);
+        if (_disposed || gen != _fetchGeneration) return null;
+        final grouped = await _groupByRoom(response.notifications);
+        return (grouped: grouped, token: response.nextToken);
+      });
 
-  Future<void> _load({required int pages}) async {
+  Future<void> refresh() => _withLoad((gen) async {
+        final response = await _client.getNotifications(limit: 30);
+        if (_disposed || gen != _fetchGeneration) return null;
+        final headIds =
+            response.notifications.map((n) => n.event.eventId).toSet();
+        final grouped = await _groupByRoom([
+          ...response.notifications,
+          for (final n in _flatNotifications)
+            if (!headIds.contains(n.event.eventId)) n,
+        ]);
+        return (grouped: grouped, token: _nextToken);
+      });
+
+  Future<void> loadMore() async {
+    if (_nextToken == null || _isLoading) return;
+    await _withLoad((gen) async {
+      final response = await _client.getNotifications(
+        limit: 30,
+        from: _nextToken,
+      );
+      if (_disposed || gen != _fetchGeneration) return null;
+      final grouped = await _groupByRoom([
+        ..._flatNotifications,
+        ...response.notifications,
+      ]);
+      return (grouped: grouped, token: response.nextToken);
+    });
+  }
+
+  Future<void> _withLoad(
+    Future<({List<NotificationGroup> grouped, String? token})?> Function(int gen)
+        build,
+  ) async {
     final gen = ++_fetchGeneration;
     _isLoading = true;
     _error = null;
     if (!_disposed) notifyListeners();
 
     try {
-      final all = <matrix_sdk.Notification>[];
-      String? token;
-      var fetched = 0;
-      for (var page = 0; page < pages; page++) {
-        final response = await _client.getNotifications(
-          limit: 30,
-          from: page == 0 ? null : token,
-        );
-        if (_disposed || gen != _fetchGeneration) return;
-        all.addAll(response.notifications);
-        fetched++;
-        token = response.nextToken;
-        if (token == null) break;
-      }
-      final grouped = await _groupByRoom(all);
-      if (_disposed || gen != _fetchGeneration) return;
-      _nextToken = token;
-      _loadedPages = fetched < 1 ? 1 : fetched;
-      _grouped = grouped;
+      final result = await build(gen);
+      if (result == null || _disposed || gen != _fetchGeneration) return;
+      _nextToken = result.token;
+      _grouped = result.grouped;
       _updateUnreadCount();
     } catch (e) {
       if (_disposed || gen != _fetchGeneration) return;
@@ -157,47 +174,7 @@ class InboxController extends ChangeNotifier {
         return;
       }
       _error = e.toString();
-      debugPrint('[Kohera] Inbox fetch error: $e');
-    } finally {
-      if (!_disposed && gen == _fetchGeneration) {
-        _isLoading = false;
-        notifyListeners();
-      }
-    }
-  }
-
-  Future<void> loadMore() async {
-    if (_nextToken == null || _isLoading) return;
-
-    final gen = ++_fetchGeneration;
-    _isLoading = true;
-    _error = null;
-    if (!_disposed) notifyListeners();
-
-    try {
-      final response = await _client.getNotifications(
-        limit: 30,
-        from: _nextToken,
-      );
-      if (_disposed || gen != _fetchGeneration) return;
-
-      // Merge new notifications into existing groups. Duplicates straddling
-      // a token boundary are deduped by event id in _groupByRoom.
-      final all = <matrix_sdk.Notification>[];
-      for (final group in _grouped) {
-        all.addAll(group.notifications);
-      }
-      all.addAll(response.notifications);
-      final grouped = await _groupByRoom(all);
-      if (_disposed || gen != _fetchGeneration) return;
-      _nextToken = response.nextToken;
-      _loadedPages++;
-      _grouped = grouped;
-      _updateUnreadCount();
-    } catch (e) {
-      if (_disposed || gen != _fetchGeneration) return;
-      _error = e.toString();
-      debugPrint('[Kohera] Inbox loadMore error: $e');
+      debugPrint('[Kohera] Inbox load error: $e');
     } finally {
       if (!_disposed && gen == _fetchGeneration) {
         _isLoading = false;
@@ -220,7 +197,6 @@ class InboxController extends ChangeNotifier {
     }
     _grouped = [];
     _nextToken = null;
-    _loadedPages = 1;
     _updateUnreadCount();
     if (!_disposed) notifyListeners();
     unawaited(fetch().catchError((Object e) => debugPrint('[Kohera] Inbox fetch error: $e')));
@@ -370,7 +346,6 @@ class InboxController extends ChangeNotifier {
     _grouped = [];
     _decryptedContent.clear();
     _nextToken = null;
-    _loadedPages = 1;
     _isLoading = false;
     _error = null;
     _updateUnreadCount();

--- a/test/services/inbox_controller_test.dart
+++ b/test/services/inbox_controller_test.dart
@@ -356,7 +356,7 @@ void main() {
           ),);
     }
 
-    test('refresh re-fetches the loaded depth instead of collapsing', () async {
+    test('refresh merges the head and keeps loaded pages', () async {
       stubTwoPages();
 
       await controller.fetch();
@@ -364,12 +364,24 @@ void main() {
       expect(controller.grouped, hasLength(2));
       expect(controller.hasMore, isTrue);
 
+      clearInteractions(mockClient);
       await controller.refresh();
 
-      // Both pages retained; pagination token preserved at the loaded depth.
+      // Both pages retained; deep pagination token preserved.
       expect(controller.grouped, hasLength(2));
       expect(controller.grouped.map((g) => g.roomId), ['!r2:x', '!r1:x']);
       expect(controller.hasMore, isTrue);
+
+      // Only the first page is re-fetched, not the whole loaded depth.
+      verify(mockClient.getNotifications(
+        limit: anyNamed('limit'),
+        only: anyNamed('only'),
+      ),).called(1);
+      verifyNever(mockClient.getNotifications(
+        limit: anyNamed('limit'),
+        from: 'page2',
+        only: anyNamed('only'),
+      ),);
     });
 
     test('sync update does not collapse paged-in list', () {

--- a/test/services/inbox_controller_test.dart
+++ b/test/services/inbox_controller_test.dart
@@ -306,6 +306,112 @@ void main() {
       expect(controller.grouped, hasLength(1));
       expect(controller.grouped[0].roomId, '!new:x');
     });
+
+    test('dedups notifications by event id across a page boundary', () async {
+      when(mockClient.getNotifications(
+        limit: anyNamed('limit'),
+        only: anyNamed('only'),
+      ),).thenAnswer((_) async => _makeResponse(
+            [_makeNotification(eventId: 'e1', roomId: '!r1:x')],
+            nextToken: 'page2',
+          ),);
+
+      await controller.fetch();
+
+      // Page two repeats e1 (straddling the token boundary) plus a new e2.
+      when(mockClient.getNotifications(
+        limit: anyNamed('limit'),
+        from: 'page2',
+        only: anyNamed('only'),
+      ),).thenAnswer((_) async => _makeResponse([
+            _makeNotification(eventId: 'e1', roomId: '!r1:x'),
+            _makeNotification(eventId: 'e2', roomId: '!r1:x', ts: 2000),
+          ]),);
+
+      await controller.loadMore();
+
+      expect(controller.grouped, hasLength(1));
+      expect(controller.grouped[0].notifications, hasLength(2));
+    });
+  });
+
+  // ── sync refresh preserves pagination (#625) ────────────────
+
+  group('sync-driven refresh', () {
+    void stubTwoPages() {
+      when(mockClient.getNotifications(
+        limit: anyNamed('limit'),
+        only: anyNamed('only'),
+      ),).thenAnswer((_) async => _makeResponse(
+            [_makeNotification(eventId: 'e1', roomId: '!r1:x')],
+            nextToken: 'page2',
+          ),);
+      when(mockClient.getNotifications(
+        limit: anyNamed('limit'),
+        from: 'page2',
+        only: anyNamed('only'),
+      ),).thenAnswer((_) async => _makeResponse(
+            [_makeNotification(eventId: 'e2', roomId: '!r2:x', ts: 2000)],
+            nextToken: 'page3',
+          ),);
+    }
+
+    test('refresh re-fetches the loaded depth instead of collapsing', () async {
+      stubTwoPages();
+
+      await controller.fetch();
+      await controller.loadMore();
+      expect(controller.grouped, hasLength(2));
+      expect(controller.hasMore, isTrue);
+
+      await controller.refresh();
+
+      // Both pages retained; pagination token preserved at the loaded depth.
+      expect(controller.grouped, hasLength(2));
+      expect(controller.grouped.map((g) => g.roomId), ['!r2:x', '!r1:x']);
+      expect(controller.hasMore, isTrue);
+    });
+
+    test('sync update does not collapse paged-in list', () {
+      fakeAsync((async) {
+        stubTwoPages();
+
+        unawaited(controller.fetch());
+        async.flushMicrotasks();
+        unawaited(controller.loadMore());
+        async.flushMicrotasks();
+        expect(controller.grouped, hasLength(2));
+
+        controller.startPolling();
+        async.flushMicrotasks();
+        syncCtl.add(SyncUpdate(
+          nextBatch: 'tok',
+          rooms: RoomsUpdate(
+            join: {
+              '!r1:x': JoinedRoomUpdate(
+                timeline: TimelineUpdate(events: [
+                  MatrixEvent(
+                    type: 'm.room.message',
+                    content: const {'body': 'hi', 'msgtype': 'm.text'},
+                    senderId: '@bob:example.com',
+                    eventId: 'sync-evt',
+                    originServerTs: DateTime.fromMillisecondsSinceEpoch(1000),
+                    roomId: '!r1:x',
+                  ),
+                ],),
+              ),
+            },
+          ),
+        ),);
+        async.elapse(const Duration(seconds: 1));
+        async.flushMicrotasks();
+        controller.stopPolling();
+
+        // The debounced refresh kept both pages rather than resetting to 30.
+        expect(controller.grouped, hasLength(2));
+        expect(controller.hasMore, isTrue);
+      });
+    });
   });
 
   // ── markRoomAsRead() ────────────────────────────────────────


### PR DESCRIPTION
## Summary

While the inbox is open, sync updates trigger a debounced refresh that used to call `fetch()` — which requests only page one and replaces the list wholesale. If the user had tapped "Load more" several times, any incoming event or read receipt collapsed the list back to the first 30 notifications. A background refresh now preserves the pages already loaded.

## Changes

- `inbox_controller.dart`:
  - Refactored `fetch()`/`loadMore()` around a shared `_load({pages})` that pages from the start up to N pages, accumulating notifications and capturing the final pagination token.
  - Added `_loadedPages` tracking (reset on `fetch`/`setFilter`/`updateClient`, incremented in `loadMore`).
  - Added `refresh()` = `_load(pages: _loadedPages)`; the sync debounce and the `markRoomAsRead` error fallback now call `refresh()` instead of `fetch()`.
  - `_groupByRoom` now dedups by `event.eventId`, fixing the related bug where an event straddling a page boundary appeared twice after `loadMore`.

## Testing

- [x] `flutter analyze` is clean
- [x] `flutter test test/services/inbox_controller_test.dart` — 51 existing + 3 new pass
  - sync update does not collapse a paged-in list
  - `refresh()` re-fetches to the loaded depth and preserves the token
  - `loadMore` dedups across a page boundary
- [x] `flutter test test/widgets/inbox_screen_test.dart` passes

## Linked issues

Closes #625

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master`