### PR TITLE
refactor(#693): wrap Notification in KoheraNotificationItem domain model

### DIFF
--- a/lib/features/home/widgets/inbox/notification_group_tile.dart
+++ b/lib/features/home/widgets/inbox/notification_group_tile.dart
@@ -94,7 +94,6 @@ class NotificationGroupTile extends StatelessWidget {
               SubGroupSection(
                 roomId: group.roomId,
                 subGroup: sub,
-                client: client,
                 controller: controller,
               ),
           ],

--- a/lib/features/home/widgets/inbox/notification_tile.dart
+++ b/lib/features/home/widgets/inbox/notification_tile.dart
@@ -1,41 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:kohera/core/routing/route_names.dart';
-import 'package:kohera/core/utils/reply_fallback.dart';
 import 'package:kohera/core/utils/time_format.dart';
+import 'package:kohera/features/notifications/models/kohera_notification_item.dart';
 import 'package:kohera/features/notifications/models/notification_constants.dart';
-import 'package:kohera/features/notifications/services/inbox_controller.dart';
-import 'package:matrix/matrix.dart' as matrix_sdk;
-import 'package:provider/provider.dart';
 
 class NotificationTile extends StatelessWidget {
   const NotificationTile({
-    required this.notification,
-    required this.client,
+    required this.item,
     required this.threadRootId,
     super.key,
   });
 
-  final matrix_sdk.Notification notification;
-  final matrix_sdk.Client client;
+  final KoheraNotificationItem item;
   final String? threadRootId;
 
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final tt = Theme.of(context).textTheme;
-    final event = notification.event;
 
-    final senderId = event.senderId;
-    final room = client.getRoomById(notification.roomId);
-    final senderName =
-        room?.unsafeGetUserFromMemoryOrFallback(senderId).calcDisplayname() ??
-            senderId;
-
-    final controller = context.read<InboxController>();
-    final body = _extractBody(context, event);
-    final ts = DateTime.fromMillisecondsSinceEpoch(notification.ts);
-    final isMention = controller.isMention(notification);
+    final body = item.body;
+    final ts = DateTime.fromMillisecondsSinceEpoch(item.timestamp);
 
     return InkWell(
       mouseCursor: SystemMouseCursors.click,
@@ -46,14 +32,14 @@ class NotificationTile extends StatelessWidget {
           context.goNamed(
             Routes.roomThread,
             pathParameters: {
-              RouteParams.roomId: notification.roomId,
+              RouteParams.roomId: item.roomId,
               RouteParams.eventId: tid,
             },
           );
         } else {
           context.goNamed(
             Routes.room,
-            pathParameters: {RouteParams.roomId: notification.roomId},
+            pathParameters: {RouteParams.roomId: item.roomId},
           );
         }
       },
@@ -63,7 +49,7 @@ class NotificationTile extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // Unread indicator
-            if (!notification.read)
+            if (!item.isRead)
               Padding(
                 padding: const EdgeInsets.only(top: 6, right: 6),
                 child: Container(
@@ -86,7 +72,7 @@ class NotificationTile extends StatelessWidget {
                     children: [
                       Expanded(
                         child: Text(
-                          senderName,
+                          item.senderName,
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                           style: tt.labelMedium?.copyWith(
@@ -95,7 +81,7 @@ class NotificationTile extends StatelessWidget {
                           ),
                         ),
                       ),
-                      if (isMention) ...[
+                      if (item.isMention) ...[
                         Icon(Icons.alternate_email_rounded,
                             size: 12, color: cs.primary,),
                         const SizedBox(width: 2),
@@ -139,22 +125,5 @@ class NotificationTile extends StatelessWidget {
         ),
       ),
     );
-  }
-
-  String _extractBody(BuildContext context, matrix_sdk.MatrixEvent event) {
-    final controller = context.read<InboxController>();
-    final content =
-        controller.decryptedContentFor(event.eventId) ?? event.content;
-    final msgtype = content['msgtype'];
-
-    if (msgtype == matrix_sdk.MessageTypes.Image) return InboxText.mediaImage;
-    if (msgtype == matrix_sdk.MessageTypes.Video) return InboxText.mediaVideo;
-    if (msgtype == matrix_sdk.MessageTypes.Audio) return InboxText.mediaAudio;
-    if (msgtype == matrix_sdk.MessageTypes.File) return InboxText.mediaFile;
-
-    final body = content['body'];
-    if (body is String) return stripReplyFallback(body);
-
-    return '';
   }
 }

--- a/lib/features/home/widgets/inbox/sub_group_section.dart
+++ b/lib/features/home/widgets/inbox/sub_group_section.dart
@@ -1,25 +1,21 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:kohera/core/utils/reply_fallback.dart';
 import 'package:kohera/features/home/widgets/inbox/notification_tile.dart';
 import 'package:kohera/features/notifications/models/notification_constants.dart';
 import 'package:kohera/features/notifications/models/thread_sub_group.dart';
 import 'package:kohera/features/notifications/services/inbox_controller.dart';
-import 'package:matrix/matrix.dart' as matrix_sdk;
 
 class SubGroupSection extends StatefulWidget {
   const SubGroupSection({
     required this.roomId,
     required this.subGroup,
-    required this.client,
     required this.controller,
     super.key,
   });
 
   final String roomId;
   final ThreadSubGroup subGroup;
-  final matrix_sdk.Client client;
   final InboxController controller;
 
   @override
@@ -40,18 +36,9 @@ class _SubGroupSectionState extends State<SubGroupSection> {
   }
 
   Future<void> _loadRoot(String eventId) async {
-    final room = widget.client.getRoomById(widget.roomId);
-    if (room == null) return;
-    try {
-      final event = await room.getEventById(eventId);
-      if (event == null || !mounted) return;
-      final body = stripReplyFallback(event.body).trim();
-      if (body.isEmpty) return;
-      final truncated = body.length > 80 ? '${body.substring(0, 80)}…' : body;
-      final preview = InboxText.inReplyTo(truncated);
-      widget.controller.setRootPreview(eventId, preview);
-      if (mounted) setState(() => _rootPreview = preview);
-    } catch (_) {}
+    final preview =
+        await widget.controller.loadRootPreview(widget.roomId, eventId);
+    if (mounted && preview != null) setState(() => _rootPreview = preview);
   }
 
   @override
@@ -92,10 +79,9 @@ class _SubGroupSectionState extends State<SubGroupSection> {
               ],
             ),
           ),
-        for (final notification in widget.subGroup.notifications)
+        for (final item in widget.subGroup.notifications)
           NotificationTile(
-            notification: notification,
-            client: widget.client,
+            item: item,
             threadRootId: threadRootId,
           ),
       ],

--- a/lib/features/notifications/models/kohera_notification_item.dart
+++ b/lib/features/notifications/models/kohera_notification_item.dart
@@ -1,0 +1,21 @@
+class KoheraNotificationItem {
+  final String eventId;
+  final String roomId;
+  final String senderName;
+  final String body;
+  final int timestamp;
+  final bool isRead;
+  final bool isMention;
+  final String? threadRootId;
+
+  const KoheraNotificationItem({
+    required this.eventId,
+    required this.roomId,
+    required this.senderName,
+    required this.body,
+    required this.timestamp,
+    required this.isRead,
+    required this.isMention,
+    required this.threadRootId,
+  });
+}

--- a/lib/features/notifications/models/notification_group.dart
+++ b/lib/features/notifications/models/notification_group.dart
@@ -1,10 +1,10 @@
+import 'package:kohera/features/notifications/models/kohera_notification_item.dart';
 import 'package:kohera/features/notifications/models/thread_sub_group.dart';
-import 'package:matrix/matrix.dart' as matrix_sdk;
 
 class NotificationGroup {
   final String roomId;
   final String roomName;
-  final List<matrix_sdk.Notification> notifications;
+  final List<KoheraNotificationItem> notifications;
   final List<ThreadSubGroup> subGroups;
 
   const NotificationGroup({

--- a/lib/features/notifications/models/thread_sub_group.dart
+++ b/lib/features/notifications/models/thread_sub_group.dart
@@ -1,8 +1,8 @@
-import 'package:matrix/matrix.dart' as matrix_sdk;
+import 'package:kohera/features/notifications/models/kohera_notification_item.dart';
 
 class ThreadSubGroup {
   final String? threadRootId;
-  final List<matrix_sdk.Notification> notifications;
+  final List<KoheraNotificationItem> notifications;
 
   const ThreadSubGroup({
     required this.threadRootId,

--- a/lib/features/notifications/services/inbox_controller.dart
+++ b/lib/features/notifications/services/inbox_controller.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:kohera/core/utils/notification_filter.dart';
+import 'package:kohera/core/utils/reply_fallback.dart';
 import 'package:kohera/features/notifications/enum/inbox_filter.dart';
+import 'package:kohera/features/notifications/models/notification_constants.dart';
 import 'package:kohera/features/notifications/models/notification_group.dart';
 import 'package:kohera/features/notifications/services/apns_push_service.dart';
 import 'package:kohera/features/notifications/services/notification_grouper.dart';
@@ -40,6 +42,7 @@ class InboxController extends ChangeNotifier {
   static const _debounceDelay = Duration(milliseconds: 750);
 
   int _fetchGeneration = 0;
+  List<matrix_sdk.Notification> _rawNotifications = [];
 
   // ── Public getters ─────────────────────────────────────────
 
@@ -47,28 +50,38 @@ class InboxController extends ChangeNotifier {
 
   bool get hasMore => _nextToken != null;
 
-  Map<String, Object?>? decryptedContentFor(String eventId) =>
-      _grouper.decryptedContentFor(eventId);
-
   // ── Thread-root preview cache (cleared on account switch) ─────
   String? rootPreviewFor(String eventId) => _grouper.rootPreviewFor(eventId);
   void setRootPreview(String eventId, String preview) =>
       _grouper.setRootPreview(eventId, preview);
 
-  String? threadRootIdFor(matrix_sdk.Notification n) =>
-      _grouper.threadRootIdFor(n);
-
-  bool isMention(matrix_sdk.Notification n) => _grouper.isMention(n);
+  Future<String?> loadRootPreview(String roomId, String eventId) async {
+    final cached = _grouper.rootPreviewFor(eventId);
+    if (cached != null) return cached;
+    final room = _client.getRoomById(roomId);
+    if (room == null) return null;
+    try {
+      final event = await room.getEventById(eventId);
+      if (event == null) return null;
+      final body = stripReplyFallback(event.body).trim();
+      if (body.isEmpty) return null;
+      final truncated =
+          body.length > 80 ? '${body.substring(0, 80)}…' : body;
+      final preview = InboxText.inReplyTo(truncated);
+      _grouper.setRootPreview(eventId, preview);
+      return preview;
+    } catch (_) {
+      return null;
+    }
+  }
 
   // ── Fetch ──────────────────────────────────────────────────
 
-  List<matrix_sdk.Notification> get _flatNotifications => [
-        for (final group in _grouped) ...group.notifications,
-      ];
 
   Future<void> fetch() => _withLoad((gen) async {
         final response = await _client.getNotifications(limit: 30);
         if (_disposed || gen != _fetchGeneration) return null;
+        _rawNotifications = response.notifications;
         final grouped = await _grouper.group(response.notifications, _filter);
         return (grouped: grouped, token: response.nextToken);
       });
@@ -78,11 +91,13 @@ class InboxController extends ChangeNotifier {
         if (_disposed || gen != _fetchGeneration) return null;
         final headIds =
             response.notifications.map((n) => n.event.eventId).toSet();
-        final grouped = await _grouper.group([
+        final merged = [
           ...response.notifications,
-          for (final n in _flatNotifications)
+          for (final n in _rawNotifications)
             if (!headIds.contains(n.event.eventId)) n,
-        ], _filter,);
+        ];
+        _rawNotifications = merged;
+        final grouped = await _grouper.group(merged, _filter);
         return (grouped: grouped, token: _nextToken);
       });
 
@@ -94,10 +109,9 @@ class InboxController extends ChangeNotifier {
         from: _nextToken,
       );
       if (_disposed || gen != _fetchGeneration) return null;
-      final grouped = await _grouper.group([
-        ..._flatNotifications,
-        ...response.notifications,
-      ], _filter,);
+      final merged = [..._rawNotifications, ...response.notifications];
+      _rawNotifications = merged;
+      final grouped = await _grouper.group(merged, _filter);
       return (grouped: grouped, token: response.nextToken);
     });
   }
@@ -225,15 +239,15 @@ class InboxController extends ChangeNotifier {
     for (final group in _grouped) {
       if (group.roomId != roomId) continue;
       for (final n in group.notifications) {
-        final threadId = _grouper.threadRootIdFor(n);
+        final threadId = n.threadRootId;
         if (threadId != null) {
           final cur = perThread[threadId];
-          if (cur == null || n.ts > cur.ts) {
-            perThread[threadId] = (eventId: n.event.eventId, ts: n.ts);
+          if (cur == null || n.timestamp > cur.ts) {
+            perThread[threadId] = (eventId: n.eventId, ts: n.timestamp);
           }
-        } else if (n.ts > mainTs) {
-          mainTs = n.ts;
-          mainEventId = n.event.eventId;
+        } else if (n.timestamp > mainTs) {
+          mainTs = n.timestamp;
+          mainEventId = n.eventId;
         }
       }
       break;
@@ -245,6 +259,10 @@ class InboxController extends ChangeNotifier {
     _grouped = [
       for (final g in _grouped)
         if (g.roomId != roomId) g,
+    ];
+    _rawNotifications = [
+      for (final n in _rawNotifications)
+        if (n.roomId != roomId) n,
     ];
     final remainingUnread = totalUnreadCount(_client) - room.notificationCount;
     final remainingBadge = remainingUnread < 0 ? 0 : remainingUnread;
@@ -307,6 +325,7 @@ class InboxController extends ChangeNotifier {
   void _resetList() {
     _grouped = [];
     _nextToken = null;
+    _rawNotifications = [];
   }
 
   void _startFetch() => unawaited(

--- a/lib/features/notifications/services/notification_grouper.dart
+++ b/lib/features/notifications/services/notification_grouper.dart
@@ -1,6 +1,9 @@
 import 'package:clock/clock.dart';
+import 'package:kohera/core/utils/reply_fallback.dart';
 import 'package:kohera/core/utils/word_boundary.dart';
 import 'package:kohera/features/notifications/enum/inbox_filter.dart';
+import 'package:kohera/features/notifications/models/kohera_notification_item.dart';
+import 'package:kohera/features/notifications/models/notification_constants.dart';
 import 'package:kohera/features/notifications/models/notification_group.dart';
 import 'package:kohera/features/notifications/models/thread_sub_group.dart';
 import 'package:matrix/matrix.dart' as matrix_sdk;
@@ -95,9 +98,19 @@ class NotificationGrouper {
     List<matrix_sdk.Notification> notifications,
     InboxFilter filter,
   ) async {
-    final visible = await _filterVisible(notifications, filter);
+    final candidates = _collectCandidates(notifications);
+    await Future.wait(candidates.map(_tryDecrypt));
+
+    final items = <KoheraNotificationItem>[];
+    for (final n in candidates) {
+      final item = _toItem(n);
+      if (filter == InboxFilter.mentions && !item.isMention) continue;
+      if (filter == InboxFilter.threads && item.threadRootId == null) continue;
+      items.add(item);
+    }
+
     return [
-      for (final bucket in _bucketByRecency(visible, (n) => n.roomId))
+      for (final bucket in _bucketByRecency(items, (n) => n.roomId))
         NotificationGroup(
           roomId: bucket.key,
           roomName: _client.getRoomById(bucket.key)?.getLocalizedDisplayname() ??
@@ -106,25 +119,6 @@ class NotificationGrouper {
           subGroups: _buildSubGroups(bucket.value),
         ),
     ];
-  }
-
-  Future<List<matrix_sdk.Notification>> _filterVisible(
-    List<matrix_sdk.Notification> notifications,
-    InboxFilter filter,
-  ) async {
-    final candidates = _collectCandidates(notifications);
-
-    await Future.wait(candidates.map(_tryDecrypt));
-
-    final visible = <matrix_sdk.Notification>[];
-    for (final n in candidates) {
-      if (filter == InboxFilter.mentions && !isMention(n)) continue;
-      if (filter == InboxFilter.threads && threadRootIdFor(n) == null) {
-        continue;
-      }
-      visible.add(n);
-    }
-    return visible;
   }
 
   List<matrix_sdk.Notification> _collectCandidates(
@@ -141,13 +135,45 @@ class NotificationGrouper {
     return candidates;
   }
 
-  List<ThreadSubGroup> _buildSubGroups(
-    List<matrix_sdk.Notification> notifications,
-  ) {
+  KoheraNotificationItem _toItem(matrix_sdk.Notification n) {
+    final content = _decryptedContent[n.event.eventId] ?? n.event.content;
+    return KoheraNotificationItem(
+      eventId: n.event.eventId,
+      roomId: n.roomId,
+      senderName: _senderName(n),
+      body: _extractBody(content),
+      timestamp: n.ts,
+      isRead: n.read,
+      isMention: isMention(n),
+      threadRootId: threadRootIdFor(n),
+    );
+  }
+
+  String _senderName(matrix_sdk.Notification n) {
+    final room = _client.getRoomById(n.roomId);
+    return room?.unsafeGetUserFromMemoryOrFallback(n.event.senderId)
+            .calcDisplayname() ??
+        n.event.senderId;
+  }
+
+  String _extractBody(Map<String, Object?> content) {
+    final msgtype = content['msgtype'];
+    if (msgtype == matrix_sdk.MessageTypes.Image) return InboxText.mediaImage;
+    if (msgtype == matrix_sdk.MessageTypes.Video) return InboxText.mediaVideo;
+    if (msgtype == matrix_sdk.MessageTypes.Audio) return InboxText.mediaAudio;
+    if (msgtype == matrix_sdk.MessageTypes.File) return InboxText.mediaFile;
+
+    final body = content['body'];
+    if (body is String) return stripReplyFallback(body);
+
+    return '';
+  }
+
+  List<ThreadSubGroup> _buildSubGroups(List<KoheraNotificationItem> items) {
     const mainKey = '__main__';
     return [
       for (final bucket
-          in _bucketByRecency(notifications, (n) => threadRootIdFor(n) ?? mainKey))
+          in _bucketByRecency(items, (n) => n.threadRootId ?? mainKey))
         ThreadSubGroup(
           threadRootId: bucket.key == mainKey ? null : bucket.key,
           notifications: bucket.value,
@@ -155,13 +181,13 @@ class NotificationGrouper {
     ];
   }
 
-  List<MapEntry<String, List<matrix_sdk.Notification>>> _bucketByRecency(
-    List<matrix_sdk.Notification> notifications,
-    String Function(matrix_sdk.Notification) keyOf,
+  List<MapEntry<String, List<KoheraNotificationItem>>> _bucketByRecency(
+    List<KoheraNotificationItem> items,
+    String Function(KoheraNotificationItem) keyOf,
   ) {
-    final buckets = <String, List<matrix_sdk.Notification>>{};
+    final buckets = <String, List<KoheraNotificationItem>>{};
     final order = <String>[];
-    for (final n in notifications) {
+    for (final n in items) {
       final key = keyOf(n);
       buckets.putIfAbsent(key, () {
         order.add(key);
@@ -222,5 +248,5 @@ bool _hasHighlightAction(List<Object?> actions) {
   return false;
 }
 
-int _mostRecentTimestamp(Iterable<matrix_sdk.Notification> notifications) =>
-    notifications.map((n) => n.ts).reduce((a, b) => a > b ? a : b);
+int _mostRecentTimestamp(Iterable<KoheraNotificationItem> items) =>
+    items.map((n) => n.timestamp).reduce((a, b) => a > b ? a : b);

--- a/test/services/inbox_controller_test.dart
+++ b/test/services/inbox_controller_test.dart
@@ -68,6 +68,11 @@ void main() {
     when(defaultRoom.membership).thenReturn(Membership.join);
     when(mockClient.getRoomById(any)).thenReturn(defaultRoom);
     when(mockClient.onSync).thenReturn(syncCtl);
+    when(defaultRoom.client).thenReturn(mockClient);
+    when(defaultRoom.getLocalizedDisplayname()).thenReturn('Test Room');
+    when(defaultRoom.unsafeGetUserFromMemoryOrFallback(any)).thenReturn(
+      User('@alice:example.com', displayName: 'Alice', room: defaultRoom),
+    );
     controller = InboxController(client: mockClient);
   });
 
@@ -433,6 +438,11 @@ void main() {
     test('calls setReadMarker with latest eventId and refreshes', () async {
       final mockRoom = MockRoom();
       when(mockRoom.membership).thenReturn(Membership.join);
+      when(mockRoom.client).thenReturn(mockClient);
+      when(mockRoom.getLocalizedDisplayname()).thenReturn('Test Room');
+      when(mockRoom.unsafeGetUserFromMemoryOrFallback(any)).thenReturn(
+        User('@alice:example.com', displayName: 'Alice', room: mockRoom),
+      );
       when(mockRoom.lastEvent).thenReturn(null);
       when(mockRoom.setReadMarker(any, mRead: anyNamed('mRead'))).thenAnswer((_) async {});
       when(mockClient.getRoomById('!r1:x')).thenReturn(mockRoom);
@@ -454,6 +464,11 @@ void main() {
     test('optimistically removes group before server call', () async {
       final mockRoom = MockRoom();
       when(mockRoom.membership).thenReturn(Membership.join);
+      when(mockRoom.client).thenReturn(mockClient);
+      when(mockRoom.getLocalizedDisplayname()).thenReturn('Test Room');
+      when(mockRoom.unsafeGetUserFromMemoryOrFallback(any)).thenReturn(
+        User('@alice:example.com', displayName: 'Alice', room: mockRoom),
+      );
       when(mockRoom.lastEvent).thenReturn(null);
       when(mockRoom.setReadMarker(any, mRead: anyNamed('mRead'))).thenAnswer((_) async {});
       when(mockClient.getRoomById('!r1:x')).thenReturn(mockRoom);
@@ -819,7 +834,7 @@ void main() {
 
         expect(controller.grouped, hasLength(1));
         expect(controller.grouped[0].notifications, hasLength(1));
-        expect(controller.grouped[0].notifications[0].event.eventId, 'e2');
+        expect(controller.grouped[0].notifications[0].eventId, 'e2');
       });
     });
     test('excludes notifications for rooms with non-join membership', () async {
@@ -865,6 +880,11 @@ void main() {
     test('uses notification with highest ts, not last in list', () async {
       final mockRoom = MockRoom();
       when(mockRoom.membership).thenReturn(Membership.join);
+      when(mockRoom.client).thenReturn(mockClient);
+      when(mockRoom.getLocalizedDisplayname()).thenReturn('Test Room');
+      when(mockRoom.unsafeGetUserFromMemoryOrFallback(any)).thenReturn(
+        User('@alice:example.com', displayName: 'Alice', room: mockRoom),
+      );
       when(mockRoom.lastEvent).thenReturn(null);
       when(mockRoom.setReadMarker(any, mRead: anyNamed('mRead'))).thenAnswer((_) async {});
       when(mockClient.getRoomById('!r1:x')).thenReturn(mockRoom);
@@ -1219,7 +1239,14 @@ void main() {
           .thenReturn(user);
     }
 
-    test('true for highlight action without value', () {
+    void stubFetch(Notification n) {
+      when(mockClient.getNotifications(
+        limit: anyNamed('limit'),
+        only: anyNamed('only'),
+      ),).thenAnswer((_) async => _makeResponse([n]));
+    }
+
+    test('true for highlight action without value', () async {
       stubDisplayName('Me');
       final n = _makeNotification(
         eventId: 'e1',
@@ -1229,10 +1256,12 @@ void main() {
           {'set_tweak': 'highlight'},
         ],
       );
-      expect(controller.isMention(n), isTrue);
+      stubFetch(n);
+      await controller.fetch();
+      expect(controller.grouped[0].notifications[0].isMention, isTrue);
     });
 
-    test('true for highlight action with value true', () {
+    test('true for highlight action with value true', () async {
       stubDisplayName('Me');
       final n = _makeNotification(
         eventId: 'e1',
@@ -1242,10 +1271,12 @@ void main() {
           {'set_tweak': 'highlight', 'value': true},
         ],
       );
-      expect(controller.isMention(n), isTrue);
+      stubFetch(n);
+      await controller.fetch();
+      expect(controller.grouped[0].notifications[0].isMention, isTrue);
     });
 
-    test('false for highlight action with value false', () {
+    test('false for highlight action with value false', () async {
       stubDisplayName('Me');
       final n = _makeNotification(
         eventId: 'e1',
@@ -1255,10 +1286,12 @@ void main() {
           {'set_tweak': 'highlight', 'value': false},
         ],
       );
-      expect(controller.isMention(n), isFalse);
+      stubFetch(n);
+      await controller.fetch();
+      expect(controller.grouped[0].notifications[0].isMention, isFalse);
     });
 
-    test('true when m.mentions lists the user', () {
+    test('true when m.mentions lists the user', () async {
       stubDisplayName('Me');
       final n = _makeNotification(
         eventId: 'e1',
@@ -1271,10 +1304,12 @@ void main() {
           },
         },
       );
-      expect(controller.isMention(n), isTrue);
+      stubFetch(n);
+      await controller.fetch();
+      expect(controller.grouped[0].notifications[0].isMention, isTrue);
     });
 
-    test('true when m.mentions flags a room mention', () {
+    test('true when m.mentions flags a room mention', () async {
       stubDisplayName('Me');
       final n = _makeNotification(
         eventId: 'e1',
@@ -1286,10 +1321,12 @@ void main() {
           'm.mentions': {'room': true},
         },
       );
-      expect(controller.isMention(n), isTrue);
+      stubFetch(n);
+      await controller.fetch();
+      expect(controller.grouped[0].notifications[0].isMention, isTrue);
     });
 
-    test('false when m.mentions is present without the user, even if the body matches', () {
+    test('false when m.mentions is present without the user, even if the body matches', () async {
       stubDisplayName('Me');
       final n = _makeNotification(
         eventId: 'e1',
@@ -1303,20 +1340,24 @@ void main() {
           },
         },
       );
-      expect(controller.isMention(n), isFalse);
+      stubFetch(n);
+      await controller.fetch();
+      expect(controller.grouped[0].notifications[0].isMention, isFalse);
     });
 
-    test('false for plaintext body match without highlight action', () {
+    test('false for plaintext body match without highlight action', () async {
       stubDisplayName('Will');
       final n = _makeNotification(
         eventId: 'e1',
         roomId: '!r1:x',
         content: {'body': 'Will you join?', 'msgtype': 'm.text'},
       );
-      expect(controller.isMention(n), isFalse);
+      stubFetch(n);
+      await controller.fetch();
+      expect(controller.grouped[0].notifications[0].isMention, isFalse);
     });
 
-    test('encrypted fallback matches a word-bounded display name', () {
+    test('encrypted fallback matches a word-bounded display name', () async {
       stubDisplayName('Will');
       final n = _makeNotification(
         eventId: 'e1',
@@ -1324,10 +1365,12 @@ void main() {
         type: 'm.room.encrypted',
         content: {'body': 'Will, are you there?', 'msgtype': 'm.text'},
       );
-      expect(controller.isMention(n), isTrue);
+      stubFetch(n);
+      await controller.fetch();
+      expect(controller.grouped[0].notifications[0].isMention, isTrue);
     });
 
-    test('encrypted fallback ignores the display name inside a larger word', () {
+    test('encrypted fallback ignores the display name inside a larger word', () async {
       stubDisplayName('Will');
       final n = _makeNotification(
         eventId: 'e1',
@@ -1335,10 +1378,12 @@ void main() {
         type: 'm.room.encrypted',
         content: {'body': 'willpower beats talent', 'msgtype': 'm.text'},
       );
-      expect(controller.isMention(n), isFalse);
+      stubFetch(n);
+      await controller.fetch();
+      expect(controller.grouped[0].notifications[0].isMention, isFalse);
     });
 
-    test('encrypted fallback treats digits as word characters', () {
+    test('encrypted fallback treats digits as word characters', () async {
       stubDisplayName('Max');
       final n = _makeNotification(
         eventId: 'e1',
@@ -1346,10 +1391,12 @@ void main() {
         type: 'm.room.encrypted',
         content: {'body': 'Max99 said hi', 'msgtype': 'm.text'},
       );
-      expect(controller.isMention(n), isFalse);
+      stubFetch(n);
+      await controller.fetch();
+      expect(controller.grouped[0].notifications[0].isMention, isFalse);
     });
 
-    test('encrypted fallback is Unicode-aware for Cyrillic display names', () {
+    test('encrypted fallback is Unicode-aware for Cyrillic display names', () async {
       stubDisplayName('Вера');
       final bounded = _makeNotification(
         eventId: 'e1',
@@ -1363,8 +1410,13 @@ void main() {
         type: 'm.room.encrypted',
         content: {'body': 'проверая текст', 'msgtype': 'm.text'},
       );
-      expect(controller.isMention(bounded), isTrue);
-      expect(controller.isMention(embedded), isFalse);
+      when(mockClient.getNotifications(
+        limit: anyNamed('limit'),
+        only: anyNamed('only'),
+      ),).thenAnswer((_) async => _makeResponse([bounded, embedded]));
+      await controller.fetch();
+      expect(controller.grouped[0].notifications[0].isMention, isTrue);
+      expect(controller.grouped[0].notifications[1].isMention, isFalse);
     });
   });
 
@@ -1460,7 +1512,7 @@ void main() {
       expect(controller.grouped, hasLength(1));
       expect(controller.grouped[0].roomId, '!r1:x');
       expect(controller.grouped[0].notifications, hasLength(1));
-      expect(controller.grouped[0].notifications[0].event.eventId, 't1');
+      expect(controller.grouped[0].notifications[0].eventId, 't1');
     });
   });
 
@@ -1470,6 +1522,11 @@ void main() {
         () async {
       final mockRoom = MockRoom();
       when(mockRoom.membership).thenReturn(Membership.join);
+      when(mockRoom.client).thenReturn(mockClient);
+      when(mockRoom.getLocalizedDisplayname()).thenReturn('Test Room');
+      when(mockRoom.unsafeGetUserFromMemoryOrFallback(any)).thenReturn(
+        User('@alice:example.com', displayName: 'Alice', room: mockRoom),
+      );
       when(mockRoom.lastEvent).thenReturn(null);
       when(mockRoom.setReadMarker(any, mRead: anyNamed('mRead')))
           .thenAnswer((_) async {});
@@ -1528,6 +1585,11 @@ void main() {
     test('skips main receipt when thread reply is newer', () async {
       final mockRoom = MockRoom();
       when(mockRoom.membership).thenReturn(Membership.join);
+      when(mockRoom.client).thenReturn(mockClient);
+      when(mockRoom.getLocalizedDisplayname()).thenReturn('Test Room');
+      when(mockRoom.unsafeGetUserFromMemoryOrFallback(any)).thenReturn(
+        User('@alice:example.com', displayName: 'Alice', room: mockRoom),
+      );
       when(mockRoom.lastEvent).thenReturn(null);
       when(mockRoom.setReadMarker(any, mRead: anyNamed('mRead')))
           .thenAnswer((_) async {});
@@ -1560,6 +1622,11 @@ void main() {
     test('posts main receipt when no threads present', () async {
       final mockRoom = MockRoom();
       when(mockRoom.membership).thenReturn(Membership.join);
+      when(mockRoom.client).thenReturn(mockClient);
+      when(mockRoom.getLocalizedDisplayname()).thenReturn('Test Room');
+      when(mockRoom.unsafeGetUserFromMemoryOrFallback(any)).thenReturn(
+        User('@alice:example.com', displayName: 'Alice', room: mockRoom),
+      );
       when(mockRoom.lastEvent).thenReturn(null);
       when(mockRoom.setReadMarker(any, mRead: anyNamed('mRead')))
           .thenAnswer((_) async {});

--- a/test/services/notification_grouper_test.dart
+++ b/test/services/notification_grouper_test.dart
@@ -98,6 +98,9 @@ void main() {
     when(mockClient.getRoomById(any)).thenReturn(mockRoom);
     when(mockClient.encryption).thenReturn(mockEncryption);
     when(mockRoom.getLocalizedDisplayname()).thenReturn('Test Room');
+    when(mockRoom.unsafeGetUserFromMemoryOrFallback(any)).thenReturn(
+      User('@alice:example.com', displayName: 'Alice', room: mockRoom),
+    );
 
     grouper = NotificationGrouper(mockClient);
   });
@@ -141,6 +144,9 @@ void main() {
       final groups = await groupFuture;
       expect(groups, hasLength(1));
       expect(groups[0].notifications, hasLength(3));
+      expect(groups[0].notifications[0].eventId, 'e1');
+      expect(groups[0].notifications[0].body, 'decrypted text');
+      expect(groups[0].notifications[0].senderName, 'Alice');
     });
   });
 


### PR DESCRIPTION
## Summary

Wraps `matrix_sdk.Notification` in a Kohera-owned `KoheraNotificationItem` domain model with pre-computed display fields. The `NotificationGrouper` becomes the single conversion boundary, eliminating all SDK coupling from the inbox UI layer.

## Changes

- **New `KoheraNotificationItem` model** (`lib/features/notifications/models/kohera_notification_item.dart`) — plain Dart class with 8 pre-computed fields: `eventId`, `roomId`, `senderName`, `body`, `timestamp`, `isRead`, `isMention`, `threadRootId`. No SDK import.
- **`NotificationGroup` and `ThreadSubGroup`** — `notifications` field changed from `List<matrix_sdk.Notification>` to `List<KoheraNotificationItem>`. Removed SDK imports.
- **`NotificationGrouper`** — Added `_toItem()`, `_senderName()`, `_extractBody()` helpers. `group()` now converts SDK notifications to `KoheraNotificationItem` with all fields computed once (sender name, body with reply fallback stripped + media labels, mention flag, thread root ID). Removed `_filterVisible` (folded into `group()`). Updated `_bucketByRecency`, `_mostRecentTimestamp`, `_buildSubGroups` to work with the new model.
- **`InboxController`** — Removed `threadRootIdFor()`, `isMention()`, `decryptedContentFor()` from public API. Added `_rawNotifications` field for SDK notification tracking in refresh/loadMore pagination. Added `loadRootPreview()` method (moved from `SubGroupSection`). Updated `markRoomAsRead()` to use model fields. Removed unused `_flatNotifications` getter.
- **`NotificationTile`** — Takes `KoheraNotificationItem` instead of `matrix_sdk.Notification` + `matrix_sdk.Client`. Removed `matrix_sdk` import, `_extractBody` helper, and `provider`/`InboxController` dependencies. Uses pre-computed `senderName`, `body`, `isMention` from the model.
- **`SubGroupSection`** — Removed `Client` parameter. Delegates root preview loading to `controller.loadRootPreview()`. Removed `matrix_sdk` import.
- **`NotificationGroupTile`** — Stopped passing `client` to `SubGroupSection`.
- **Tests** — Grouper tests: added `unsafeGetUserFromMemoryOrFallback` stub + model field assertions. Controller tests: added stubs to setUp and all 6 custom mock rooms, fixed `.event.eventId` → `.eventId` assertions, reworked 12 `isMention` tests to go through `fetch()` and assert on the model's `isMention` field.

## Testing

- [x] `flutter analyze` is clean
- [x] `flutter test` passes (2172/2172)

## Linked issues

Closes #693
Refs #697

## Checklist

- [x] Commits use a Conventional Commits subject with an allowed type, and bodies keep issue refs in the footer (no `Word:` lines or inline `#123`)
- [x] Logs use the `debugPrint('[Kohera] ...')` prefix
- [x] No stray comments added (only `// ── Section ──` markers)
- [x] Tests added or updated to cover the change
- [x] Targets `master` (not another feature branch, unless an explicitly requested stacked PR)