### PR TITLE
fix(chat): show pointer cursor on hover action bar buttons

### DIFF
--- a/lib/features/chat/widgets/hover_action_bar.dart
+++ b/lib/features/chat/widgets/hover_action_bar.dart
@@ -170,6 +170,7 @@ class _ActionIcon extends StatelessWidget {
     return InkWell(
       borderRadius: borderRadius ?? BorderRadius.zero,
       onTap: onTap,
+      mouseCursor: SystemMouseCursors.click,
       child: Padding(
         padding: const EdgeInsets.all(6),
         child: Icon(icon, size: 16, color: cs.onSurfaceVariant),

--- a/test/widgets/chat/hover_action_bar_test.dart
+++ b/test/widgets/chat/hover_action_bar_test.dart
@@ -59,6 +59,28 @@ void main() {
       expect(find.byIcon(Icons.reply_rounded), findsOneWidget);
     });
 
+    testWidgets('action buttons use a clickable pointer cursor',
+        (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        onQuickReact: (_) {},
+        onReply: () {},
+      ),);
+
+      for (final icon in [
+        Icons.add_reaction_outlined,
+        Icons.reply_rounded,
+        Icons.more_horiz_rounded,
+      ]) {
+        final inkWell = tester.widget<InkWell>(
+          find.ancestor(
+            of: find.byIcon(icon),
+            matching: find.byType(InkWell),
+          ),
+        );
+        expect(inkWell.mouseCursor, SystemMouseCursors.click);
+      }
+    });
+
     testWidgets('hides reply icon when onReply is null', (tester) async {
       await tester.pumpWidget(buildTestWidget());
       expect(find.byIcon(Icons.reply_rounded), findsNothing);


### PR DESCRIPTION
## Summary

The hover action bar's react / reply / more buttons trigger on click but showed no clickable cursor on hover, so they didn't read as interactive on desktop/web. Set an explicit pointer cursor.

## Changes

- `hover_action_bar.dart`: `_ActionIcon`'s `InkWell` now sets `mouseCursor: SystemMouseCursors.click`.

## Testing

- `flutter analyze` — clean
- `flutter test test/widgets/chat/hover_action_bar_test.dart` — passes

## Notes

The quick-react popup overlay (emoji buttons + its "..." toggle) uses the same `InkWell` pattern and likely wants the same cursor; left out of this change since it wasn't in the reported scope. Easy follow-up if desired.
