### PR TITLE
feat: implement showSpaceRooms for direct space preview access

### DIFF
--- a/lib/features/spaces/widgets/space_action_dialog.dart
+++ b/lib/features/spaces/widgets/space_action_dialog.dart
@@ -418,10 +418,12 @@ class SpaceDiscoveryDialog extends StatefulWidget {
   const SpaceDiscoveryDialog._({
     required this.matrixService,
     required this.dataSource,
+    this.initialFrame,
   });
 
   final MatrixService matrixService;
   final SpaceDiscoveryDataSource dataSource;
+  final PreviewFrame? initialFrame;
 
   static Future<void> show(
     BuildContext context, {
@@ -439,12 +441,40 @@ class SpaceDiscoveryDialog extends StatefulWidget {
     );
   }
 
+  /// Opens the dialog directly to the preview for a specific space,
+  /// bypassing the public search list. Use this for joined spaces.
+  static Future<void> showSpaceRooms(
+    BuildContext context, {
+    required MatrixService matrixService,
+    required String roomId,
+    String? name,
+    Uri? avatar,
+    String? canonicalAlias,
+    SpaceDiscoveryDataSource? dataSource,
+  }) {
+    final ds = dataSource ??
+        defaultSpaceDiscoveryDataSource(matrixService.client);
+    return showDialog(
+      context: context,
+      builder: (_) => SpaceDiscoveryDialog._(
+        matrixService: matrixService,
+        dataSource: ds,
+        initialFrame: PreviewFrame(
+          roomId: roomId,
+          fallbackName: name,
+          fallbackAvatar: avatar,
+          canonicalAlias: canonicalAlias,
+        ),
+      ),
+    );
+  }
+
   @override
   State<SpaceDiscoveryDialog> createState() => _SpaceDiscoveryDialogState();
 }
 
-class _PreviewFrame {
-  _PreviewFrame({
+class PreviewFrame {
+  PreviewFrame({
     required this.roomId,
     this.fallbackName,
     this.fallbackAvatar,
@@ -470,7 +500,8 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
   String? _error;
   String? _joiningRoomId;
   String? _joinError;
-  final List<_PreviewFrame> _previewStack = [];
+  final List<PreviewFrame> _previewStack = [];
+  bool _directlySeeded = false;
 
   String? _nextBatch;
   bool _loadingMore = false;
@@ -605,7 +636,14 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
   @override
   void initState() {
     super.initState();
-    unawaited(_load());
+    final initial = widget.initialFrame;
+    if (initial != null) {
+      _directlySeeded = true;
+      _previewStack.add(initial);
+      unawaited(_loadHierarchy(initial));
+    } else {
+      unawaited(_load());
+    }
   }
 
   @override
@@ -760,7 +798,7 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
 
   void _openPreview(PublishedRoomsChunk chunk) {
     debugPrint('[Kohera] Space preview opened: ${chunk.roomId}');
-    final frame = _PreviewFrame(
+    final frame = PreviewFrame(
       roomId: chunk.roomId,
       fallbackName: chunk.name ?? chunk.canonicalAlias,
       fallbackAvatar: chunk.avatarUrl,
@@ -779,7 +817,7 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
       return;
     }
     debugPrint('[Kohera] Space subspace opened: ${child.roomId}');
-    final frame = _PreviewFrame(
+    final frame = PreviewFrame(
       roomId: child.roomId,
       fallbackName: child.name ?? child.canonicalAlias,
       fallbackAvatar: child.avatarUrl,
@@ -794,13 +832,17 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
 
   void _popPreview() {
     if (_previewStack.isEmpty) return;
+    if (_directlySeeded && _previewStack.length == 1) {
+      Navigator.pop(context);
+      return;
+    }
     setState(() {
       _previewStack.removeLast();
       _joinError = null;
     });
   }
 
-  Future<void> _loadHierarchy(_PreviewFrame frame) async {
+  Future<void> _loadHierarchy(PreviewFrame frame) async {
     try {
       final resp = await widget.dataSource.getSpaceHierarchy(
         frame.roomId,
@@ -820,7 +862,7 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
     }
   }
 
-  Future<void> _retryHierarchy(_PreviewFrame frame) async {
+  Future<void> _retryHierarchy(PreviewFrame frame) async {
     setState(() {
       frame.error = null;
       frame.hierarchy = null;
@@ -877,6 +919,7 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
     final size = MediaQuery.sizeOf(context);
     final isWide = size.width >= HomeShell.wideBreakpoint;
     final inPreview = _previewStack.isNotEmpty;
+    final atRootPreview = _directlySeeded && _previewStack.length == 1;
     final isJoiningAny = _joiningRoomId != null;
 
     final Widget content;
@@ -892,6 +935,15 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
         tooltip: 'Back',
         onPressed: isJoiningAny ? null : _popPreview,
       );
+    } else if (_directlySeeded) {
+      // Seeded preview was popped; close the dialog since there's no
+      // underlying search list to return to.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) Navigator.pop(context);
+      });
+      content = const SizedBox.shrink();
+      title = '';
+      leading = null;
     } else {
       content = _buildList();
       title = 'Explore spaces';
@@ -899,7 +951,7 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
     }
 
     return PopScope(
-      canPop: !isJoiningAny && !inPreview,
+      canPop: !isJoiningAny && (!inPreview || atRootPreview),
       onPopInvokedWithResult: (didPop, _) {
         if (!didPop && inPreview && !isJoiningAny) _popPreview();
       },
@@ -1057,7 +1109,7 @@ class _SpaceDiscoveryDialogState extends State<SpaceDiscoveryDialog> {
 
   // ── Preview view ────────────────────────────────────────────────
 
-  Widget _buildPreview(_PreviewFrame frame) {
+  Widget _buildPreview(PreviewFrame frame) {
     final cs = Theme.of(context).colorScheme;
 
     if (frame.error != null) {

--- a/lib/features/spaces/widgets/space_details_panel.dart
+++ b/lib/features/spaces/widgets/space_details_panel.dart
@@ -8,6 +8,7 @@ import 'package:kohera/features/rooms/widgets/invite_user_dialog.dart';
 import 'package:kohera/features/rooms/widgets/join_access_controller.dart';
 import 'package:kohera/features/rooms/widgets/room_members_section.dart';
 import 'package:kohera/features/spaces/widgets/notification_radio_group.dart';
+import 'package:kohera/features/spaces/widgets/space_action_dialog.dart';
 import 'package:kohera/features/spaces/widgets/space_context_menu.dart';
 import 'package:kohera/shared/widgets/avatar_edit_overlay.dart';
 import 'package:kohera/shared/widgets/detail_action_button.dart';
@@ -211,6 +212,11 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
+          DetailActionButton(
+            icon: Icons.meeting_room_outlined,
+            label: 'Browse rooms',
+            onTap: () => _browseSpaceRooms(space),
+          ),
           if (space.canInvite)
             DetailActionButton(
               icon: Icons.person_add_outlined,
@@ -225,6 +231,17 @@ class _SpaceDetailsPanelState extends State<SpaceDetailsPanel> {
           ),
         ],
       ),
+    );
+  }
+
+  Future<void> _browseSpaceRooms(Room space) async {
+    await SpaceDiscoveryDialog.showSpaceRooms(
+      context,
+      matrixService: context.read<MatrixService>(),
+      roomId: space.id,
+      name: space.getLocalizedDisplayname(),
+      avatar: space.avatar,
+      canonicalAlias: space.canonicalAlias,
     );
   }
 }

--- a/test/widgets/space_action_dialog_test.dart
+++ b/test/widgets/space_action_dialog_test.dart
@@ -2,6 +2,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kohera/core/services/matrix_service.dart';
 import 'package:kohera/core/services/sub_services/selection_service.dart';
+import 'package:kohera/features/spaces/services/space_discovery_data_source.dart';
 import 'package:kohera/features/spaces/widgets/space_action_dialog.dart';
 import 'package:matrix/matrix.dart';
 import 'package:matrix/src/utils/cached_stream_controller.dart';
@@ -263,6 +264,94 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Join Space'), findsNothing);
+    });
+  });
+
+  group('SpaceDiscoveryDialog.showSpaceRooms', () {
+    late FakeSpaceDiscoveryDataSource dataSource;
+
+    setUp(() {
+      dataSource = FakeSpaceDiscoveryDataSource(delay: Duration.zero);
+    });
+
+    Widget buildTestWidget() {
+      return MultiProvider(
+        providers: [
+          ChangeNotifierProvider<MatrixService>.value(
+            value: mockMatrixService,
+          ),
+          ChangeNotifierProvider<SelectionService>.value(
+            value: selectionService,
+          ),
+        ],
+        child: MaterialApp(
+          theme: ThemeData(splashFactory: InkRipple.splashFactory),
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: ElevatedButton(
+                onPressed: () => SpaceDiscoveryDialog.showSpaceRooms(
+                  context,
+                  matrixService: mockMatrixService,
+                  roomId: '!fake-space-0:example.org',
+                  name: 'Quantum HQ',
+                  dataSource: dataSource,
+                ),
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('opens directly to space preview', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Explore spaces'), findsNothing);
+      expect(find.text('Quantum HQ'), findsWidgets);
+      expect(find.text('Rooms in this space'), findsOneWidget);
+    });
+
+    testWidgets('shows Open header for a joined space', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.runAsync(() => dataSource.joinRoom('!fake-space-0:example.org'));
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Join space'), findsNothing);
+      expect(
+        find.widgetWithText(OutlinedButton, 'Open'),
+        findsAtLeastNWidgets(1),
+      );
+    });
+
+    testWidgets('shows Join for unjoined child rooms', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.runAsync(() => dataSource.joinRoom('!fake-space-0:example.org'));
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Join'), findsAtLeastNWidgets(1));
+    });
+
+    testWidgets('back button closes seeded preview', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+      await tester.runAsync(() => dataSource.joinRoom('!fake-space-0:example.org'));
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Quantum HQ'), findsWidgets);
+
+      await tester.tap(find.byTooltip('Back'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Quantum HQ'), findsNothing);
+      expect(find.text('Explore spaces'), findsNothing);
     });
   });
 }

--- a/test/widgets/space_details_panel_test.dart
+++ b/test/widgets/space_details_panel_test.dart
@@ -105,10 +105,11 @@ void main() {
       expect(find.text('Space not found'), findsOneWidget);
     });
 
-    testWidgets('shows Invite and Leave actions', (tester) async {
+    testWidgets('shows Browse rooms, Invite and Leave actions', (tester) async {
       await tester.pumpWidget(buildTestWidget());
       await tester.pumpAndSettle();
 
+      expect(find.text('Browse rooms'), findsOneWidget);
       expect(find.text('Invite'), findsOneWidget);
       expect(find.text('Leave'), findsOneWidget);
     });
@@ -121,6 +122,36 @@ void main() {
 
       expect(find.text('Invite'), findsNothing);
       expect(find.text('Leave'), findsOneWidget);
+    });
+
+    testWidgets('Browse rooms opens space preview dialog', (tester) async {
+      when(mockClient.getSpaceHierarchy(
+        '!space:example.com',
+        maxDepth: anyNamed('maxDepth'),
+        suggestedOnly: anyNamed('suggestedOnly'),
+      ),).thenAnswer((_) async => GetSpaceHierarchyResponse(
+        rooms: [
+          SpaceRoomsChunk$2(
+            guestCanJoin: false,
+            numJoinedMembers: 5,
+            roomId: '!space:example.com',
+            worldReadable: true,
+            childrenState: const [],
+            name: 'Test Space',
+            canonicalAlias: '#test-space:example.com',
+            roomType: 'm.space',
+          ),
+        ],
+      ),);
+
+      await tester.pumpWidget(buildTestWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Browse rooms'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Test Space'), findsWidgets);
+      expect(find.text('This space has no rooms yet.'), findsOneWidget);
     });
 
     testWidgets('renders as Scaffold when isFullPage is true', (tester) async {


### PR DESCRIPTION
## Summary

Implements the space room-preview dialog seeded to a joined space, allowing users to directly access the "Browse all" preview for joined spaces.

## Changes

- Add SpaceDiscoveryDialog.showSpaceRooms() static method
- Add initialFrame parameter and _directlySeeded flag for bypassing public search list
- Update _popPreview and PopScope to close dialog at root when directly seeded
- Add "Browse rooms" button to SpaceDetailsPanel that calls showSpaceRooms
- Add widget tests for showSpaceRooms functionality

## Testing

- [x] `flutter analyze` is clean
- [x] `flutter test` passes (run `dart run build_runner build --delete-conflicting-outputs` first if mocks changed)
  - Affected tests all pass (42 tests)
  - Full test suite has pre-existing failures in unrelated files (e2e, chat message actions, etc.)

## Linked issues

Closes #679

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master` (not another feature branch, unless an explicitly requested stacked PR)