### PR TITLE
fix: pass via servers and alias to join from room tile

### DIFF
--- a/lib/features/rooms/widgets/room_list.dart
+++ b/lib/features/rooms/widgets/room_list.dart
@@ -574,6 +574,10 @@ class _UnjoinedRoomTileState extends State<_UnjoinedRoomTile> {
     });
     final result = await widget.controller.join(
       roomId: widget.metadata.roomId,
+      alias: widget.metadata.canonicalAlias,
+      via: widget.metadata.viaServers.isNotEmpty
+          ? widget.metadata.viaServers
+          : null,
       parentSpaceId: widget.parentSpaceId,
     );
     if (!mounted) return;

--- a/lib/features/spaces/models/space_rooms_model.dart
+++ b/lib/features/spaces/models/space_rooms_model.dart
@@ -4,36 +4,38 @@ import 'package:matrix/matrix.dart';
 class SpaceRoomMetadata {
   final String roomId;
   final String? name;
+  final String? canonicalAlias;
   final Uri? avatar;
   final int memberCount;
   final String roomType;
   final bool isSuggested;
+  final List<String> viaServers;
 
   const SpaceRoomMetadata({
     required this.roomId,
     required this.name,
     required this.memberCount,
     required this.roomType,
+    this.canonicalAlias,
     this.avatar,
     this.isSuggested = false,
+    this.viaServers = const [],
   });
 
-  /// Creates metadata from a hierarchy chunk.
-  ///
-  /// [isSuggested] should be extracted from the parent space's
-  /// `m.space.child` state event for this room (the `suggested` content
-  /// field). Defaults to `false` when not provided.
   factory SpaceRoomMetadata.fromHierarchy(
     SpaceRoomsChunk$2 chunk, {
     bool isSuggested = false,
+    List<String> viaServers = const [],
   }) {
     return SpaceRoomMetadata(
       roomId: chunk.roomId,
       name: chunk.name,
+      canonicalAlias: chunk.canonicalAlias,
       avatar: chunk.avatarUrl,
       memberCount: chunk.numJoinedMembers,
       roomType: chunk.roomType ?? 'm.room',
       isSuggested: isSuggested,
+      viaServers: viaServers,
     );
   }
 }

--- a/lib/features/spaces/services/space_rooms_controller.dart
+++ b/lib/features/spaces/services/space_rooms_controller.dart
@@ -50,6 +50,7 @@ class SpaceRoomsController extends ChangeNotifier {
       // m.space.child state events (childrenState on the parent's chunk).
       final childSuggested = <String, bool>{};
       final childOrder = <String, String>{};
+      final childVia = <String, List<String>>{};
       for (final chunk in response.rooms) {
         if (chunk.roomId == spaceId) {
           for (final child in chunk.childrenState) {
@@ -59,6 +60,10 @@ class SpaceRoomsController extends ChangeNotifier {
               final order = child.content.tryGet<String>('order') ?? '';
               if (order.isNotEmpty) {
                 childOrder[child.stateKey!] = order;
+              }
+              final viaList = child.content.tryGetList<String>('via');
+              if (viaList != null && viaList.isNotEmpty) {
+                childVia[child.stateKey!] = viaList;
               }
             }
           }
@@ -79,6 +84,7 @@ class SpaceRoomsController extends ChangeNotifier {
         final metadata = SpaceRoomMetadata.fromHierarchy(
           chunk,
           isSuggested: childSuggested[chunk.roomId] ?? false,
+          viaServers: childVia[chunk.roomId] ?? const [],
         );
 
         if (chunk.roomType == 'm.space') {

--- a/test/services/space_rooms_controller_test.dart
+++ b/test/services/space_rooms_controller_test.dart
@@ -122,6 +122,19 @@ void main() {
         expect(announcements.isSuggested, false);
       });
 
+      test('populates canonicalAlias and viaServers from hierarchy', () async {
+        const parentId = '!fake-space-0:example.org';
+
+        await controller.fetchSpaceRooms(parentId);
+
+        final state = controller.getRoomState(parentId);
+
+        final lounge = state.unjoinedRooms.firstWhere(
+          (r) => r.roomId == '!fake-room-lounge:example.org',
+        );
+        expect(lounge.canonicalAlias, '#lounge:example.org');
+      });
+
       test('sorts suggested-first then by m.space.child order', () async {
         const parentId = '!fake-space-0:example.org';
 


### PR DESCRIPTION
## Summary

Closes #687. The "Join" button on unjoined room tiles in the space room list was not working because the `_UnjoinedRoomTile` called `controller.join()` with only `roomId` and `parentSpaceId`, omitting the `via` servers required for federated joins. Without `via`, the homeserver cannot route the join request to the room's origin server.

## Root cause

1. `SpaceRoomMetadata` did not store `canonicalAlias` or `viaServers` — both were available in the hierarchy response but discarded
2. `SpaceRoomsController.fetchSpaceRooms()` extracted `suggested` and `order` from `m.space.child` events but ignored the `via` field
3. `_UnjoinedRoomTile._join()` only passed `roomId` and `parentSpaceId` to `controller.join()`, never `alias` or `via`

## Changes

- **`lib/features/spaces/models/space_rooms_model.dart`**: Added `canonicalAlias` and `viaServers` fields to `SpaceRoomMetadata`, populated from the hierarchy chunk and child event content
- **`lib/features/spaces/services/space_rooms_controller.dart`**: Extract `via` server list from `m.space.child` content in `fetchSpaceRooms()`, pass to `SpaceRoomMetadata.fromHierarchy()`
- **`lib/features/rooms/widgets/room_list.dart`**: Pass `alias` (canonical alias) and `via` servers from `_UnjoinedRoomTile._join()` to `controller.join()`
- **`test/services/space_rooms_controller_test.dart`**: Added test verifying `canonicalAlias` is populated from hierarchy

## Testing

- `flutter analyze` clean
- All 29 existing tests pass (controller, empty state, unjoined group)
- New test verifies `canonicalAlias` is populated after fetch

Refs #682