### PR TITLE
fix(chat): guard OpenMoji precache against deactivated context

### DIFF
--- a/lib/shared/widgets/openmoji_image.dart
+++ b/lib/shared/widgets/openmoji_image.dart
@@ -72,6 +72,7 @@ Future<void> precacheOpenMoji(
   Iterable<String> graphemes,
 ) async {
   for (final g in graphemes) {
+    if (!context.mounted) return;
     final asset = openMojiAssetFor(g);
     if (asset != null) {
       await precacheImage(AssetImage(asset), context);

--- a/test/widgets/shared/openmoji_image_test.dart
+++ b/test/widgets/shared/openmoji_image_test.dart
@@ -103,4 +103,23 @@ void main() {
     expect(find.byType(Image), findsNothing);
     expect(find.text('x'), findsOneWidget);
   });
+
+  testWidgets('precacheOpenMoji bails out on a deactivated context',
+      (tester) async {
+    late BuildContext captured;
+    await tester.pumpWidget(_wrap(Builder(
+      builder: (ctx) {
+        captured = ctx;
+        return const SizedBox();
+      },
+    ),),);
+
+    // Tear the owning element out of the tree so its context deactivates,
+    // mirroring a HoverActionBar disposed mid-precache.
+    await tester.pumpWidget(_wrap(const SizedBox()));
+
+    // Without the context.mounted guard this throws "Looking up a deactivated
+    // widget's ancestor is unsafe" from precacheImage.
+    await precacheOpenMoji(captured, const ['\u{1F44D}']);
+  });
 }


### PR DESCRIPTION
## Summary

Fixes an unhandled exception seen at runtime:

```
Unhandled Exception: Looking up a deactivated widget's ancestor is unsafe.
...
#5  precacheImage (package:flutter/src/widgets/image.dart:127:37)
#6  precacheOpenMoji (package:kohera/shared/widgets/openmoji_image.dart:77:13)
```

`precacheOpenMoji` loops over the quick-react emoji set with an `await` between each grapheme. It's kicked off from `HoverActionBar.didChangeDependencies`. If that bar is disposed while the loop is still running — hover ends, or the message scrolls offscreen — the next `precacheImage(..., context)` call resolves an inherited widget (`DefaultAssetBundle.of`) on a now-deactivated element and throws.

## Changes

- `openmoji_image.dart`: bail out of the precache loop once `context.mounted` is false.

## Testing

- `flutter analyze` — clean
- Added a regression test in `test/widgets/shared/openmoji_image_test.dart` that captures a context, tears its element out of the tree, then calls `precacheOpenMoji` and asserts it no longer throws.

## Checklist

- [x] Code follows project conventions
- [x] Tests added/updated
- [x] `flutter analyze` passes
- [x] `flutter test` passes
