### PR TITLE
refactor: extract cross-cutting UI helpers to cut duplication

### DIFF
--- a/lib/core/extensions/context_extension.dart
+++ b/lib/core/extensions/context_extension.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+/// Convenience helpers on [BuildContext] for common UI actions.
+extension ContextExtension on BuildContext {
+  /// Shows a simple text [SnackBar] via the nearest [ScaffoldMessenger].
+  void showSnack(String message) {
+    ScaffoldMessenger.of(this).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+}

--- a/lib/core/utils/confirm_dialog.dart
+++ b/lib/core/utils/confirm_dialog.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+/// Shows a standard confirmation [AlertDialog] with a cancel and a confirm
+/// action, returning `true` only when the user confirms.
+///
+/// Set [destructive] to style the confirm button with the error colour.
+Future<bool> confirmDialog(
+  BuildContext context, {
+  required String title,
+  required String message,
+  String confirmLabel = 'Confirm',
+  String cancelLabel = 'Cancel',
+  bool destructive = false,
+  bool barrierDismissible = true,
+}) async {
+  final cs = Theme.of(context).colorScheme;
+  final confirmed = await showDialog<bool>(
+    context: context,
+    barrierDismissible: barrierDismissible,
+    builder: (ctx) => AlertDialog(
+      title: Text(title),
+      content: Text(message),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(ctx, false),
+          child: Text(cancelLabel),
+        ),
+        FilledButton(
+          style: destructive
+              ? FilledButton.styleFrom(
+                  backgroundColor: cs.error,
+                  foregroundColor: cs.onError,
+                )
+              : null,
+          onPressed: () => Navigator.pop(ctx, true),
+          child: Text(confirmLabel),
+        ),
+      ],
+    ),
+  );
+  return confirmed ?? false;
+}

--- a/lib/core/utils/sender_color.dart
+++ b/lib/core/utils/sender_color.dart
@@ -2,7 +2,10 @@ import 'package:flutter/material.dart';
 
 /// Returns a deterministic colour for a Matrix sender ID, using a mix
 /// of the current theme's semantic colours and fixed accent tones.
-Color senderColor(String senderId, ColorScheme cs) {
+///
+/// When [senderId] is empty, returns [fallback] if provided.
+Color senderColor(String senderId, ColorScheme cs, {Color? fallback}) {
+  if (senderId.isEmpty && fallback != null) return fallback;
   final hash = senderId.codeUnits.fold<int>(0, (h, c) => h + c);
   final palette = [
     cs.primary,

--- a/lib/features/auth/screens/homeserver_screen.dart
+++ b/lib/features/auth/screens/homeserver_screen.dart
@@ -9,6 +9,7 @@ import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/features/auth/widgets/app_logo_header.dart';
 import 'package:kohera/features/auth/widgets/homeserver_controller.dart';
 import 'package:kohera/shared/widgets/kohera_loader.dart';
+import 'package:kohera/shared/widgets/loading_button_child.dart';
 import 'package:provider/provider.dart';
 
 class HomeserverScreen extends StatefulWidget {
@@ -207,16 +208,11 @@ class _HomeserverScreenState extends State<HomeserverScreen>
                               borderRadius: BorderRadius.circular(16),
                             ),
                           ),
-                          child: isChecking
-                              ? SizedBox(
-                                  width: 22,
-                                  height: 22,
-                                  child: CircularProgressIndicator(
-                                    strokeWidth: 2.5,
-                                    color: cs.onPrimary,
-                                  ),
-                                )
-                              : const Text('Continue'),
+                          child: LoadingButtonChild(
+                            loading: isChecking,
+                            color: cs.onPrimary,
+                            child: const Text('Continue'),
+                          ),
                         ),
                       ),
                       const SizedBox(height: 16),

--- a/lib/features/auth/screens/login_screen.dart
+++ b/lib/features/auth/screens/login_screen.dart
@@ -9,6 +9,7 @@ import 'package:kohera/core/services/client_manager.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/features/auth/widgets/login_controller.dart';
 import 'package:kohera/shared/widgets/kohera_loader.dart';
+import 'package:kohera/shared/widgets/loading_button_child.dart';
 import 'package:provider/provider.dart';
 
 class LoginScreen extends StatefulWidget {
@@ -235,16 +236,11 @@ class _LoginScreenState extends State<LoginScreen>
                             borderRadius: BorderRadius.circular(16),
                           ),
                         ),
-                        child: isLoggingIn
-                            ? SizedBox(
-                                width: 22,
-                                height: 22,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2.5,
-                                  color: cs.onPrimary,
-                                ),
-                              )
-                            : const Text('Sign In'),
+                        child: LoadingButtonChild(
+                          loading: isLoggingIn,
+                          color: cs.onPrimary,
+                          child: const Text('Sign In'),
+                        ),
                       ),
                     ),
                   ],

--- a/lib/features/auth/screens/registration_screen.dart
+++ b/lib/features/auth/screens/registration_screen.dart
@@ -9,6 +9,7 @@ import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/features/auth/widgets/app_logo_header.dart';
 import 'package:kohera/features/auth/widgets/registration_controller.dart';
 import 'package:kohera/features/auth/widgets/registration_views.dart';
+import 'package:kohera/shared/widgets/loading_button_child.dart';
 import 'package:provider/provider.dart';
 
 class RegistrationScreen extends StatefulWidget {
@@ -301,16 +302,11 @@ class _RegistrationScreenState extends State<RegistrationScreen>
                           borderRadius: BorderRadius.circular(16),
                         ),
                       ),
-                      child: isRegistering
-                          ? SizedBox(
-                              width: 22,
-                              height: 22,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2.5,
-                                color: cs.onPrimary,
-                              ),
-                            )
-                          : const Text('Create Account'),
+                      child: LoadingButtonChild(
+                        loading: isRegistering,
+                        color: cs.onPrimary,
+                        child: const Text('Create Account'),
+                      ),
                     ),
                   ),
                   const SizedBox(height: 16),

--- a/lib/features/chat/screens/chat_screen.dart
+++ b/lib/features/chat/screens/chat_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart'
 import 'package:flutter/material.dart';
 import 'package:giphy_get/giphy_get.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/models/pending_attachment.dart';
 import 'package:kohera/core/models/sticker_pack.dart';
 import 'package:kohera/core/models/upload_state.dart';
@@ -363,13 +364,11 @@ class _ChatScreenState extends State<ChatScreen>
       case AddAttachmentResult.ok:
         return;
       case AddAttachmentResult.tooMany:
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Maximum ${ComposeStateController.maxAttachments} attachments allowed')),
+        context.showSnack(
+          'Maximum ${ComposeStateController.maxAttachments} attachments allowed',
         );
       case AddAttachmentResult.tooLarge:
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('File exceeds 25 MB limit')),
-        );
+        context.showSnack('File exceeds 25 MB limit');
     }
   }
 
@@ -517,12 +516,8 @@ class _ChatScreenState extends State<ChatScreen>
       );
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              'Failed to send sticker: ${MatrixService.friendlyAuthError(e)}',
-            ),
-          ),
+        context.showSnack(
+          'Failed to send sticker: ${MatrixService.friendlyAuthError(e)}',
         );
       }
     }

--- a/lib/features/chat/screens/thread_screen.dart
+++ b/lib/features/chat/screens/thread_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/models/pending_attachment.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
@@ -101,9 +102,7 @@ class _ThreadScreenState extends State<ThreadScreen> {
       if (!mounted) return;
       setState(() => _loadingRoot = false);
       _scheduleFocusReady();
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Could not load thread')),
-      );
+      context.showSnack('Could not load thread');
     }
   }
 
@@ -151,17 +150,11 @@ class _ThreadScreenState extends State<ThreadScreen> {
   void _addAttachment(PendingAttachment attachment) {
     final result = _compose.addAttachment(attachment);
     if (result == AddAttachmentResult.tooMany) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text(
-            'Maximum ${ComposeStateController.maxAttachments} attachments allowed',
-          ),
-        ),
+      context.showSnack(
+        'Maximum ${ComposeStateController.maxAttachments} attachments allowed',
       );
     } else if (result == AddAttachmentResult.tooLarge) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('File exceeds 25 MB limit')),
-      );
+      context.showSnack('File exceeds 25 MB limit');
     }
   }
 

--- a/lib/features/chat/services/voice_recording_mixin.dart
+++ b/lib/features/chat/services/voice_recording_mixin.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/models/upload_state.dart';
 import 'package:kohera/features/chat/services/media_playback_service.dart';
 import 'package:kohera/features/chat/services/voice_recording_controller.dart';
@@ -16,9 +17,7 @@ mixin VoiceRecordingMixin<T extends StatefulWidget> on State<T> {
     context.read<MediaPlaybackService>().pauseActive();
     final started = await voiceController!.startRecording();
     if (!started && mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Microphone permission denied')),
-      );
+      context.showSnack('Microphone permission denied');
     }
   }
 

--- a/lib/features/chat/widgets/chat_app_bar.dart
+++ b/lib/features/chat/widgets/chat_app_bar.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/routing/nav_helper.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/call_service.dart';
@@ -295,11 +296,7 @@ class _CallButtonState extends State<_CallButton> {
         type: type,
       );
     } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to start call')),
-        );
-      }
+      if (mounted) context.showSnack('Failed to start call');
     } finally {
       if (mounted) setState(() => _starting = false);
     }

--- a/lib/features/chat/widgets/delete_event_dialog.dart
+++ b/lib/features/chat/widgets/delete_event_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
@@ -39,8 +40,8 @@ Future<void> confirmAndDeleteEvent(BuildContext context, Event event) async {
     await event.room.redactEvent(event.eventId);
   } catch (e) {
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to delete: ${MatrixService.friendlyAuthError(e)}')),
+      context.showSnack(
+        'Failed to delete: ${MatrixService.friendlyAuthError(e)}',
       );
     }
   }

--- a/lib/features/chat/widgets/forward_message_dialog.dart
+++ b/lib/features/chat/widgets/forward_message_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/features/chat/services/message_forwarder.dart';
 import 'package:kohera/shared/widgets/room_avatar.dart';
@@ -74,12 +75,8 @@ class _ForwardMessageDialogState extends State<ForwardMessageDialog> {
       debugPrint('[Kohera] Failed to forward message: $e');
       if (!mounted) return;
       setState(() => _sending = false);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            'Failed to forward: ${MatrixService.friendlyAuthError(e)}',
-          ),
-        ),
+      context.showSnack(
+        'Failed to forward: ${MatrixService.friendlyAuthError(e)}',
       );
       return;
     }

--- a/lib/features/chat/widgets/message_bubble_context_menu.dart
+++ b/lib/features/chat/widgets/message_bubble_context_menu.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:kohera/core/utils/reply_fallback.dart';
+import 'package:kohera/shared/widgets/popup_menu_item_row.dart';
 import 'package:matrix/matrix.dart';
 
 Future<void> showMessageContextMenu(
@@ -22,31 +23,31 @@ Future<void> showMessageContextMenu(
   final isFailed = event.status.isError;
   final items = <PopupMenuItem<String>>[
     if (isFailed) ...[
-      _menuItem(Icons.refresh_rounded, 'Retry sending', 'outbox_retry'),
-      _menuItem(
+      menuItemRow(Icons.refresh_rounded, 'Retry sending', 'outbox_retry'),
+      menuItemRow(
         Icons.delete_outline_rounded,
         'Discard message',
         'outbox_discard',
         color: cs.error,
       ),
     ] else ...[
-      if (onReply != null) _menuItem(Icons.reply_rounded, 'Reply', 'reply'),
+      if (onReply != null) menuItemRow(Icons.reply_rounded, 'Reply', 'reply'),
       if (onReplyInThread != null)
-        _menuItem(Icons.forum_outlined, 'Reply in thread', 'reply_in_thread'),
-      if (onEdit != null) _menuItem(Icons.edit_rounded, 'Edit', 'edit'),
+        menuItemRow(Icons.forum_outlined, 'Reply in thread', 'reply_in_thread'),
+      if (onEdit != null) menuItemRow(Icons.edit_rounded, 'Edit', 'edit'),
       if (onReact != null)
-        _menuItem(Icons.add_reaction_outlined, 'React', 'react'),
-      if (!event.redacted) _menuItem(Icons.copy_rounded, 'Copy', 'copy'),
+        menuItemRow(Icons.add_reaction_outlined, 'React', 'react'),
+      if (!event.redacted) menuItemRow(Icons.copy_rounded, 'Copy', 'copy'),
       if (onForward != null)
-        _menuItem(Icons.forward_rounded, 'Forward', 'forward'),
+        menuItemRow(Icons.forward_rounded, 'Forward', 'forward'),
       if (onPin != null)
-        _menuItem(
+        menuItemRow(
           isPinned ? Icons.push_pin_rounded : Icons.push_pin_outlined,
           isPinned ? 'Unpin' : 'Pin',
           'pin',
         ),
       if (onDelete != null)
-        _menuItem(
+        menuItemRow(
           Icons.delete_outline_rounded,
           isMe ? 'Delete' : 'Remove',
           'delete',
@@ -92,22 +93,4 @@ Future<void> showMessageContextMenu(
         ClipboardData(text: stripReplyFallback(displayEvent.body)),);
   }
   if (value == 'delete') onDelete?.call();
-}
-
-PopupMenuItem<String> _menuItem(
-  IconData icon,
-  String label,
-  String value, {
-  Color? color,
-}) {
-  return PopupMenuItem<String>(
-    value: value,
-    child: Row(
-      children: [
-        Icon(icon, size: 18, color: color),
-        const SizedBox(width: 8),
-        Text(label, style: color == null ? null : TextStyle(color: color)),
-      ],
-    ),
-  );
 }

--- a/lib/features/chat/widgets/pinned_messages_popup.dart
+++ b/lib/features/chat/widgets/pinned_messages_popup.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/utils/reply_fallback.dart';
 import 'package:kohera/features/chat/widgets/html_message_text.dart';
 import 'package:kohera/features/chat/widgets/linkable_text.dart';
@@ -184,11 +185,7 @@ class _PinnedMessagesPanelState extends State<_PinnedMessagesPanel> {
         if (_pinnedEvents?.isEmpty ?? true) widget.onClose();
       }
     } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to unpin message')),
-        );
-      }
+      if (mounted) context.showSnack('Failed to unpin message');
     }
   }
 

--- a/lib/features/e2ee/screens/e2ee_setup_screen.dart
+++ b/lib/features/e2ee/screens/e2ee_setup_screen.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/chat_backup_service.dart';
+import 'package:kohera/core/utils/confirm_dialog.dart';
 import 'package:kohera/features/e2ee/widgets/bootstrap_controller.dart';
 import 'package:kohera/features/e2ee/widgets/key_verification_inline.dart';
 import 'package:kohera/shared/widgets/kohera_loader.dart';
@@ -16,30 +17,17 @@ import 'package:url_launcher/url_launcher.dart';
 const String _recoveryKeyDocsUrl =
     'https://github.com/Quantumheart/Kohera/blob/master/docs/recovery-key-storage.md';
 
-Future<bool> showRecoveryKeySavedConfirmation(BuildContext context) async {
-  final result = await showDialog<bool>(
-    context: context,
-    barrierDismissible: false,
-    builder: (ctx) => AlertDialog(
-      title: const Text('Have you saved your recovery key?'),
-      content: const Text(
-        'If you lose this key, your encrypted messages cannot be '
+Future<bool> showRecoveryKeySavedConfirmation(BuildContext context) {
+  return confirmDialog(
+    context,
+    title: 'Have you saved your recovery key?',
+    message: 'If you lose this key, your encrypted messages cannot be '
         "recovered. Make sure it's stored somewhere you'll still have "
         'access to if you lose this device.',
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.pop(ctx, false),
-          child: const Text('Not yet'),
-        ),
-        FilledButton(
-          onPressed: () => Navigator.pop(ctx, true),
-          child: const Text("I've saved it"),
-        ),
-      ],
-    ),
+    confirmLabel: "I've saved it",
+    cancelLabel: 'Not yet',
+    barrierDismissible: false,
   );
-  return result ?? false;
 }
 
 // ── Screen-local steps (outside bootstrap lifecycle) ───────────

--- a/lib/features/rooms/widgets/add_existing_rooms_dialog.dart
+++ b/lib/features/rooms/widgets/add_existing_rooms_dialog.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/shared/widgets/loading_button_child.dart';
 import 'package:kohera/shared/widgets/room_avatar.dart';
 import 'package:matrix/matrix.dart' hide Visibility;
 
@@ -87,9 +89,7 @@ class _AddExistingRoomsDialogState extends State<AddExistingRoomsDialog> {
     if (!mounted) return;
 
     if (failures > 0) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to add $failures room(s)')),
-      );
+      context.showSnack('Failed to add $failures room(s)');
       setState(() => _loading = false);
       return;
     }
@@ -170,13 +170,10 @@ class _AddExistingRoomsDialogState extends State<AddExistingRoomsDialog> {
         if (_eligibleRooms.isNotEmpty)
           FilledButton(
             onPressed: _loading || _selected.isEmpty ? null : _submit,
-            child: _loading
-                ? const SizedBox(
-                    width: 22,
-                    height: 22,
-                    child: CircularProgressIndicator(strokeWidth: 2.5),
-                  )
-                : Text('Add (${_selected.length})'),
+            child: LoadingButtonChild(
+              loading: _loading,
+              child: Text('Add (${_selected.length})'),
+            ),
           ),
       ],
     );

--- a/lib/features/rooms/widgets/add_room_to_space_dialog.dart
+++ b/lib/features/rooms/widgets/add_room_to_space_dialog.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/shared/widgets/loading_button_child.dart';
 import 'package:kohera/shared/widgets/room_avatar.dart';
 import 'package:matrix/matrix.dart' hide Visibility;
 
@@ -74,9 +76,7 @@ class _AddRoomToSpaceDialogState extends State<AddRoomToSpaceDialog> {
     if (!mounted) return;
 
     if (failures > 0) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to add room to $failures space(s)')),
-      );
+      context.showSnack('Failed to add room to $failures space(s)');
     }
 
     Navigator.pop(context);
@@ -142,13 +142,10 @@ class _AddRoomToSpaceDialogState extends State<AddRoomToSpaceDialog> {
         if (eligible.isNotEmpty)
           FilledButton(
             onPressed: _loading || !_hasSelection ? null : _submit,
-            child: _loading
-                ? const SizedBox(
-                    width: 22,
-                    height: 22,
-                    child: CircularProgressIndicator(strokeWidth: 2.5),
-                  )
-                : const Text('Add'),
+            child: LoadingButtonChild(
+              loading: _loading,
+              child: const Text('Add'),
+            ),
           ),
       ],
     );

--- a/lib/features/rooms/widgets/admin_settings_section.dart
+++ b/lib/features/rooms/widgets/admin_settings_section.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/core/utils/confirm_dialog.dart';
 import 'package:matrix/matrix.dart';
 
 /// Admin settings for a room: edit name, topic, encryption,
@@ -91,33 +92,16 @@ class _AdminSettingsSectionState extends State<AdminSettingsSection> {
   }
 
   Future<void> _enableEncryption() async {
-    final cs = Theme.of(context).colorScheme;
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Enable encryption?'),
-        content: const Text(
-          'This action is irreversible. Once encryption is enabled, '
+    final confirmed = await confirmDialog(
+      context,
+      title: 'Enable encryption?',
+      message: 'This action is irreversible. Once encryption is enabled, '
           'it cannot be disabled.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            style: FilledButton.styleFrom(
-              backgroundColor: cs.error,
-              foregroundColor: cs.onError,
-            ),
-            onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('Enable'),
-          ),
-        ],
-      ),
+      confirmLabel: 'Enable',
+      destructive: true,
     );
 
-    if (confirmed != true || !mounted) return;
+    if (!confirmed || !mounted) return;
     await _run('encryption', () => widget.room.enableEncryption(), successMessage: 'Encryption enabled');
   }
 

--- a/lib/features/rooms/widgets/invite_dialog.dart
+++ b/lib/features/rooms/widgets/invite_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
+import 'package:kohera/core/utils/confirm_dialog.dart';
 import 'package:kohera/shared/widgets/room_avatar.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
@@ -52,26 +53,13 @@ class _InviteDialogState extends State<InviteDialog> {
   }
 
   Future<void> _decline() async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Decline invite'),
-        content: Text(
-          'Decline invite to ${widget.room.getLocalizedDisplayname()}?',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('Decline'),
-          ),
-        ],
-      ),
+    final confirmed = await confirmDialog(
+      context,
+      title: 'Decline invite',
+      message: 'Decline invite to ${widget.room.getLocalizedDisplayname()}?',
+      confirmLabel: 'Decline',
     );
-    if (confirmed != true || !mounted) return;
+    if (!confirmed || !mounted) return;
 
     setState(() { _declining = true; _error = null; });
     try {

--- a/lib/features/rooms/widgets/invite_tile.dart
+++ b/lib/features/rooms/widgets/invite_tile.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
+import 'package:kohera/core/utils/confirm_dialog.dart';
 import 'package:kohera/shared/widgets/room_avatar.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
@@ -30,11 +32,7 @@ class _InviteTileState extends State<InviteTile> {
       await widget.room.join();
     } catch (e) {
       debugPrint('[Kohera] Accept invite failed: $e');
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(MatrixService.friendlyAuthError(e))),
-        );
-      }
+      if (mounted) context.showSnack(MatrixService.friendlyAuthError(e));
       if (mounted) setState(() => _isJoining = false);
       return;
     }
@@ -54,37 +52,20 @@ class _InviteTileState extends State<InviteTile> {
 
   Future<void> _decline() async {
     if (_inFlight) return;
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Decline invite'),
-        content: Text(
-          'Decline invite to ${widget.room.getLocalizedDisplayname()}?',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('Decline'),
-          ),
-        ],
-      ),
+    final confirmed = await confirmDialog(
+      context,
+      title: 'Decline invite',
+      message: 'Decline invite to ${widget.room.getLocalizedDisplayname()}?',
+      confirmLabel: 'Decline',
     );
-    if (confirmed != true || !mounted) return;
+    if (!confirmed || !mounted) return;
 
     setState(() => _isDeclining = true);
     try {
       await widget.room.leave();
     } catch (e) {
       debugPrint('[Kohera] Decline invite failed: $e');
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(MatrixService.friendlyAuthError(e))),
-        );
-      }
+      if (mounted) context.showSnack(MatrixService.friendlyAuthError(e));
     } finally {
       if (mounted) setState(() => _isDeclining = false);
     }

--- a/lib/features/rooms/widgets/join_access_controller.dart
+++ b/lib/features/rooms/widgets/join_access_controller.dart
@@ -6,6 +6,7 @@ import 'package:kohera/core/models/join_mode.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/space_access_service.dart';
+import 'package:kohera/core/utils/confirm_dialog.dart';
 import 'package:kohera/shared/widgets/join_access_section.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
@@ -179,27 +180,14 @@ class _JoinAccessControllerState extends State<JoinAccessController> {
       return;
     }
 
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Upgrade room?'),
-        content: Text(
-          'Upgrading this room creates a replacement room (v$newVersion). '
+    final confirmed = await confirmDialog(
+      context,
+      title: 'Upgrade room?',
+      message: 'Upgrading this room creates a replacement room (v$newVersion). '
           'Members will need to rejoin via the tombstone. Continue?',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('Upgrade'),
-          ),
-        ],
-      ),
+      confirmLabel: 'Upgrade',
     );
-    if (confirmed != true || !mounted) return;
+    if (!confirmed || !mounted) return;
 
     final selection = context.read<MatrixService>().selection;
     final parents = selection.parentSpacesOf(widget.room);

--- a/lib/features/rooms/widgets/new_room_dialog.dart
+++ b/lib/features/rooms/widgets/new_room_dialog.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart' hide Visibility;
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/models/join_mode.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/utils/known_contacts.dart';
 import 'package:kohera/shared/widgets/join_access_section.dart';
+import 'package:kohera/shared/widgets/loading_button_child.dart';
 import 'package:matrix/matrix.dart';
 
 // ── New Room dialog ───────────────────────────────────────────
@@ -378,12 +380,8 @@ class _NewRoomDialogState extends State<NewRoomDialog> {
         }
         widget.matrixService.selection.invalidateSpaceTree();
         if (spaceFailures > 0 && mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(
-                'Room created, but failed to add to $spaceFailures space(s)',
-              ),
-            ),
+          context.showSnack(
+            'Room created, but failed to add to $spaceFailures space(s)',
           );
         }
       }
@@ -552,13 +550,10 @@ class _NewRoomDialogState extends State<NewRoomDialog> {
         ),
         FilledButton(
           onPressed: _loading ? null : _submit,
-          child: _loading
-              ? const SizedBox(
-                  width: 22,
-                  height: 22,
-                  child: CircularProgressIndicator(strokeWidth: 2.5),
-                )
-              : const Text('Create'),
+          child: LoadingButtonChild(
+            loading: _loading,
+            child: const Text('Create'),
+          ),
         ),
       ],
     );

--- a/lib/features/rooms/widgets/room_context_menu.dart
+++ b/lib/features/rooms/widgets/room_context_menu.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
+import 'package:kohera/core/utils/confirm_dialog.dart';
 import 'package:kohera/core/utils/order_utils.dart' as order_utils;
 import 'package:kohera/features/rooms/widgets/add_room_to_space_dialog.dart';
+import 'package:kohera/shared/widgets/popup_menu_item_row.dart';
 import 'package:matrix/matrix.dart' hide Visibility;
 import 'package:provider/provider.dart';
 
@@ -65,38 +68,17 @@ Future<void> showRoomContextMenu(
     constraints: const BoxConstraints(minWidth: 200, maxWidth: 320),
     items: [
       if (canMoveUp)
-        const PopupMenuItem(
-          value: _RoomContextAction.moveUp,
-          child: Row(
-            children: [
-              Icon(Icons.arrow_upward_rounded, size: 18),
-              SizedBox(width: 8),
-              Text('Move up'),
-            ],
-          ),
-        ),
+        menuItemRow(
+          Icons.arrow_upward_rounded, 'Move up', _RoomContextAction.moveUp,),
       if (canMoveDown)
-        const PopupMenuItem(
-          value: _RoomContextAction.moveDown,
-          child: Row(
-            children: [
-              Icon(Icons.arrow_downward_rounded, size: 18),
-              SizedBox(width: 8),
-              Text('Move down'),
-            ],
-          ),
+        menuItemRow(
+          Icons.arrow_downward_rounded,
+          'Move down',
+          _RoomContextAction.moveDown,
         ),
       if (canAdd)
-        const PopupMenuItem(
-          value: _RoomContextAction.addToSpace,
-          child: Row(
-            children: [
-              Icon(Icons.add_link_rounded, size: 18),
-              SizedBox(width: 8),
-              Text('Add to space'),
-            ],
-          ),
-        ),
+        menuItemRow(
+          Icons.add_link_rounded, 'Add to space', _RoomContextAction.addToSpace,),
       if (canRemove)
         PopupMenuItem(
           value: _RoomContextAction.removeFromSpace,
@@ -181,11 +163,7 @@ Future<void> _handleReorder(
     selection.invalidateSpaceTree();
   } catch (e) {
     debugPrint('[Kohera] Reorder failed: $e');
-    if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to reorder: $e')),
-      );
-    }
+    if (context.mounted) context.showSnack('Failed to reorder: $e');
   }
 }
 
@@ -194,39 +172,22 @@ Future<void> _handleRemoveFromSpace(
   Room space,
   Room room,
 ) async {
-  final confirmed = await showDialog<bool>(
-    context: context,
-    builder: (ctx) => AlertDialog(
-      title: const Text('Remove from space?'),
-      content: Text(
-        'Remove "${room.getLocalizedDisplayname()}" from '
+  final confirmed = await confirmDialog(
+    context,
+    title: 'Remove from space?',
+    message: 'Remove "${room.getLocalizedDisplayname()}" from '
         '"${space.getLocalizedDisplayname()}"? The room won\'t be deleted, '
         'just unlinked from the space.',
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.pop(ctx, false),
-          child: const Text('Cancel'),
-        ),
-        FilledButton(
-          onPressed: () => Navigator.pop(ctx, true),
-          child: const Text('Remove'),
-        ),
-      ],
-    ),
+    confirmLabel: 'Remove',
   );
 
-  if (confirmed != true || !context.mounted) return;
+  if (!confirmed || !context.mounted) return;
 
   try {
     final selection = context.read<SelectionService>();
     await space.removeSpaceChild(room.id);
     selection.invalidateSpaceTree();
   } catch (e) {
-    if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to remove room: $e')),
-      );
-    }
+    if (context.mounted) context.showSnack('Failed to remove room: $e');
   }
 }

--- a/lib/features/rooms/widgets/room_details_panel.dart
+++ b/lib/features/rooms/widgets/room_details_panel.dart
@@ -5,6 +5,7 @@ import 'package:kohera/core/routing/nav_helper.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
+import 'package:kohera/core/utils/confirm_dialog.dart';
 import 'package:kohera/features/e2ee/widgets/key_verification_dialog.dart';
 import 'package:kohera/features/rooms/widgets/admin_settings_section.dart';
 import 'package:kohera/features/rooms/widgets/invite_user_dialog.dart';
@@ -118,30 +119,15 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
   }
 
   Future<void> _confirmLeave(Room room) async {
-    final cs = Theme.of(context).colorScheme;
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Leave room?'),
-        content: Text('You will leave "${room.getLocalizedDisplayname()}".'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            style: FilledButton.styleFrom(
-              backgroundColor: cs.error,
-              foregroundColor: cs.onError,
-            ),
-            onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('Leave'),
-          ),
-        ],
-      ),
+    final confirmed = await confirmDialog(
+      context,
+      title: 'Leave room?',
+      message: 'You will leave "${room.getLocalizedDisplayname()}".',
+      confirmLabel: 'Leave',
+      destructive: true,
     );
 
-    if (confirmed != true || !mounted) return;
+    if (!confirmed || !mounted) return;
 
     final selectionService = context.read<SelectionService>();
     final navigator = Navigator.of(context);

--- a/lib/features/rooms/widgets/room_members_section.dart
+++ b/lib/features/rooms/widgets/room_members_section.dart
@@ -3,10 +3,12 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/presence_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
+import 'package:kohera/core/utils/confirm_dialog.dart';
 import 'package:kohera/features/rooms/models/room_role.dart';
 import 'package:kohera/features/rooms/services/power_level_service.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
@@ -380,31 +382,14 @@ class _MemberSheetDialogState extends State<_MemberSheetDialog> {
     // Require explicit confirmation before demoting another admin.
     if (currentPowerLevel >= 100) {
       final displayName = widget.user.displayName ?? widget.user.id;
-      final cs = Theme.of(context).colorScheme;
-      final confirmed = await showDialog<bool>(
-        context: context,
-        builder: (ctx) => AlertDialog(
-          title: const Text('Demote admin?'),
-          content: Text(
-            'This will demote $displayName from admin. Are you sure?',
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(ctx, false),
-              child: const Text('Cancel'),
-            ),
-            FilledButton(
-              style: FilledButton.styleFrom(
-                backgroundColor: cs.error,
-                foregroundColor: cs.onError,
-              ),
-              onPressed: () => Navigator.pop(ctx, true),
-              child: const Text('Demote'),
-            ),
-          ],
-        ),
+      final confirmed = await confirmDialog(
+        context,
+        title: 'Demote admin?',
+        message: 'This will demote $displayName from admin. Are you sure?',
+        confirmLabel: 'Demote',
+        destructive: true,
       );
-      if (confirmed != true || !mounted) return;
+      if (!confirmed || !mounted) return;
     }
 
     setState(() {
@@ -489,24 +474,13 @@ class _MemberSheetDialogState extends State<_MemberSheetDialog> {
 
   Future<void> _unban() async {
     final displayName = widget.user.displayName ?? widget.user.id;
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Unban member?'),
-        content: Text('Allow $displayName to rejoin the room?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('Unban'),
-          ),
-        ],
-      ),
+    final confirmed = await confirmDialog(
+      context,
+      title: 'Unban member?',
+      message: 'Allow $displayName to rejoin the room?',
+      confirmLabel: 'Unban',
     );
-    if (confirmed != true || !mounted) return;
+    if (!confirmed || !mounted) return;
     setState(() {
       _actionLoading = true;
       _actionError = null;
@@ -645,9 +619,7 @@ class _MemberSheetDialogState extends State<_MemberSheetDialog> {
                 color: cs.onSurfaceVariant,
                 onPressed: () {
                   unawaited(Clipboard.setData(ClipboardData(text: user.id)));
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Copied to clipboard')),
-                  );
+                  context.showSnack('Copied to clipboard');
                 },
               ),
             ],

--- a/lib/features/rooms/widgets/room_section_header.dart
+++ b/lib/features/rooms/widgets/room_section_header.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
@@ -267,11 +268,7 @@ class RoomSectionHeader extends StatelessWidget {
       selection.invalidateSpaceTree();
     } catch (e) {
       debugPrint('[Kohera] Reparent failed: $e');
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to move: $e')),
-        );
-      }
+      if (context.mounted) context.showSnack('Failed to move: $e');
     }
   }
 }

--- a/lib/features/rooms/widgets/room_tile.dart
+++ b/lib/features/rooms/widgets/room_tile.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/call_service.dart';
 import 'package:kohera/core/services/matrix_service.dart';
@@ -799,11 +800,7 @@ class _ReorderDragTargetState extends State<_ReorderDragTarget> {
       selection.invalidateSpaceTree();
     } catch (e) {
       debugPrint('[Kohera] Drag reorder failed: $e');
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to reorder: $e')),
-        );
-      }
+      if (context.mounted) context.showSnack('Failed to reorder: $e');
     }
   }
 }

--- a/lib/features/rooms/widgets/shared_media_section.dart
+++ b/lib/features/rooms/widgets/shared_media_section.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:kohera/core/utils/format_file_size.dart';
 import 'package:kohera/core/utils/media_auth.dart';
 import 'package:kohera/shared/widgets/full_image_view.dart';
 import 'package:matrix/matrix.dart';
@@ -152,7 +153,10 @@ class _SharedMediaSectionState extends State<SharedMediaSection> {
                 style: tt.bodyMedium,
               ),
               subtitle: Text(
-                _formatFileSize((file.infoMap['size'] as num?)?.toInt()),
+                switch ((file.infoMap['size'] as num?)?.toInt()) {
+                  final size? => formatFileSize(size),
+                  _ => '',
+                },
                 style: tt.bodySmall,
               ),
             ),
@@ -179,12 +183,6 @@ class _SharedMediaSectionState extends State<SharedMediaSection> {
     );
   }
 
-  String _formatFileSize(int? bytes) {
-    if (bytes == null) return '';
-    if (bytes < 1024) return '$bytes B';
-    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
-    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
-  }
 }
 
 

--- a/lib/features/settings/screens/devices_screen.dart
+++ b/lib/features/settings/screens/devices_screen.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/extensions/device_extension.dart';
 import 'package:kohera/core/routing/nav_helper.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
+import 'package:kohera/core/utils/confirm_dialog.dart';
 import 'package:kohera/features/e2ee/widgets/key_verification_dialog.dart';
 import 'package:kohera/features/settings/widgets/device_list_item.dart';
 import 'package:kohera/shared/widgets/kohera_loader.dart';
@@ -164,40 +166,22 @@ class _DevicesScreenState extends State<DevicesScreen> {
     } catch (e) {
       debugPrint('[Kohera] Failed to rename device: $e');
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Failed to rename device')),
-      );
+      context.showSnack('Failed to rename device');
     }
   }
 
   // ── Remove Device ──────────────────────────────────────────
 
   Future<void> _removeDevice(Device device) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Remove device?'),
-        content: Text(
-          'Remove "${device.displayNameOrId}"? '
+    final confirmed = await confirmDialog(
+      context,
+      title: 'Remove device?',
+      message: 'Remove "${device.displayNameOrId}"? '
           'This will sign out that device.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            style: FilledButton.styleFrom(
-              backgroundColor: Theme.of(ctx).colorScheme.error,
-              foregroundColor: Theme.of(ctx).colorScheme.onError,
-            ),
-            onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('Remove'),
-          ),
-        ],
-      ),
+      confirmLabel: 'Remove',
+      destructive: true,
     );
-    if (confirmed != true) return;
+    if (!confirmed) return;
 
     try {
       if (!mounted) return;
@@ -209,9 +193,7 @@ class _DevicesScreenState extends State<DevicesScreen> {
     } catch (e) {
       debugPrint('[Kohera] Failed to remove device: $e');
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Failed to remove device')),
-      );
+      context.showSnack('Failed to remove device');
     }
   }
 
@@ -227,31 +209,15 @@ class _DevicesScreenState extends State<DevicesScreen> {
         [];
     if (otherIds.isEmpty) return;
 
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Remove all other devices?'),
-        content: Text(
-          'This will sign out ${otherIds.length} other '
+    final confirmed = await confirmDialog(
+      context,
+      title: 'Remove all other devices?',
+      message: 'This will sign out ${otherIds.length} other '
           '${otherIds.length == 1 ? 'device' : 'devices'}.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            style: FilledButton.styleFrom(
-              backgroundColor: Theme.of(ctx).colorScheme.error,
-              foregroundColor: Theme.of(ctx).colorScheme.onError,
-            ),
-            onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('Remove all'),
-          ),
-        ],
-      ),
+      confirmLabel: 'Remove all',
+      destructive: true,
     );
-    if (confirmed != true) return;
+    if (!confirmed) return;
 
     try {
       final client = matrix.client;
@@ -262,9 +228,7 @@ class _DevicesScreenState extends State<DevicesScreen> {
     } catch (e) {
       debugPrint('[Kohera] Failed to remove devices: $e');
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Failed to remove devices')),
-      );
+      context.showSnack('Failed to remove devices');
     }
   }
 
@@ -281,9 +245,7 @@ class _DevicesScreenState extends State<DevicesScreen> {
           client.userDeviceKeys[userId]?.deviceKeys[device.deviceId];
       if (deviceKeys == null) {
         if (!mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('No encryption keys found for device')),
-        );
+        context.showSnack('No encryption keys found for device');
         return;
       }
 
@@ -294,9 +256,7 @@ class _DevicesScreenState extends State<DevicesScreen> {
     } catch (e) {
       debugPrint('[Kohera] Failed to start verification: $e');
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Failed to start verification')),
-      );
+      context.showSnack('Failed to start verification');
     }
   }
 
@@ -317,9 +277,7 @@ class _DevicesScreenState extends State<DevicesScreen> {
     } catch (e) {
       debugPrint('[Kohera] Failed to toggle block: $e');
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Failed to update device')),
-      );
+      context.showSnack('Failed to update device');
     }
   }
 

--- a/lib/features/settings/screens/emoji_gg_browse_screen.dart
+++ b/lib/features/settings/screens/emoji_gg_browse_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/models/emoji_gg_pack.dart';
 import 'package:kohera/core/routing/nav_helper.dart';
 import 'package:kohera/core/routing/route_names.dart';
@@ -67,9 +68,7 @@ class _EmojiGgBrowseScreenState extends State<EmojiGgBrowseScreen> {
 
   Future<void> _importPack(EmojiGgPack pack) async {
     if (pack.emojiSlugs.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Pack details not available — try again later')),
-      );
+      context.showSnack('Pack details not available — try again later');
       return;
     }
 
@@ -91,14 +90,11 @@ class _EmojiGgBrowseScreenState extends State<EmojiGgBrowseScreen> {
       _importedSlugs = service.importedEmojiGgSlugs;
     });
 
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          succeeded == 0
-              ? 'Import failed — no images could be uploaded'
-              : 'Imported $succeeded sticker${succeeded == 1 ? '' : 's'} from ${pack.name}',
-        ),
-      ),
+    context.showSnack(
+      succeeded == 0
+          ? 'Import failed — no images could be uploaded'
+          : 'Imported $succeeded sticker${succeeded == 1 ? '' : 's'} '
+              'from ${pack.name}',
     );
   }
 

--- a/lib/features/settings/screens/settings_screen.dart
+++ b/lib/features/settings/screens/settings_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/routing/nav_helper.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/call_service.dart';
@@ -41,9 +42,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       _lastShownError = error;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(error)),
-        );
+        context.showSnack(error);
       });
     } else if (error == null) {
       _lastShownError = null;

--- a/lib/features/settings/widgets/profile_avatar_card.dart
+++ b/lib/features/settings/widgets/profile_avatar_card.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/shared/widgets/user_avatar.dart';
 import 'package:matrix/matrix.dart';
@@ -72,8 +73,9 @@ class _ProfileAvatarCardState extends State<ProfileAvatarCard> {
     } catch (e) {
       debugPrint('[Kohera] Display name update failed: $e');
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to update display name: ${MatrixService.friendlyAuthError(e)}')),
+        context.showSnack(
+          'Failed to update display name: '
+          '${MatrixService.friendlyAuthError(e)}',
         );
       }
     } finally {
@@ -101,8 +103,8 @@ class _ProfileAvatarCardState extends State<ProfileAvatarCard> {
     } catch (e) {
       debugPrint('[Kohera] Avatar upload failed: $e');
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to upload avatar: ${MatrixService.friendlyAuthError(e)}')),
+        context.showSnack(
+          'Failed to upload avatar: ${MatrixService.friendlyAuthError(e)}',
         );
       }
     } finally {
@@ -120,8 +122,8 @@ class _ProfileAvatarCardState extends State<ProfileAvatarCard> {
     } catch (e) {
       debugPrint('[Kohera] Avatar removal failed: $e');
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Failed to remove avatar: ${MatrixService.friendlyAuthError(e)}')),
+        context.showSnack(
+          'Failed to remove avatar: ${MatrixService.friendlyAuthError(e)}',
         );
       }
     } finally {

--- a/lib/features/spaces/widgets/create_subspace_dialog.dart
+++ b/lib/features/spaces/widgets/create_subspace_dialog.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart' hide Visibility;
 import 'package:kohera/core/models/join_mode.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/shared/widgets/join_access_section.dart';
+import 'package:kohera/shared/widgets/loading_button_child.dart';
 import 'package:matrix/matrix.dart';
 
 /// Dialog to create a new subspace within a parent space.
@@ -230,13 +231,10 @@ class _CreateSubspaceDialogState extends State<CreateSubspaceDialog> {
         ),
         FilledButton(
           onPressed: _loading ? null : _submit,
-          child: _loading
-              ? const SizedBox(
-                  width: 22,
-                  height: 22,
-                  child: CircularProgressIndicator(strokeWidth: 2.5),
-                )
-              : const Text('Create'),
+          child: LoadingButtonChild(
+            loading: _loading,
+            child: const Text('Create'),
+          ),
         ),
       ],
     );

--- a/lib/features/spaces/widgets/space_action_dialog.dart
+++ b/lib/features/spaces/widgets/space_action_dialog.dart
@@ -4,8 +4,10 @@ import 'package:flutter/material.dart' hide Visibility;
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/preferences_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
+import 'package:kohera/core/utils/confirm_dialog.dart';
 import 'package:kohera/features/home/screens/home_shell.dart';
 import 'package:kohera/features/spaces/services/space_discovery_data_source.dart';
+import 'package:kohera/shared/widgets/loading_button_child.dart';
 import 'package:kohera/shared/widgets/mxc_image.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
@@ -264,13 +266,10 @@ class _CreateSpaceDialogState extends State<CreateSpaceDialog> {
                   ),
                   FilledButton(
                     onPressed: _loading ? null : _submit,
-                    child: _loading
-                        ? const SizedBox(
-                            width: 22,
-                            height: 22,
-                            child: CircularProgressIndicator(strokeWidth: 2.5),
-                          )
-                        : const Text('Create'),
+                    child: LoadingButtonChild(
+                      loading: _loading,
+                      child: const Text('Create'),
+                    ),
                   ),
                 ],
               ),
@@ -398,13 +397,10 @@ class _JoinSpaceDialogState extends State<JoinSpaceDialog> {
                   ),
                   FilledButton(
                     onPressed: _loading ? null : _submit,
-                    child: _loading
-                        ? const SizedBox(
-                            width: 22,
-                            height: 22,
-                            child: CircularProgressIndicator(strokeWidth: 2.5),
-                          )
-                        : const Text('Join'),
+                    child: LoadingButtonChild(
+                      loading: _loading,
+                      child: const Text('Join'),
+                    ),
                   ),
                 ],
               ),
@@ -590,24 +586,13 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
 
   Future<void> _confirmRemoveServer(String host) async {
     final prefs = context.read<PreferencesService>();
-    final ok = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Remove server?'),
-        content: Text('Remove "$host" from your browse list?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('Remove'),
-          ),
-        ],
-      ),
+    final ok = await confirmDialog(
+      context,
+      title: 'Remove server?',
+      message: 'Remove "$host" from your browse list?',
+      confirmLabel: 'Remove',
     );
-    if (ok != true || !mounted) return;
+    if (!ok || !mounted) return;
     final next =
         prefs.browseServers.where((h) => h != host).toList(growable: false);
     await prefs.setBrowseServers(next);

--- a/lib/features/spaces/widgets/space_context_menu.dart
+++ b/lib/features/spaces/widgets/space_context_menu.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
@@ -11,6 +12,7 @@ import 'package:kohera/features/rooms/widgets/new_room_dialog.dart';
 import 'package:kohera/features/spaces/widgets/create_subspace_dialog.dart';
 import 'package:kohera/features/spaces/widgets/notification_radio_group.dart';
 import 'package:kohera/features/spaces/widgets/space_details_panel.dart' show SpaceDetailsPanel;
+import 'package:kohera/shared/widgets/popup_menu_item_row.dart';
 import 'package:matrix/matrix.dart' hide Visibility;
 import 'package:provider/provider.dart';
 
@@ -44,90 +46,45 @@ Future<void> showSpaceContextMenu(
     color: cs.surfaceContainer,
     constraints: const BoxConstraints(minWidth: 200, maxWidth: 320),
     items: [
-      const PopupMenuItem(
-        value: SpaceContextAction.markAsRead,
-        child: Row(
-          children: [
-            Icon(Icons.done_all_rounded, size: 18),
-            SizedBox(width: 8),
-            Text('Mark as read'),
-          ],
-        ),
-      ),
+      menuItemRow(
+        Icons.done_all_rounded, 'Mark as read', SpaceContextAction.markAsRead,),
       if (canInvite)
-        const PopupMenuItem(
-          value: SpaceContextAction.invitePeople,
-          child: Row(
-            children: [
-              Icon(Icons.person_add_outlined, size: 18),
-              SizedBox(width: 8),
-              Text('Invite people'),
-            ],
-          ),
+        menuItemRow(
+          Icons.person_add_outlined,
+          'Invite people',
+          SpaceContextAction.invitePeople,
         ),
       if (canEditName)
-        const PopupMenuItem(
-          value: SpaceContextAction.spaceSettings,
-          child: Row(
-            children: [
-              Icon(Icons.settings_outlined, size: 18),
-              SizedBox(width: 8),
-              Text('Space settings'),
-            ],
-          ),
+        menuItemRow(
+          Icons.settings_outlined,
+          'Space settings',
+          SpaceContextAction.spaceSettings,
         ),
       if (canManageChildren) ...[
-        const PopupMenuItem(
-          value: SpaceContextAction.createRoom,
-          child: Row(
-            children: [
-              Icon(Icons.add_rounded, size: 18),
-              SizedBox(width: 8),
-              Text('Create room'),
-            ],
-          ),
+        menuItemRow(
+          Icons.add_rounded, 'Create room', SpaceContextAction.createRoom,),
+        menuItemRow(
+          Icons.workspaces_outlined,
+          'Create subspace',
+          SpaceContextAction.createSubspace,
         ),
-        const PopupMenuItem(
-          value: SpaceContextAction.createSubspace,
-          child: Row(
-            children: [
-              Icon(Icons.workspaces_outlined, size: 18),
-              SizedBox(width: 8),
-              Text('Create subspace'),
-            ],
-          ),
-        ),
-        const PopupMenuItem(
-          value: SpaceContextAction.addExistingRoom,
-          child: Row(
-            children: [
-              Icon(Icons.link_rounded, size: 18),
-              SizedBox(width: 8),
-              Text('Add existing room'),
-            ],
-          ),
+        menuItemRow(
+          Icons.link_rounded,
+          'Add existing room',
+          SpaceContextAction.addExistingRoom,
         ),
       ],
-      const PopupMenuItem(
-        value: SpaceContextAction.notifications,
-        child: Row(
-          children: [
-            Icon(Icons.notifications_outlined, size: 18),
-            SizedBox(width: 8),
-            Text('Notifications'),
-          ],
-        ),
+      menuItemRow(
+        Icons.notifications_outlined,
+        'Notifications',
+        SpaceContextAction.notifications,
       ),
       const PopupMenuDivider(),
-      PopupMenuItem(
-        value: SpaceContextAction.leaveSpace,
-        child: Row(
-          children: [
-            Icon(Icons.logout_rounded, size: 18, color: cs.error),
-            const SizedBox(width: 8),
-            Text('Leave space', style: TextStyle(color: cs.error)),
-          ],
-        ),
+      menuItemRow(
+        Icons.logout_rounded,
+        'Leave space',
+        SpaceContextAction.leaveSpace,
+        color: cs.error,
       ),
     ],
   );
@@ -219,16 +176,10 @@ Future<void> _handleNotifications(BuildContext context, Room space) async {
 
   try {
     await space.setPushRuleState(result);
-    if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Notifications updated')),
-      );
-    }
+    if (context.mounted) context.showSnack('Notifications updated');
   } catch (e) {
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to update notifications: $e')),
-      );
+      context.showSnack('Failed to update notifications: $e');
     }
   }
 }
@@ -273,17 +224,9 @@ Future<void> _handleInvite(BuildContext context, Room space) async {
 
   try {
     await space.invite(mxid);
-    if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Invited $mxid')),
-      );
-    }
+    if (context.mounted) context.showSnack('Invited $mxid');
   } catch (e) {
-    if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to invite: $e')),
-      );
-    }
+    if (context.mounted) context.showSnack('Failed to invite: $e');
   }
 }
 
@@ -364,16 +307,10 @@ Future<void> _handleLeave(BuildContext context, Room space) async {
       }
     }
     if (failCount > 0 && context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to leave $failCount room(s)')),
-      );
+      context.showSnack('Failed to leave $failCount room(s)');
     }
   } catch (e) {
-    if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Failed to leave space: $e')),
-      );
-    }
+    if (context.mounted) context.showSnack('Failed to leave space: $e');
   }
 }
 

--- a/lib/features/spaces/widgets/space_details_panel.dart
+++ b/lib/features/spaces/widgets/space_details_panel.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
 import 'package:kohera/core/routing/route_names.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/features/rooms/widgets/admin_settings_section.dart';
@@ -57,11 +58,7 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
 
     await _run('invite', () async {
       await space.invite(result);
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Invited $result')),
-        );
-      }
+      if (mounted) context.showSnack('Invited $result');
     });
   }
 

--- a/lib/shared/widgets/loading_button_child.dart
+++ b/lib/shared/widgets/loading_button_child.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+/// A button child that shows a centered spinner while [loading], otherwise
+/// renders [child]. Defaults match the app's button spinner (22px, stroke 2.5).
+class LoadingButtonChild extends StatelessWidget {
+  const LoadingButtonChild({
+    required this.loading,
+    required this.child,
+    this.size = 22,
+    this.strokeWidth = 2.5,
+    this.color,
+    super.key,
+  });
+
+  final bool loading;
+  final Widget child;
+  final double size;
+  final double strokeWidth;
+  final Color? color;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!loading) return child;
+    return SizedBox(
+      width: size,
+      height: size,
+      child: CircularProgressIndicator(strokeWidth: strokeWidth, color: color),
+    );
+  }
+}

--- a/lib/shared/widgets/popup_menu_item_row.dart
+++ b/lib/shared/widgets/popup_menu_item_row.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+/// Builds a [PopupMenuItem] with a leading icon and label, matching the app's
+/// context-menu row convention (icon size 18, 8px gap). Pass [color] to tint
+/// both the icon and label (e.g. for destructive actions).
+PopupMenuItem<T> menuItemRow<T>(
+  IconData icon,
+  String label,
+  T value, {
+  Color? color,
+}) {
+  return PopupMenuItem<T>(
+    value: value,
+    child: Row(
+      children: [
+        Icon(icon, size: 18, color: color),
+        const SizedBox(width: 8),
+        Text(label, style: color == null ? null : TextStyle(color: color)),
+      ],
+    ),
+  );
+}

--- a/lib/shared/widgets/room_avatar.dart
+++ b/lib/shared/widgets/room_avatar.dart
@@ -4,6 +4,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart';
 import 'package:flutter/material.dart';
 import 'package:kohera/core/utils/media_auth.dart';
+import 'package:kohera/core/utils/sender_color.dart';
 import 'package:matrix/matrix.dart';
 
 /// Displays a room's avatar with a colored-initial fallback.
@@ -63,7 +64,7 @@ class _RoomAvatarWidgetState extends State<RoomAvatarWidget> {
     final cs = Theme.of(context).colorScheme;
     final name = widget.room.getLocalizedDisplayname();
     final initial = name.isNotEmpty ? name[0].toUpperCase() : '#';
-    final bgColor = _colorFromString(name, cs);
+    final bgColor = senderColor(name, cs, fallback: cs.primaryContainer);
 
     return ClipRRect(
       borderRadius: BorderRadius.circular(widget.size * 0.28),
@@ -100,21 +101,6 @@ class _RoomAvatarWidgetState extends State<RoomAvatarWidget> {
     );
   }
 
-  Color _colorFromString(String str, ColorScheme cs) {
-    if (str.isEmpty) return cs.primaryContainer;
-    final hash = str.codeUnits.fold<int>(0, (h, c) => h + c);
-    final palette = [
-      cs.primary,
-      cs.tertiary,
-      cs.secondary,
-      cs.error,
-      const Color(0xFF6750A4),
-      const Color(0xFFB4846C),
-      const Color(0xFF7C9A6E),
-      const Color(0xFFC17B5F),
-    ];
-    return palette[hash % palette.length];
-  }
 }
 
 class _Fallback extends StatelessWidget {

--- a/lib/shared/widgets/user_avatar.dart
+++ b/lib/shared/widgets/user_avatar.dart
@@ -5,6 +5,7 @@ import 'package:cached_network_image_platform_interface/cached_network_image_pla
 import 'package:flutter/material.dart';
 import 'package:kohera/core/services/sub_services/presence_service.dart';
 import 'package:kohera/core/utils/media_auth.dart';
+import 'package:kohera/core/utils/sender_color.dart';
 import 'package:kohera/shared/widgets/presence_dot.dart';
 import 'package:matrix/matrix.dart';
 
@@ -71,7 +72,8 @@ class _UserAvatarState extends State<UserAvatar> {
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final initial = _userInitial(widget.userId);
-    final bgColor = _colorFromString(widget.userId ?? '', cs);
+    final bgColor =
+        senderColor(widget.userId ?? '', cs, fallback: cs.primaryContainer);
 
     final avatar = ClipOval(
       child: SizedBox(
@@ -115,21 +117,6 @@ class _UserAvatarState extends State<UserAvatar> {
     return (userId ?? '?')[0].toUpperCase();
   }
 
-  static Color _colorFromString(String str, ColorScheme cs) {
-    if (str.isEmpty) return cs.primaryContainer;
-    final hash = str.codeUnits.fold<int>(0, (h, c) => h + c);
-    final palette = [
-      cs.primary,
-      cs.tertiary,
-      cs.secondary,
-      cs.error,
-      const Color(0xFF6750A4),
-      const Color(0xFFB4846C),
-      const Color(0xFF7C9A6E),
-      const Color(0xFFC17B5F),
-    ];
-    return palette[hash % palette.length];
-  }
 }
 
 class _Fallback extends StatelessWidget {

--- a/test/extensions/context_extension_test.dart
+++ b/test/extensions/context_extension_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/extensions/context_extension.dart';
+
+void main() {
+  group('ContextExtension.showSnack', () {
+    testWidgets('shows a SnackBar with the given message', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () => context.showSnack('Hello there'),
+                child: const Text('tap'),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('tap'));
+      await tester.pump();
+
+      expect(find.byType(SnackBar), findsOneWidget);
+      expect(find.text('Hello there'), findsOneWidget);
+    });
+  });
+}

--- a/test/utils/confirm_dialog_test.dart
+++ b/test/utils/confirm_dialog_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/core/utils/confirm_dialog.dart';
+
+void main() {
+  group('confirmDialog', () {
+    Future<bool> pumpAndConfirm(
+      WidgetTester tester, {
+      required String tapLabel,
+    }) async {
+      late bool result;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => ElevatedButton(
+                onPressed: () async {
+                  result = await confirmDialog(
+                    context,
+                    title: 'Title',
+                    message: 'Body',
+                    confirmLabel: 'Yes',
+                  );
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(tapLabel));
+      await tester.pumpAndSettle();
+      return result;
+    }
+
+    testWidgets('returns true when confirmed', (tester) async {
+      expect(await pumpAndConfirm(tester, tapLabel: 'Yes'), isTrue);
+    });
+
+    testWidgets('returns false when cancelled', (tester) async {
+      expect(await pumpAndConfirm(tester, tapLabel: 'Cancel'), isFalse);
+    });
+  });
+}

--- a/test/utils/sender_color_test.dart
+++ b/test/utils/sender_color_test.dart
@@ -35,5 +35,19 @@ void main() {
       }
       expect(colors.length, greaterThan(1));
     });
+
+    test('returns fallback for empty sender when provided', () {
+      expect(
+        senderColor('', cs, fallback: cs.primaryContainer),
+        equals(cs.primaryContainer),
+      );
+    });
+
+    test('ignores fallback for non-empty sender', () {
+      expect(
+        senderColor('@alice:example.com', cs, fallback: cs.primaryContainer),
+        isNot(equals(cs.primaryContainer)),
+      );
+    });
   });
 }

--- a/test/widgets/loading_button_child_test.dart
+++ b/test/widgets/loading_button_child_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kohera/shared/widgets/loading_button_child.dart';
+
+void main() {
+  group('LoadingButtonChild', () {
+    testWidgets('shows spinner when loading', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: LoadingButtonChild(loading: true, child: Text('Save')),
+          ),
+        ),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('Save'), findsNothing);
+    });
+
+    testWidgets('shows child when not loading', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: LoadingButtonChild(loading: false, child: Text('Save')),
+          ),
+        ),
+      );
+
+      expect(find.text('Save'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Extracts four shared UI helpers and routes existing call sites through them, removing repeated boilerplate across ~36 files without changing behavior. First batch of a duplication-reduction effort identified by a repo-wide audit.

Net **−268 lines in `lib/`** (380 added — including 105 lines of new helpers — and 648 deleted).

## Changes

New helpers:
- `lib/core/extensions/context_extension.dart` — `context.showSnack(msg)`, replacing ~40 inline `ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(...)))` blocks
- `lib/core/utils/confirm_dialog.dart` — `confirmDialog(...)`, replacing 13 hand-rolled confirm `AlertDialog`s (supports a `destructive` flag and custom labels)
- `lib/shared/widgets/loading_button_child.dart` — `LoadingButtonChild`, replacing the spinner-or-label button idiom in auth and dialog buttons
- `lib/shared/widgets/popup_menu_item_row.dart` — `menuItemRow<T>(...)`, promoting the previously private popup-menu row builder for the room/space/message context menus

Adopt existing utils in place of inline copies:
- `senderColor` (with a new optional `fallback`) replaces the duplicated colour-from-string hash in `user_avatar` and `room_avatar`
- `formatFileSize` replaces the inline byte-size formatter in `shared_media_section`

Intentionally left alone: alias-captured snackbars across async gaps (would trip `use_build_context_synchronously`), service-context snackbars that hold a `ScaffoldMessengerState` rather than a `BuildContext`, and the two snackbars with a custom `duration:`.

## Testing

- `flutter analyze` — clean
- `flutter test` — full suite green (2101 passing) after `dart run build_runner build`
- Added focused tests: `test/extensions/context_extension_test.dart`, `test/utils/confirm_dialog_test.dart`, `test/widgets/loading_button_child_test.dart`, plus `senderColor` fallback cases

## Checklist

- [x] Behavior-preserving refactor
- [x] `flutter analyze` clean
- [x] Tests pass
- [x] No new comments outside section markers; `[Kohera]` log prefix preserved