### PR TITLE
feat: resolve accurate joined-member count in room/space headers

### DIFF
--- a/lib/features/chat/widgets/chat_app_bar.dart
+++ b/lib/features/chat/widgets/chat_app_bar.dart
@@ -11,6 +11,7 @@ import 'package:kohera/features/calling/models/incoming_call_info.dart' as model
 import 'package:kohera/features/calling/services/call_navigator.dart';
 import 'package:kohera/features/chat/widgets/pinned_messages_popup.dart';
 import 'package:kohera/features/home/screens/home_shell.dart';
+import 'package:kohera/shared/widgets/joined_member_count.dart';
 import 'package:kohera/shared/widgets/presence_dot.dart';
 import 'package:kohera/shared/widgets/room_avatar.dart';
 import 'package:matrix/matrix.dart';
@@ -223,26 +224,31 @@ class _HeaderSubtitle extends StatelessWidget {
     final presence = this.presence;
     final userId = this.userId;
     if (presence == null || userId == null) {
-      return Text(_memberCountLabel(room), style: style);
+      return JoinedMemberCount(
+        room: room,
+        builder: (context, count) => Text(_memberCountLabel(count), style: style),
+      );
     }
-    return ListenableBuilder(
-      listenable: presence,
-      builder: (context, _) {
-        final label =
-            _presenceLabel(presence.presenceFor(userId)) ?? _memberCountLabel(room);
-        return Text(
-          label,
-          style: style,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-        );
-      },
+    return JoinedMemberCount(
+      room: room,
+      builder: (context, count) => ListenableBuilder(
+        listenable: presence,
+        builder: (context, _) {
+          final label =
+              _presenceLabel(presence.presenceFor(userId)) ?? _memberCountLabel(count);
+          return Text(
+            label,
+            style: style,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          );
+        },
+      ),
     );
   }
 }
 
-String _memberCountLabel(Room room) {
-  final count = room.summary.mJoinedMemberCount ?? 0;
+String _memberCountLabel(int count) {
   if (count == 0) return '';
   if (count == 1) return '1 member';
   return '$count members';

--- a/lib/features/rooms/widgets/room_details_panel.dart
+++ b/lib/features/rooms/widgets/room_details_panel.dart
@@ -14,6 +14,7 @@ import 'package:kohera/features/rooms/widgets/room_members_section.dart';
 import 'package:kohera/features/rooms/widgets/shared_media_section.dart';
 import 'package:kohera/shared/widgets/avatar_edit_overlay.dart';
 import 'package:kohera/shared/widgets/detail_action_button.dart';
+import 'package:kohera/shared/widgets/joined_member_count.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';
 
@@ -217,7 +218,6 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
   // ── Header ─────────────────────────────────────────────────
 
   Widget _buildHeader(Room room, ColorScheme cs, TextTheme tt) {
-    final memberCount = room.summary.mJoinedMemberCount ?? 0;
     return Padding(
       padding: const EdgeInsets.all(20),
       child: Column(
@@ -240,9 +240,12 @@ class _RoomDetailsPanelState extends State<RoomDetailsPanel> {
             ),
           ],
           const SizedBox(height: 4),
-          Text(
-            memberCount == 1 ? '1 member' : '$memberCount members',
-            style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
+          JoinedMemberCount(
+            room: room,
+            builder: (context, memberCount) => Text(
+              memberCount == 1 ? '1 member' : '$memberCount members',
+              style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
+            ),
           ),
         ],
       ),

--- a/lib/features/spaces/widgets/space_details_panel.dart
+++ b/lib/features/spaces/widgets/space_details_panel.dart
@@ -11,6 +11,7 @@ import 'package:kohera/features/spaces/widgets/notification_radio_group.dart';
 import 'package:kohera/features/spaces/widgets/space_context_menu.dart';
 import 'package:kohera/shared/widgets/avatar_edit_overlay.dart';
 import 'package:kohera/shared/widgets/detail_action_button.dart';
+import 'package:kohera/shared/widgets/joined_member_count.dart';
 import 'package:matrix/matrix.dart' hide Visibility;
 import 'package:provider/provider.dart';
 
@@ -168,7 +169,6 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
   // ── Header ─────────────────────────────────────────────────
 
   Widget _buildHeader(Room space, ColorScheme cs, TextTheme tt) {
-    final memberCount = space.summary.mJoinedMemberCount ?? 0;
     return Padding(
       padding: const EdgeInsets.all(20),
       child: Column(
@@ -191,9 +191,12 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
             ),
           ],
           const SizedBox(height: 4),
-          Text(
-            memberCount == 1 ? '1 member' : '$memberCount members',
-            style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
+          JoinedMemberCount(
+            room: space,
+            builder: (context, memberCount) => Text(
+              memberCount == 1 ? '1 member' : '$memberCount members',
+              style: tt.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
+            ),
           ),
         ],
       ),

--- a/lib/shared/widgets/joined_member_count.dart
+++ b/lib/shared/widgets/joined_member_count.dart
@@ -1,0 +1,79 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:matrix/matrix.dart';
+
+/// Resolves an accurate joined-member count for [room] and rebuilds when it
+/// becomes available.
+///
+/// The Matrix sync `summary` can report a stale or partial
+/// `m.joined_member_count` — most visibly, Synapse partial-state joins report
+/// `1` for large federated rooms. This widget shows the summary value
+/// immediately, then refines it with the authoritative count from
+/// `/joined_members`, caching the result per room for the session.
+class JoinedMemberCount extends StatefulWidget {
+  const JoinedMemberCount({
+    required this.room,
+    required this.builder,
+    super.key,
+  });
+
+  final Room room;
+  final Widget Function(BuildContext context, int count) builder;
+
+  static final Map<String, int> _cache = {};
+  static final Map<String, Future<void>> _inFlight = {};
+
+  @override
+  State<JoinedMemberCount> createState() => _JoinedMemberCountState();
+}
+
+class _JoinedMemberCountState extends State<JoinedMemberCount> {
+  int get _summaryCount => widget.room.summary.mJoinedMemberCount ?? 0;
+
+  int get _bestCount {
+    final cached = JoinedMemberCount._cache[widget.room.id] ?? 0;
+    return cached > _summaryCount ? cached : _summaryCount;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _resolve();
+  }
+
+  @override
+  void didUpdateWidget(JoinedMemberCount oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.room.id != widget.room.id) _resolve();
+  }
+
+  void _resolve() {
+    final room = widget.room;
+    final id = room.id;
+    if (JoinedMemberCount._cache.containsKey(id)) return;
+    // Trust the summary when our local member list already accounts for it.
+    if (room.participantListComplete) return;
+
+    final pending = JoinedMemberCount._inFlight[id];
+    if (pending != null) {
+      unawaited(pending.whenComplete(_apply));
+      return;
+    }
+
+    final future = room.client.getJoinedMembersByRoom(id).then((members) {
+      if (members != null) JoinedMemberCount._cache[id] = members.length;
+    }).catchError((Object e) {
+      debugPrint('[Kohera] Failed to resolve member count for $id: $e');
+    }).whenComplete(() => JoinedMemberCount._inFlight.remove(id));
+    JoinedMemberCount._inFlight[id] = future;
+    unawaited(future.whenComplete(_apply));
+  }
+
+  void _apply() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.builder(context, _bestCount);
+}


### PR DESCRIPTION
## Summary

Room and space headers showed wrong member counts because Synapse partial-state joins report `m.joined_member_count` as `1` for large federated rooms. This extracts a reusable `JoinedMemberCount` widget that shows the sync summary immediately, then refines it with the authoritative `/joined_members` count.

## Changes

- Add `lib/shared/widgets/joined_member_count.dart` — a builder widget that displays the summary count, then resolves the accurate count via `getJoinedMembersByRoom`, caching per room for the session and de-duplicating in-flight requests. Trusts the summary when the local participant list is already complete.
- Wire it into the chat app bar subtitle (`chat_app_bar.dart`), preserving presence-label behaviour for DMs.
- Wire it into the room and space detail panel headers (`room_details_panel.dart`, `space_details_panel.dart`).

## Testing

- [x] `flutter analyze` is clean (the 4 changed files)
- [x] `flutter test` passes for `chat_app_bar_test.dart`, `room_details_panel_test.dart`, `space_details_panel_test.dart` (29 tests) after `dart run build_runner build --delete-conflicting-outputs`

## Linked issues

<!-- none -->

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master`
