### PR TITLE
fix: identify call participants by sender, not state-key regex

### DIFF
--- a/lib/features/calling/services/rtc_membership_service.dart
+++ b/lib/features/calling/services/rtc_membership_service.dart
@@ -148,10 +148,11 @@ class RtcMembershipService {
     final userIds = <String>{};
 
     for (final entry in states.entries) {
-      final content = entry.value.content;
+      final stateEvent = entry.value;
+      final content = stateEvent.content;
       if (content.isEmpty) continue;
-      final originTs = entry.value is Event
-          ? (entry.value as Event).originServerTs.millisecondsSinceEpoch
+      final originTs = stateEvent is Event
+          ? stateEvent.originServerTs.millisecondsSinceEpoch
           : now;
 
       final memberships = content['memberships'];
@@ -167,8 +168,9 @@ class RtcMembershipService {
       }
 
       if (hasActive) {
-        final match = _stateKeyUserIdRegex.firstMatch(entry.key);
-        if (match != null) userIds.add(match.group(1)!);
+        final userId = userIdFromStateKey(entry.key) ??
+            (stateEvent.senderId.isNotEmpty ? stateEvent.senderId : null);
+        if (userId != null) userIds.add(userId);
       }
     }
     return userIds;

--- a/test/services/rtc_membership_service_test.dart
+++ b/test/services/rtc_membership_service_test.dart
@@ -679,5 +679,72 @@ void main() {
       );
       expect(userIds, {'@alice:example.com'});
     });
+
+    test('falls back to senderId when state key is unparseable', () {
+      final mockRoom = MockRoom();
+      when(mockClient.getRoomById('!r:x')).thenReturn(mockRoom);
+      final now = DateTime.now().millisecondsSinceEpoch;
+      when(mockRoom.states).thenReturn({
+        callMemberEventType: {
+          '@poly:example.com': FakeEvent(
+            content: {'expires_ts': now + 60000},
+            originServerTs: now,
+            senderId: '@poly:example.com',
+          ),
+        },
+      });
+
+      final userIds = RtcMembershipService.activeCallParticipantUserIds(
+        mockClient,
+        '!r:x',
+      );
+      expect(userIds, {'@poly:example.com'});
+    });
+
+    test('parseable key and senderId both present yield one id', () {
+      final mockRoom = MockRoom();
+      when(mockClient.getRoomById('!r:x')).thenReturn(mockRoom);
+      final now = DateTime.now().millisecondsSinceEpoch;
+      when(mockRoom.states).thenReturn({
+        callMemberEventType: {
+          '_@alice:example.com_DEV1_m.call': FakeEvent(
+            content: {'expires_ts': now + 60000},
+            originServerTs: now,
+            senderId: '@alice:example.com',
+          ),
+          'opaque-foreign-key': FakeEvent(
+            content: {'expires_ts': now + 60000},
+            originServerTs: now,
+            senderId: '@bob:server.org',
+          ),
+        },
+      });
+
+      final userIds = RtcMembershipService.activeCallParticipantUserIds(
+        mockClient,
+        '!r:x',
+      );
+      expect(userIds, {'@alice:example.com', '@bob:server.org'});
+    });
+
+    test('skips entry with unparseable key and empty senderId', () {
+      final mockRoom = MockRoom();
+      when(mockClient.getRoomById('!r:x')).thenReturn(mockRoom);
+      final now = DateTime.now().millisecondsSinceEpoch;
+      when(mockRoom.states).thenReturn({
+        callMemberEventType: {
+          'opaque-foreign-key': FakeEvent(
+            content: {'expires_ts': now + 60000},
+            originServerTs: now,
+          ),
+        },
+      });
+
+      final userIds = RtcMembershipService.activeCallParticipantUserIds(
+        mockClient,
+        '!r:x',
+      );
+      expect(userIds, isEmpty);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Voice-chat participant icons in the room list silently dropped participants whose `m.call.member` state key wasn't written in Kohera's format. A user already in a voice call (e.g. on another client) appeared on the in-room call screen but not in the room-list icon strip, even though the call row itself showed.

## Changes

- `lib/features/calling/services/rtc_membership_service.dart` — `activeCallParticipantUserIds` now identifies each participant by the state event's homeserver-stamped `senderId` as a fallback when the state key doesn't parse. The regex key-parse is kept as the primary path so appservice/bridge memberships set on behalf of another user keep attributing to the key's user rather than the sending bot.

### Root cause

The icon list parsed each user ID out of the `m.call.member` **state key** via `_(@[^:]+:[^_]+)_`. That key shape (`_@user:server_device_m.call`) is client-specific and not standardized — foreign clients write bare-MXID or differently delimited keys that don't match, so those memberships were dropped. `roomHasActiveCall` doesn't parse the key, so the row still lit; the in-room screen reads LiveKit's live participant list, so it was unaffected.

## Testing

- [x] `flutter analyze` is clean (changed files)
- [x] `flutter test test/services/rtc_membership_service_test.dart` passes (40/40, incl. 3 new regression tests: unparseable-key fallback, parseable+foreign mix, empty-sender skip)
- [x] `flutter test test/widgets/room_tile_test.dart` passes (36/36)

## Linked issues

Refs #191

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master`